### PR TITLE
chore(abi): Rust public-API snapshot を M5 land 済み surface に rotate

### DIFF
--- a/docs/abi/vokra-rust-public-api.v1.0-rc.list
+++ b/docs/abi/vokra-rust-public-api.v1.0-rc.list
@@ -31,6 +31,8 @@
 CONST vokra-core::complex::ZERO|pub const ZERO: Self = Self { re: 0.0, im: 0.0 };
 CONST vokra-core::compliance::ENV_ALLOW_RESEARCH_LICENSE|pub const ENV_ALLOW_RESEARCH_LICENSE: &str = "VOKRA_ALLOW_RESEARCH_LICENSE";
 CONST vokra-core::decode::stepper::TOKEN_FLAG_EOT|pub const TOKEN_FLAG_EOT: u32 = 1;
+CONST vokra-core::decode::word_timing::APPEND_PUNCTUATIONS|pub const APPEND_PUNCTUATIONS: &str = "\"'.。,，!！?？:：”)]}、";
+CONST vokra-core::decode::word_timing::PREPEND_PUNCTUATIONS|pub const PREPEND_PUNCTUATIONS: &str = "\"'“¿([{-";
 CONST vokra-core::gguf::DEFAULT_ALIGNMENT|pub const DEFAULT_ALIGNMENT: u64 = 32;
 CONST vokra-core::gguf::GGUF_MAGIC|pub const GGUF_MAGIC: [u8; 4] = *b"GGUF";
 CONST vokra-core::gguf::GGUF_VERSION|pub const GGUF_VERSION: u32 = 3;
@@ -60,8 +62,11 @@ CONST vokra-core::gguf::chunks::KEY_QUANT_HIFIGAN_INT8_CALIBRATION_REF|pub const
 CONST vokra-core::gguf::chunks::KEY_QUANT_HIFIGAN_INT8_OPT_IN|pub const KEY_QUANT_HIFIGAN_INT8_OPT_IN: &str = "vokra.quant.hifigan_int8_opt_in";
 CONST vokra-core::gguf::chunks::KEY_QUANT_MIN_DTYPE_ENFORCED|pub const KEY_QUANT_MIN_DTYPE_ENFORCED: &str = "vokra.quant.min_dtype_enforced";
 CONST vokra-core::gguf::chunks::KEY_QUANT_RULE_COUNT|pub const KEY_QUANT_RULE_COUNT: &str = "vokra.quant.rule_count";
+CONST vokra-core::gguf::chunks::KEY_SCHEMA_PRODUCER|pub const KEY_SCHEMA_PRODUCER: &str = "vokra.schema.producer";
+CONST vokra-core::gguf::chunks::KEY_SCHEMA_VERSION|pub const KEY_SCHEMA_VERSION: &str = "vokra.schema.version";
 CONST vokra-core::gguf::chunks::PREFIX_QUANT_RULE|pub const PREFIX_QUANT_RULE: &str = "vokra.quant.rule.";
 CONST vokra-core::gguf::chunks::VOKRA_PREFIX|pub const VOKRA_PREFIX: &str = "vokra.";
+CONST vokra-core::gguf::schema::SCHEMA_VERSION|pub const SCHEMA_VERSION: u32 = 1;
 CONST vokra-core::gguf::tensor::MAX_TENSOR_DIMS|pub const MAX_TENSOR_DIMS: usize = 4;
 CONST vokra-core::gguf::tensor::QK_K|pub const QK_K: usize = 256;
 CONST vokra-core::kv_quant::KV_QUANT_BLOCK_SIZE|pub const KV_QUANT_BLOCK_SIZE: usize = 32;
@@ -94,6 +99,8 @@ ENUM vokra-core::backend::BackendKind|pub enum BackendKind {
 ENUM vokra-core::cache::paged::BlockSize|pub enum BlockSize {
 ENUM vokra-core::cache::paged_quant::AnyBlock|pub enum AnyBlock {
 ENUM vokra-core::compliance::ResolutionSource|pub enum ResolutionSource {
+ENUM vokra-core::compliance::consent::ConsentScope|pub enum ConsentScope {
+ENUM vokra-core::compliance::consent::SignatureStatus|pub enum SignatureStatus {
 ENUM vokra-core::compliance::level::ComplianceLevel|pub enum ComplianceLevel {
 ENUM vokra-core::compliance::level::SpeakerEmbeddingPolicy|pub enum SpeakerEmbeddingPolicy {
 ENUM vokra-core::compliance::level::VoiceCloningPolicy|pub enum VoiceCloningPolicy {
@@ -103,6 +110,7 @@ ENUM vokra-core::decode::cfg::CfgMode|pub enum CfgMode {
 ENUM vokra-core::error::VokraError|pub enum VokraError {
 ENUM vokra-core::gguf::GgufError|pub enum GgufError {
 ENUM vokra-core::gguf::frontend_spec::FrontendPolicy|pub enum FrontendPolicy {
+ENUM vokra-core::gguf::schema::SchemaGeneration|pub enum SchemaGeneration {
 ENUM vokra-core::gguf::tensor::GgmlType|pub enum GgmlType {
 ENUM vokra-core::gguf::value::GgufMetadataValue|pub enum GgufMetadataValue {
 ENUM vokra-core::gguf::value::GgufValueType|pub enum GgufValueType {
@@ -205,6 +213,7 @@ FN vokra-core::cache::paged::positions|pub const fn positions(&self) -> usize {
 FN vokra-core::cache::paged::pre_allocate|pub fn pre_allocate(dims: KvDims, block_size: BlockSize) -> Result<Self> {
 FN vokra-core::cache::paged::read_step|pub fn read_step(&self, layer: usize, t: usize, s: usize, c: usize) -> Option<(&[T], &[T])> {
 FN vokra-core::cache::paged::release_layer|pub fn release_layer(&mut self, layer: usize) -> Result<()> {
+FN vokra-core::cache::paged::release_stream|pub fn release_stream(&mut self, stream: usize) -> Result<()> {
 FN vokra-core::cache::paged::reset|pub fn reset(&mut self) {
 FN vokra-core::cache::paged::row_width|pub const fn row_width(&self) -> usize {
 FN vokra-core::cache::paged_quant::advance|pub fn advance(&mut self, n_positions: usize) {
@@ -223,22 +232,39 @@ FN vokra-core::cache::paged_quant::quant|pub const fn quant(&self) -> KvQuant {
 FN vokra-core::cache::paged_quant::read_step|pub fn read_step(
 FN vokra-core::cache::paged_quant::release_layer|pub fn release_layer(&mut self, layer: usize) -> Result<()> {
 FN vokra-core::cache::paged_quant::reset|pub fn reset(&mut self) {
+FN vokra-core::cache::ring::advance|pub fn advance(&mut self, n: usize) {
+FN vokra-core::cache::ring::append_step|pub fn append_step(
+FN vokra-core::cache::ring::capacity|pub const fn capacity(&self) -> usize {
+FN vokra-core::cache::ring::live_len|pub fn live_len(&self) -> usize {
+FN vokra-core::cache::ring::live_window|pub fn live_window(&self) -> Range<usize> {
+FN vokra-core::cache::ring::positions|pub const fn positions(&self) -> usize {
+FN vokra-core::cache::ring::pre_allocate|pub fn pre_allocate(dims: KvDims, capacity: usize) -> Result<Self> {
+FN vokra-core::cache::ring::read_step|pub fn read_step(&self, layer: usize, t: usize, s: usize, c: usize) -> Option<(&[T], &[T])> {
+FN vokra-core::cache::ring::reset|pub fn reset(&mut self) {
+FN vokra-core::cache::ring::storage_elements|pub fn storage_elements(&self) -> usize {
 FN vokra-core::complex::conj|pub const fn conj(self) -> Self {
 FN vokra-core::complex::from_real|pub const fn from_real(re: f32) -> Self {
 FN vokra-core::complex::new|pub const fn new(re: f32, im: f32) -> Self {
 FN vokra-core::complex::norm_sqr|pub fn norm_sqr(self) -> f32 {
 FN vokra-core::complex::scale|pub fn scale(self, s: f32) -> Self {
 FN vokra-core::compliance::check_weight_license|pub fn check_weight_license(
+FN vokra-core::compliance::consent::as_token|pub fn as_token(self) -> &'static str {
+FN vokra-core::compliance::consent::from_token|pub fn from_token(s: &str) -> Option<Self> {
+FN vokra-core::compliance::consent::parse|pub fn parse(bytes: &[u8]) -> Result<Self> {
+FN vokra-core::compliance::consent::signature_status|pub fn signature_status(&self) -> SignatureStatus {
 FN vokra-core::compliance::from_env|pub fn from_env() -> Self {
 FN vokra-core::compliance::is_research_only|pub fn is_research_only(&self) -> bool {
+FN vokra-core::compliance::level::authorize_embedding_for_tts|pub fn authorize_embedding_for_tts(self, consent: Option<&ConsentManifest>) -> Result<()> {
 FN vokra-core::compliance::level::policy|pub fn policy(&self) -> super::CompliancePolicy {
 FN vokra-core::compliance::level|pub fn level(&self) -> ComplianceLevel {
 FN vokra-core::compliance::license_class::as_str|pub fn as_str(self) -> &'static str {
 FN vokra-core::compliance::license_class::commercial_ok|pub fn commercial_ok(self) -> bool {
 FN vokra-core::compliance::license_class::from_class_str|pub fn from_class_str(s: &str) -> Option<Self> {
 FN vokra-core::compliance::license_class::from_license_str|pub fn from_license_str(s: &str) -> Self {
+FN vokra-core::compliance::license_class::redistributable|pub fn redistributable(self) -> bool {
 FN vokra-core::compliance::license_class::registry_lookup|pub fn registry_lookup(model_id: &str) -> Option<LicenseClass> {
 FN vokra-core::compliance::license_class::requires_attribution|pub fn requires_attribution(self) -> bool {
+FN vokra-core::compliance::license_class::requires_license_preserved|pub fn requires_license_preserved(self) -> bool {
 FN vokra-core::compliance::license_class::requires_research_flag|pub fn requires_research_flag(self) -> bool {
 FN vokra-core::compliance::new|pub fn new(level: ComplianceLevel) -> Self {
 FN vokra-core::compliance::research_license_allowed|pub fn research_license_allowed(&self) -> bool {
@@ -266,6 +292,44 @@ FN vokra-core::decode::stepper::finished|pub fn finished(&self) -> bool {
 FN vokra-core::decode::stepper::new|pub fn new(
 FN vokra-core::decode::stepper::run|pub fn run(&mut self, sink: &mut dyn EventSink, max_new: usize) -> Result<usize> {
 FN vokra-core::decode::stepper::step|pub fn step(&mut self, sink: &mut dyn EventSink) -> Result<Option<u32>> {
+FN vokra-core::decode::wfst::decoder::beam|pub fn beam(mut self, beam: f32) -> Self {
+FN vokra-core::decode::wfst::decoder::decode_nbest|pub fn decode_nbest(&self, emission: &[Vec<f32>]) -> Result<Vec<WfstHypothesis>> {
+FN vokra-core::decode::wfst::decoder::decode|pub fn decode(&self, emission: &[Vec<f32>]) -> Result<Option<WfstHypothesis>> {
+FN vokra-core::decode::wfst::decoder::lattice|pub fn lattice(&self, emission: &[Vec<f32>]) -> Result<WfstLattice> {
+FN vokra-core::decode::wfst::decoder::n_best|pub fn n_best(mut self, n: usize) -> Self {
+FN vokra-core::decode::wfst::decoder::new|pub fn new(fst: &'f Fst<TropicalWeight>) -> Self {
+FN vokra-core::decode::wfst::decoder::with_config|pub fn with_config(fst: &'f Fst<TropicalWeight>, config: WfstDecodeConfig) -> Self {
+FN vokra-core::decode::wfst::fst::add_arc|pub fn add_arc(&mut self, from: StateId, arc: Arc<W>) -> Result<()> {
+FN vokra-core::decode::wfst::fst::add_state|pub fn add_state(&mut self, final_weight: W) -> StateId {
+FN vokra-core::decode::wfst::fst::arcs_of|pub fn arcs_of(&self, s: StateId) -> Result<&[Arc<W>]> {
+FN vokra-core::decode::wfst::fst::final_weight|pub fn final_weight(&self, s: StateId) -> Result<W> {
+FN vokra-core::decode::wfst::fst::is_epsilon|pub fn is_epsilon(&self) -> bool {
+FN vokra-core::decode::wfst::fst::is_final|pub fn is_final(&self, s: StateId) -> Result<bool> {
+FN vokra-core::decode::wfst::fst::new|pub fn new() -> Self {
+FN vokra-core::decode::wfst::fst::num_arcs|pub fn num_arcs(&self) -> usize {
+FN vokra-core::decode::wfst::fst::num_states|pub fn num_states(&self) -> usize {
+FN vokra-core::decode::wfst::fst::set_final|pub fn set_final(&mut self, s: StateId, final_weight: W) -> Result<()> {
+FN vokra-core::decode::wfst::fst::set_start|pub fn set_start(&mut self, s: StateId) {
+FN vokra-core::decode::wfst::fst::start|pub fn start(&self) -> Option<StateId> {
+FN vokra-core::decode::wfst::fst::validate|pub fn validate(&self) -> Result<()> {
+FN vokra-core::decode::wfst::lattice::arcs|pub fn arcs(&self) -> &[LatArc] {
+FN vokra-core::decode::wfst::lattice::backward_distances|pub fn backward_distances(&self) -> Vec<f32> {
+FN vokra-core::decode::wfst::lattice::best_path|pub fn best_path(&self) -> Option<WfstHypothesis> {
+FN vokra-core::decode::wfst::lattice::final_node|pub fn final_node(&self) -> usize {
+FN vokra-core::decode::wfst::lattice::forward_distances|pub fn forward_distances(&self) -> Vec<f32> {
+FN vokra-core::decode::wfst::lattice::has_path|pub fn has_path(&self) -> bool {
+FN vokra-core::decode::wfst::lattice::is_acyclic|pub fn is_acyclic(&self) -> bool {
+FN vokra-core::decode::wfst::lattice::is_well_formed|pub fn is_well_formed(&self) -> bool {
+FN vokra-core::decode::wfst::lattice::nbest|pub fn nbest(&self, n: usize) -> Vec<WfstHypothesis> {
+FN vokra-core::decode::wfst::lattice::node|pub fn node(&self, i: usize) -> (usize, Option<StateId>) {
+FN vokra-core::decode::wfst::lattice::num_arcs|pub fn num_arcs(&self) -> usize {
+FN vokra-core::decode::wfst::lattice::num_frames|pub fn num_frames(&self) -> usize {
+FN vokra-core::decode::wfst::lattice::num_nodes|pub fn num_nodes(&self) -> usize {
+FN vokra-core::decode::wfst::lattice::start|pub fn start(&self) -> usize {
+FN vokra-core::decode::wfst::reader::read_openfst_vector|pub fn read_openfst_vector(bytes: &[u8]) -> Result<Fst<TropicalWeight>> {
+FN vokra-core::decode::wfst::semiring::new|pub fn new(cost: f32) -> Self {
+FN vokra-core::decode::wfst::semiring::value|pub fn value(self) -> f32 {
+FN vokra-core::decode::word_timing::merge_punctuations|pub fn merge_punctuations(
 FN vokra-core::decode::word_timing::token_alignment|pub fn token_alignment(attn: &CrossAttention, params: &AlignmentParams) -> Result<Vec<f32>> {
 FN vokra-core::decode::word_timing::validate|pub fn validate(&self) -> Result<()> {
 FN vokra-core::decode::word_timing::words_from_alignment|pub fn words_from_alignment(
@@ -308,6 +372,12 @@ FN vokra-core::gguf::reader::tensor_f32|pub fn tensor_f32(&self, name: &str) -> 
 FN vokra-core::gguf::reader::tensor_info|pub fn tensor_info(&self, name: &str) -> Option<&GgufTensorInfo> {
 FN vokra-core::gguf::reader::tensors|pub fn tensors(&self) -> &[GgufTensorInfo] {
 FN vokra-core::gguf::reader::version|pub fn version(&self) -> u32 {
+FN vokra-core::gguf::schema::describe|pub fn describe(file: &GgufFile) -> String {
+FN vokra-core::gguf::schema::is_older_than_current|pub fn is_older_than_current(self) -> bool {
+FN vokra-core::gguf::schema::label|pub fn label(self) -> String {
+FN vokra-core::gguf::schema::producer|pub fn producer(file: &GgufFile) -> Option<&str> {
+FN vokra-core::gguf::schema::schema_version|pub fn schema_version(file: &GgufFile) -> SchemaGeneration {
+FN vokra-core::gguf::schema::stale_group_hint|pub fn stale_group_hint(file: &GgufFile, group: &str, re_convert: &str) -> String {
 FN vokra-core::gguf::tensor::block_size|pub fn block_size(self) -> usize {
 FN vokra-core::gguf::tensor::byte_len|pub fn byte_len(&self) -> Result<u64, GgufError> {
 FN vokra-core::gguf::tensor::element_count|pub fn element_count(&self) -> Result<u64, GgufError> {
@@ -329,11 +399,15 @@ FN vokra-core::gguf::writer::add_metadata|pub fn add_metadata(&mut self, key: &s
 FN vokra-core::gguf::writer::add_string|pub fn add_string(&mut self, key: &str, value: &str) -> &mut Self {
 FN vokra-core::gguf::writer::add_tensor|pub fn add_tensor(
 FN vokra-core::gguf::writer::add_u32|pub fn add_u32(&mut self, key: &str, value: u32) -> &mut Self {
+FN vokra-core::gguf::writer::begin|pub fn begin(
+FN vokra-core::gguf::writer::finish|pub fn finish(mut self) -> Result<W, GgufError> {
 FN vokra-core::gguf::writer::metadata_count|pub fn metadata_count(&self) -> usize {
 FN vokra-core::gguf::writer::new|pub fn new() -> Self {
+FN vokra-core::gguf::writer::remaining|pub fn remaining(&self) -> usize {
 FN vokra-core::gguf::writer::set_alignment|pub fn set_alignment(&mut self, align: u64) -> Result<&mut Self, GgufError> {
 FN vokra-core::gguf::writer::tensor_count|pub fn tensor_count(&self) -> usize {
 FN vokra-core::gguf::writer::to_bytes|pub fn to_bytes(&self) -> Result<Vec<u8>, GgufError> {
+FN vokra-core::gguf::writer::write_tensor|pub fn write_tensor(&mut self, name: &str, data: &[u8]) -> Result<(), GgufError> {
 FN vokra-core::ir::fusion::disabled|pub fn disabled() -> Self {
 FN vokra-core::ir::fusion::fuse|pub fn fuse(
 FN vokra-core::ir::fusion::new|pub fn new() -> Self {
@@ -472,6 +546,7 @@ FN vokra-core::runtime::tensor::zeros_f32|pub fn zeros_f32(shape: Vec<usize>) ->
 FN vokra-core::safetensors::element_count|pub fn element_count(&self) -> u64 {
 FN vokra-core::safetensors::open|pub fn open(path: impl AsRef<Path>) -> Result<Self, SafetensorsError> {
 FN vokra-core::safetensors::parse|pub fn parse(data: Vec<u8>) -> Result<Self, SafetensorsError> {
+FN vokra-core::safetensors::read_tensor_into|pub fn read_tensor_into(
 FN vokra-core::safetensors::tensor_bytes|pub fn tensor_bytes(&self, t: &SafeTensorInfo) -> &[u8] {
 FN vokra-core::safetensors::tensor_data|pub fn tensor_data(&self, name: &str) -> Option<&[u8]> {
 FN vokra-core::safetensors::tensor_f32|pub fn tensor_f32(&self, name: &str) -> Result<Vec<f32>, SafetensorsError> {
@@ -550,25 +625,34 @@ FN vokra-ops::aec::process_with_far|pub fn process_with_far(
 FN vokra-ops::aec::process|pub fn process(
 FN vokra-ops::aec::reset|pub fn reset(&mut self) {
 FN vokra-ops::agc::agc|pub fn agc(input: &[f32], attrs: &AgcAttrs) -> Result<Vec<f32>> {
+FN vokra-ops::agc::attrs|pub fn attrs(&self) -> &AgcAttrs {
+FN vokra-ops::agc::new|pub fn new(attrs: &AgcAttrs) -> Result<Self> {
+FN vokra-ops::agc::process_chunk|pub fn process_chunk(&mut self, chunk: &[f32]) -> Result<Vec<f32>> {
+FN vokra-ops::agc::reset|pub fn reset(&mut self) {
 FN vokra-ops::agc::speech_default|pub fn speech_default() -> Self {
 FN vokra-ops::dac_rvq::dac_24khz|pub const fn dac_24khz() -> Self {
 FN vokra-ops::dac_rvq::dac_paged_dims|pub fn dac_paged_dims(attrs: &DacRvqAttrs, n_stream: usize, max_time: usize) -> KvDims {
 FN vokra-ops::dac_rvq::dac_rvq_decode_paged|pub fn dac_rvq_decode_paged(
 FN vokra-ops::dac_rvq::dac_rvq_decode|pub fn dac_rvq_decode(
+FN vokra-ops::dac_rvq::dac_rvq_read_summed_range|pub fn dac_rvq_read_summed_range(
 FN vokra-ops::dac_rvq::dac_rvq_read_summed|pub fn dac_rvq_read_summed(
 FN vokra-ops::dac_rvq::new|pub fn new(
 FN vokra-ops::dac_rvq::weight_row|pub fn weight_row(&self, o: usize) -> &[f32] {
 FN vokra-ops::dct::dct|pub fn dct(input: &[f32], rows: usize, n: usize, attrs: &DctAttrs) -> Vec<f32> {
 FN vokra-ops::denoise::config|pub fn config(&self) -> &DeepFilterNetConfig {
 FN vokra-ops::denoise::deep_filter_net3|pub fn deep_filter_net3() -> Self {
+FN vokra-ops::denoise::denoise_skipped_checkpoint_tensors|pub fn denoise_skipped_checkpoint_tensors() -> &'static [&'static str] {
+FN vokra-ops::denoise::denoise_synthesized_tensors|pub fn denoise_synthesized_tensors(
+FN vokra-ops::denoise::denoise_tensor_manifest|pub fn denoise_tensor_manifest(cfg: &DeepFilterNetConfig) -> Vec<TensorSpec> {
 FN vokra-ops::denoise::denoise|pub fn denoise(noisy: &[f32], model: &DenoiseModel) -> Result<Vec<f32>> {
-FN vokra-ops::denoise::forward|pub fn forward(&self, noisy: &[f32]) -> Result<Vec<f32>> {
+FN vokra-ops::denoise::emb_dim|pub fn emb_dim(&self) -> usize {
+FN vokra-ops::denoise::enhance_with_taps|pub fn enhance_with_taps(&self, noisy: &[f32]) -> Result<(Vec<f32>, DenoiseTaps)> {
+FN vokra-ops::denoise::enhance|pub fn enhance(&self, noisy: &[f32]) -> Result<Vec<f32>> {
+FN vokra-ops::denoise::erb_widths|pub fn erb_widths(&self) -> Result<Vec<usize>> {
 FN vokra-ops::denoise::from_gguf|pub fn from_gguf(gguf: &vokra_core::gguf::GgufFile) -> Result<Self> {
-FN vokra-ops::denoise::from_gguf|pub fn from_gguf(gguf: &vokra_core::gguf::GgufFile, cfg: &DeepFilterNetConfig) -> Result<Self> {
+FN vokra-ops::denoise::from_tensors|pub fn from_tensors(
 FN vokra-ops::denoise::n_bins|pub fn n_bins(&self) -> usize {
-FN vokra-ops::denoise::new|pub fn new(cfg: DeepFilterNetConfig, weights: DenoiseWeights) -> Result<Self> {
-FN vokra-ops::denoise::synthesized|pub fn synthesized(cfg: &DeepFilterNetConfig, seed: u64) -> Self {
-FN vokra-ops::denoise::to_gguf_bytes|pub fn to_gguf_bytes(&self) -> Result<Vec<u8>> {
+FN vokra-ops::denoise::write_gguf_metadata|pub fn write_gguf_metadata(&self, b: &mut vokra_core::gguf::GgufBuilder) {
 FN vokra-ops::dispatch::as_complex|pub fn as_complex(&self) -> Option<(&[usize], &[f32], &[f32])> {
 FN vokra-ops::dispatch::as_real|pub fn as_real(&self) -> Option<(&[usize], &[f32])> {
 FN vokra-ops::dispatch::dispatch|pub fn dispatch(op: &OpKind, inputs: &[OpValue]) -> Result<Vec<OpValue>> {
@@ -621,8 +705,12 @@ FN vokra-ops::hifigan::new|pub fn new(strategy: CalibrationStrategy) -> Self {
 FN vokra-ops::hifigan::validate|pub fn validate(&self) -> Result<()> {
 FN vokra-ops::hifigan::with_int8_opt_in|pub fn with_int8_opt_in(
 FN vokra-ops::hifigan::with_threshold|pub fn with_threshold(threshold: f32) -> Self {
+FN vokra-ops::hpf::attrs|pub fn attrs(&self) -> &HpfAttrs {
 FN vokra-ops::hpf::butterworth|pub fn butterworth(cutoff_hz: f32, sample_rate: u32) -> Self {
 FN vokra-ops::hpf::hpf|pub fn hpf(input: &[f32], attrs: &HpfAttrs) -> Result<Vec<f32>> {
+FN vokra-ops::hpf::new|pub fn new(attrs: &HpfAttrs) -> Result<Self> {
+FN vokra-ops::hpf::process_chunk|pub fn process_chunk(&mut self, chunk: &[f32]) -> Result<Vec<f32>> {
+FN vokra-ops::hpf::reset|pub fn reset(&mut self) {
 FN vokra-ops::istft::istft|pub fn istft(spectrogram: &Spectrogram, attrs: &IstftAttrs) -> Result<Vec<f32>> {
 FN vokra-ops::istft_streaming::emitted|pub fn emitted(&self) -> usize {
 FN vokra-ops::istft_streaming::expected_bins|pub fn expected_bins(&self) -> usize {
@@ -678,6 +766,7 @@ FN vokra-ops::window::window|pub fn window(kind: Window, length: usize, symmetry
 MOD vokra-core::backend|pub mod backend;
 MOD vokra-core::cache::paged_quant|pub mod paged_quant;
 MOD vokra-core::cache::paged|pub mod paged;
+MOD vokra-core::cache::ring|pub mod ring;
 MOD vokra-core::cache|pub mod cache;
 MOD vokra-core::complex|pub mod complex;
 MOD vokra-core::compliance|pub mod compliance;
@@ -685,6 +774,12 @@ MOD vokra-core::decode::beam_search|pub mod beam_search;
 MOD vokra-core::decode::cfg|pub mod cfg;
 MOD vokra-core::decode::sampler|pub mod sampler;
 MOD vokra-core::decode::stepper|pub mod stepper;
+MOD vokra-core::decode::wfst::decoder|pub mod decoder;
+MOD vokra-core::decode::wfst::fst|pub mod fst;
+MOD vokra-core::decode::wfst::lattice|pub mod lattice;
+MOD vokra-core::decode::wfst::reader|pub mod reader;
+MOD vokra-core::decode::wfst::semiring|pub mod semiring;
+MOD vokra-core::decode::wfst|pub mod wfst;
 MOD vokra-core::decode::word_timing|pub mod word_timing;
 MOD vokra-core::decode|pub mod decode;
 MOD vokra-core::engines|pub mod engines;
@@ -692,6 +787,7 @@ MOD vokra-core::error|pub mod error;
 MOD vokra-core::gguf::chunks|pub mod chunks;
 MOD vokra-core::gguf::frontend_spec|pub mod frontend_spec;
 MOD vokra-core::gguf::quant|pub mod quant;
+MOD vokra-core::gguf::schema|pub mod schema;
 MOD vokra-core::gguf::tensor|pub mod tensor;
 MOD vokra-core::gguf::value|pub mod value;
 MOD vokra-core::gguf|pub mod gguf;
@@ -774,10 +870,12 @@ STRUCT vokra-core::cache::paged::PagedKvCache|pub struct PagedKvCache<T: KvEleme
 STRUCT vokra-core::cache::paged::TimeRangeIter|pub struct TimeRangeIter<'a, T: KvElement> {
 STRUCT vokra-core::cache::paged_quant::AllocatorSnapshot|pub struct AllocatorSnapshot {
 STRUCT vokra-core::cache::paged_quant::QuantizedPagedKvCache|pub struct QuantizedPagedKvCache {
+STRUCT vokra-core::cache::ring::RingKvCache|pub struct RingKvCache<T: KvElement> {
 STRUCT vokra-core::complex::Complex32|pub struct Complex32 {
 STRUCT vokra-core::compliance::AttributionInfo|pub struct AttributionInfo {
 STRUCT vokra-core::compliance::CompliancePolicy|pub struct CompliancePolicy {
 STRUCT vokra-core::compliance::LicenseResolution|pub struct LicenseResolution {
+STRUCT vokra-core::compliance::consent::ConsentManifest|pub struct ConsentManifest {
 STRUCT vokra-core::compliance::level::ComplianceConfig|pub struct ComplianceConfig {
 STRUCT vokra-core::compliance::level::DisclosureConfig|pub struct DisclosureConfig {
 STRUCT vokra-core::compliance::watermark::WatermarkConfig|pub struct WatermarkConfig {
@@ -786,6 +884,14 @@ STRUCT vokra-core::decode::beam_search::BeamSearchConfig|pub struct BeamSearchCo
 STRUCT vokra-core::decode::sampler::SamplerConfig|pub struct SamplerConfig {
 STRUCT vokra-core::decode::sampler::Sampler|pub struct Sampler {
 STRUCT vokra-core::decode::stepper::DecodeStepper|pub struct DecodeStepper {
+STRUCT vokra-core::decode::wfst::decoder::WfstDecodeConfig|pub struct WfstDecodeConfig {
+STRUCT vokra-core::decode::wfst::decoder::WfstDecoder|pub struct WfstDecoder<'f> {
+STRUCT vokra-core::decode::wfst::fst::Arc|pub struct Arc<W: Semiring> {
+STRUCT vokra-core::decode::wfst::fst::Fst|pub struct Fst<W: Semiring> {
+STRUCT vokra-core::decode::wfst::lattice::LatArc|pub struct LatArc {
+STRUCT vokra-core::decode::wfst::lattice::WfstHypothesis|pub struct WfstHypothesis {
+STRUCT vokra-core::decode::wfst::lattice::WfstLattice|pub struct WfstLattice {
+STRUCT vokra-core::decode::wfst::semiring::TropicalWeight|pub struct TropicalWeight(pub f32);
 STRUCT vokra-core::decode::word_timing::AlignmentParams|pub struct AlignmentParams {
 STRUCT vokra-core::decode::word_timing::CrossAttention|pub struct CrossAttention {
 STRUCT vokra-core::decode::word_timing::WordTiming|pub struct WordTiming {
@@ -801,6 +907,8 @@ STRUCT vokra-core::gguf::reader::GgufFile|pub struct GgufFile {
 STRUCT vokra-core::gguf::tensor::GgufTensorInfo|pub struct GgufTensorInfo {
 STRUCT vokra-core::gguf::value::GgufArray|pub struct GgufArray {
 STRUCT vokra-core::gguf::writer::GgufBuilder|pub struct GgufBuilder {
+STRUCT vokra-core::gguf::writer::GgufStreamWriter|pub struct GgufStreamWriter<W: std::io::Write> {
+STRUCT vokra-core::gguf::writer::GgufTensorDecl|pub struct GgufTensorDecl {
 STRUCT vokra-core::ir::fusion::FusionOptions|pub struct FusionOptions {
 STRUCT vokra-core::ir::fusion::patterns::logmel::LogMelPattern|pub struct LogMelPattern;
 STRUCT vokra-core::ir::fusion::patterns::snake::Conv1dSnakePattern|pub struct Conv1dSnakePattern;
@@ -843,6 +951,7 @@ STRUCT vokra-core::rng::SplitMix64|pub struct SplitMix64 {
 STRUCT vokra-core::rng::Xorshift64Star|pub struct Xorshift64Star {
 STRUCT vokra-core::runtime::tensor::Tensor|pub struct Tensor {
 STRUCT vokra-core::safetensors::SafeTensorInfo|pub struct SafeTensorInfo {
+STRUCT vokra-core::safetensors::SafetensorsFileReader|pub struct SafetensorsFileReader {
 STRUCT vokra-core::safetensors::SafetensorsFile|pub struct SafetensorsFile {
 STRUCT vokra-core::session::SessionBuilder|pub struct SessionBuilder {
 STRUCT vokra-core::session::Session|pub struct Session {
@@ -865,12 +974,13 @@ STRUCT vokra-core::tasks::Tts|pub struct Tts<'a> {
 STRUCT vokra-ops::aec::AecAttrs|pub struct AecAttrs {
 STRUCT vokra-ops::aec::Aec|pub struct Aec {
 STRUCT vokra-ops::agc::AgcAttrs|pub struct AgcAttrs {
+STRUCT vokra-ops::agc::AgcState|pub struct AgcState {
 STRUCT vokra-ops::dac_rvq::DacOutProj|pub struct DacOutProj {
 STRUCT vokra-ops::dac_rvq::DacRvqAttrs|pub struct DacRvqAttrs {
 STRUCT vokra-ops::denoise::DeepFilterNetConfig|pub struct DeepFilterNetConfig {
 STRUCT vokra-ops::denoise::DenoiseModel|pub struct DenoiseModel {
-STRUCT vokra-ops::denoise::DenoiseWeights|pub struct DenoiseWeights {
-STRUCT vokra-ops::denoise::DenseLayer|pub struct DenseLayer {
+STRUCT vokra-ops::denoise::DenoiseTaps|pub struct DenoiseTaps {
+STRUCT vokra-ops::denoise::TensorSpec|pub struct TensorSpec {
 STRUCT vokra-ops::encodec_rvq::EncodecRvqAttrs|pub struct EncodecRvqAttrs {
 STRUCT vokra-ops::fft::plan::FftPlan|pub struct FftPlan {
 STRUCT vokra-ops::fft::real::RealFftPlan|pub struct RealFftPlan {
@@ -888,6 +998,7 @@ STRUCT vokra-ops::hifigan::MrfBranchWeights|pub struct MrfBranchWeights {
 STRUCT vokra-ops::hifigan::ResBlockLayer|pub struct ResBlockLayer {
 STRUCT vokra-ops::hifigan::UpsampleStageWeights|pub struct UpsampleStageWeights {
 STRUCT vokra-ops::hpf::HpfAttrs|pub struct HpfAttrs {
+STRUCT vokra-ops::hpf::HpfState|pub struct HpfState {
 STRUCT vokra-ops::istft_streaming::IstftStreamingState|pub struct IstftStreamingState {
 STRUCT vokra-ops::kaldi_fbank::KaldiFbankOpts|pub struct KaldiFbankOpts {
 STRUCT vokra-ops::loudness_norm::LoudnessNormAttrs|pub struct LoudnessNormAttrs {
@@ -902,6 +1013,7 @@ TRAIT vokra-core::cache::paged::GpuPagedKvCacheOps|pub trait GpuPagedKvCacheOps 
 TRAIT vokra-core::cache::paged::KvElement|pub trait KvElement: Copy + Send + Sync + 'static {
 TRAIT vokra-core::decode::LogitsSource|pub trait LogitsSource {
 TRAIT vokra-core::decode::beam_search::BeamScorer|pub trait BeamScorer {
+TRAIT vokra-core::decode::wfst::semiring::Semiring|pub trait Semiring: Copy + Clone + Debug + PartialEq {
 TRAIT vokra-core::engines::AsrEngine|pub trait AsrEngine: Send + Sync {
 TRAIT vokra-core::engines::S2sDuplexEngine|pub trait S2sDuplexEngine: Send + Sync {
 TRAIT vokra-core::engines::S2sDuplexHandle|pub trait S2sDuplexHandle {
@@ -915,14 +1027,18 @@ TRAIT vokra-core::kv_quant::gpu_ops::KvQuantDequantGemvOps|pub trait KvQuantDequ
 TRAIT vokra-core::stream::event::EventSink|pub trait EventSink {
 TRAIT vokra-core::stream::step::StreamStep|pub trait StreamStep: Send {
 TRAIT vokra-ops::prosody::ApplyProsody|pub trait ApplyProsody {
-TYPE vokra-core::error::Result|pub type Result<T> = std::result::Result<T, VokraError>;
+TYPE vokra-core::decode::wfst::fst::Label|pub type Label = u32;
+TYPE vokra-core::decode::wfst::fst::StateId|pub type StateId = u32;
+TYPE vokra-core::error::Result|pub type Result<T> = core::result::Result<T, VokraError>;
 USE vokra-core::backend::{Backend, BackendKind}|pub use backend::{Backend, BackendKind};
 USE vokra-core::cache::KvCache|pub use cache::KvCache;
 USE vokra-core::cache::kv::KvCache|pub use kv::KvCache;
 USE vokra-core::cache::paged::{ AllocatorSnapshot, BlockSize, GpuPagedKvCacheOps, KvDims, KvElement, KvSlot, PageId, PagedKvCache, TimeRangeIter, }|pub use cache::paged::{ AllocatorSnapshot, BlockSize, GpuPagedKvCacheOps, KvDims, KvElement, KvSlot, PageId, PagedKvCache, TimeRangeIter, };
 USE vokra-core::cache::paged_quant::{ AllocatorSnapshot as QuantAllocatorSnapshot, AnyBlock, QuantizedPagedKvCache, }|pub use cache::paged_quant::{ AllocatorSnapshot as QuantAllocatorSnapshot, AnyBlock, QuantizedPagedKvCache, };
 USE vokra-core::cache::paged_quant::{ AllocatorSnapshot as QuantAllocatorSnapshot, AnyBlock, QuantizedPagedKvCache, }|pub use paged_quant::{ AllocatorSnapshot as QuantAllocatorSnapshot, AnyBlock, QuantizedPagedKvCache, };
+USE vokra-core::cache::ring::RingKvCache|pub use ring::RingKvCache;
 USE vokra-core::complex::Complex32|pub use complex::Complex32;
+USE vokra-core::compliance::consent::{ConsentManifest, ConsentScope, SignatureStatus}|pub use consent::{ConsentManifest, ConsentScope, SignatureStatus};
 USE vokra-core::compliance::level::{ ComplianceConfig, ComplianceLevel, DisclosureConfig, SpeakerEmbeddingPolicy, VoiceCloningPolicy, }|pub use level::{ ComplianceConfig, ComplianceLevel, DisclosureConfig, SpeakerEmbeddingPolicy, VoiceCloningPolicy, };
 USE vokra-core::compliance::license_class::{LicenseClass, registry_lookup}|pub use license_class::{LicenseClass, registry_lookup};
 USE vokra-core::compliance::watermark::{WatermarkBackendStatus, WatermarkConfig}|pub use watermark::{WatermarkBackendStatus, WatermarkConfig};
@@ -931,16 +1047,24 @@ USE vokra-core::decode::beam_search::{BeamHypothesis, BeamScorer, BeamSearchConf
 USE vokra-core::decode::cfg::{CfgMode, apply_cfg, apply_cfg_inplace}|pub use cfg::{CfgMode, apply_cfg, apply_cfg_inplace};
 USE vokra-core::decode::sampler::{Sampler, SamplerConfig, argmax, sample_sequence}|pub use sampler::{Sampler, SamplerConfig, argmax, sample_sequence};
 USE vokra-core::decode::stepper::{DecodeStepper, TOKEN_FLAG_EOT}|pub use stepper::{DecodeStepper, TOKEN_FLAG_EOT};
-USE vokra-core::decode::word_timing::{ AlignmentParams, CrossAttention, WordTiming, token_alignment, words_from_alignment, }|pub use word_timing::{ AlignmentParams, CrossAttention, WordTiming, token_alignment, words_from_alignment, };
+USE vokra-core::decode::wfst::decoder::{WfstDecodeConfig, WfstDecoder}|pub use decoder::{WfstDecodeConfig, WfstDecoder};
+USE vokra-core::decode::wfst::fst::{Arc, Fst, Label, StateId}|pub use fst::{Arc, Fst, Label, StateId};
+USE vokra-core::decode::wfst::lattice::{LatArc, WfstHypothesis, WfstLattice}|pub use lattice::{LatArc, WfstHypothesis, WfstLattice};
+USE vokra-core::decode::wfst::reader::read_openfst_vector|pub use reader::read_openfst_vector;
+USE vokra-core::decode::wfst::semiring::{Semiring, TropicalWeight}|pub use semiring::{Semiring, TropicalWeight};
+USE vokra-core::decode::wfst::{ Arc, Fst, Label, Semiring, StateId, TropicalWeight, WfstDecodeConfig, WfstDecoder, WfstHypothesis, WfstLattice, read_openfst_vector, }|pub use wfst::{ Arc, Fst, Label, Semiring, StateId, TropicalWeight, WfstDecodeConfig, WfstDecoder, WfstHypothesis, WfstLattice, read_openfst_vector, };
+USE vokra-core::decode::word_timing::{ APPEND_PUNCTUATIONS, AlignmentParams, CrossAttention, PREPEND_PUNCTUATIONS, WordTiming, merge_punctuations, token_alignment, words_from_alignment, }|pub use word_timing::{ APPEND_PUNCTUATIONS, AlignmentParams, CrossAttention, PREPEND_PUNCTUATIONS, WordTiming, merge_punctuations, token_alignment, words_from_alignment, };
 USE vokra-core::decode::{ CfgMode, DecodeStepper, LogitsSource, Sampler, SamplerConfig, TOKEN_FLAG_EOT, apply_cfg, apply_cfg_inplace, argmax, sample_sequence, }|pub use decode::{ CfgMode, DecodeStepper, LogitsSource, Sampler, SamplerConfig, TOKEN_FLAG_EOT, apply_cfg, apply_cfg_inplace, argmax, sample_sequence, };
 USE vokra-core::engines::{ AsrEngine, DialogContextTurn, DialogRequest, DuplexInterruptHandle, DuplexPushReport, DuplexSessionConfig, S2sDuplexEngine, S2sDuplexHandle, S2sEngine, SynthesisRequest, TtsEngine, VadEngine, VadStreamHandle, }|pub use engines::{ AsrEngine, DialogContextTurn, DialogRequest, DuplexInterruptHandle, DuplexPushReport, DuplexSessionConfig, S2sDuplexEngine, S2sDuplexHandle, S2sEngine, SynthesisRequest, TtsEngine, VadEngine, VadStreamHandle, };
 USE vokra-core::error::{Result, VokraError}|pub use error::{Result, VokraError};
 USE vokra-core::gguf::frontend_spec::{FieldMismatch, FrontendPolicy, FrontendSpec}|pub use frontend_spec::{FieldMismatch, FrontendPolicy, FrontendSpec};
 USE vokra-core::gguf::reader::{AsBytes, GgufFile}|pub use reader::{AsBytes, GgufFile};
+USE vokra-core::gguf::schema::{SCHEMA_VERSION, SchemaGeneration, schema_version, stale_group_hint}|pub use schema::{SCHEMA_VERSION, SchemaGeneration, schema_version, stale_group_hint};
 USE vokra-core::gguf::tensor::{GgmlType, GgufTensorInfo}|pub use tensor::{GgmlType, GgufTensorInfo};
 USE vokra-core::gguf::value::{GgufArray, GgufMetadataValue, GgufValueType}|pub use value::{GgufArray, GgufMetadataValue, GgufValueType};
-USE vokra-core::gguf::writer::GgufBuilder|pub use writer::GgufBuilder;
-USE vokra-core::gguf::{ FieldMismatch, FrontendPolicy, FrontendSpec, GgmlType, GgufBuilder, GgufError, GgufFile, GgufTensorInfo, }|pub use gguf::{ FieldMismatch, FrontendPolicy, FrontendSpec, GgmlType, GgufBuilder, GgufError, GgufFile, GgufTensorInfo, };
+USE vokra-core::gguf::writer::{GgufBuilder, GgufStreamWriter, GgufTensorDecl}|pub use writer::{GgufBuilder, GgufStreamWriter, GgufTensorDecl};
+USE vokra-core::gguf::{FieldMismatch, FrontendPolicy, FrontendSpec, GgufBuilder}|pub use gguf::{FieldMismatch, FrontendPolicy, FrontendSpec, GgufBuilder};
+USE vokra-core::gguf::{GgmlType, GgufError, GgufFile, GgufTensorInfo}|pub use gguf::{GgmlType, GgufError, GgufFile, GgufTensorInfo};
 USE vokra-core::ir::fusion::FusedOp|pub use fusion::FusedOp;
 USE vokra-core::ir::graph::{AudioGraph, GraphBuilder, Node, OpKind}|pub use graph::{AudioGraph, GraphBuilder, Node, OpKind};
 USE vokra-core::ir::tensor::{DType, Dim, TensorDesc, TensorId}|pub use tensor::{DType, Dim, TensorDesc, TensorId};
@@ -974,11 +1098,11 @@ USE vokra-core::stream::step::StreamStep|pub use step::StreamStep;
 USE vokra-core::stream::{ EventPoller, EventSink, InterruptHandle, RawEvent, RingConsumer, RingFull, RingProducer, Stream, StreamEvent, StreamState, StreamStep, channel, }|pub use stream::{ EventPoller, EventSink, InterruptHandle, RawEvent, RingConsumer, RingFull, RingProducer, Stream, StreamEvent, StreamState, StreamStep, channel, };
 USE vokra-core::tasks::{Asr, DialogTurn, S2s, SynthesizedAudio, Transcription, Tts}|pub use tasks::{Asr, DialogTurn, S2s, SynthesizedAudio, Transcription, Tts};
 USE vokra-ops::aec::{Aec, AecAttrs, AecStatus}|pub use aec::{Aec, AecAttrs, AecStatus};
-USE vokra-ops::agc::{AgcAttrs, agc}|pub use agc::{AgcAttrs, agc};
+USE vokra-ops::agc::{AgcAttrs, AgcState, agc}|pub use agc::{AgcAttrs, AgcState, agc};
 USE vokra-ops::attrs::vokra_core::ir::graph::{ DctAttrs, DurationUnit, HifiGanAttrs, IstftAttrs, IstftStreamingAttrs, LengthConditioningAttrs, LengthConditioningMode, MelAttrs, MelNorm, MelScale, MfccAttrs, Normalization, PadMode, StftAttrs, Window, WindowSymmetry, }|pub use vokra_core::ir::graph::{ DctAttrs, DurationUnit, HifiGanAttrs, IstftAttrs, IstftStreamingAttrs, LengthConditioningAttrs, LengthConditioningMode, MelAttrs, MelNorm, MelScale, MfccAttrs, Normalization, PadMode, StftAttrs, Window, WindowSymmetry, };
-USE vokra-ops::dac_rvq::{ DacOutProj, DacRvqAttrs, dac_paged_dims, dac_rvq_decode, dac_rvq_decode_paged, dac_rvq_read_summed, }|pub use dac_rvq::{ DacOutProj, DacRvqAttrs, dac_paged_dims, dac_rvq_decode, dac_rvq_decode_paged, dac_rvq_read_summed, };
+USE vokra-ops::dac_rvq::{ DacOutProj, DacRvqAttrs, dac_paged_dims, dac_rvq_decode, dac_rvq_decode_paged, dac_rvq_read_summed, dac_rvq_read_summed_range, }|pub use dac_rvq::{ DacOutProj, DacRvqAttrs, dac_paged_dims, dac_rvq_decode, dac_rvq_decode_paged, dac_rvq_read_summed, dac_rvq_read_summed_range, };
 USE vokra-ops::dct::dct|pub use dct::dct;
-USE vokra-ops::denoise::{DeepFilterNetConfig, DenoiseModel, DenoiseWeights, denoise}|pub use denoise::{DeepFilterNetConfig, DenoiseModel, DenoiseWeights, denoise};
+USE vokra-ops::denoise::{ DeepFilterNetConfig, DenoiseModel, DenoiseTaps, TensorSpec, denoise, denoise_skipped_checkpoint_tensors, denoise_synthesized_tensors, denoise_tensor_manifest, }|pub use denoise::{ DeepFilterNetConfig, DenoiseModel, DenoiseTaps, TensorSpec, denoise, denoise_skipped_checkpoint_tensors, denoise_synthesized_tensors, denoise_tensor_manifest, };
 USE vokra-ops::dispatch::{OpValue, dispatch}|pub use dispatch::{OpValue, dispatch};
 USE vokra-ops::encodec_rvq::{EncodecRvqAttrs, encodec_rvq_decode}|pub use encodec_rvq::{EncodecRvqAttrs, encodec_rvq_decode};
 USE vokra-ops::fft::plan::FftPlan|pub use plan::FftPlan;
@@ -989,7 +1113,7 @@ USE vokra-ops::frontend::{mel_attrs_from_spec, stft_attrs_from_spec}|pub use fro
 USE vokra-ops::fsq_codec::{ FsqOutProj, WavTokenizerVqAttrs, Xcodec2FsqAttrs, fsq_index_to_grid_codes, wavtokenizer_vq_decode, xcodec2_fsq_decode, }|pub use fsq_codec::{ FsqOutProj, WavTokenizerVqAttrs, Xcodec2FsqAttrs, fsq_index_to_grid_codes, wavtokenizer_vq_decode, xcodec2_fsq_decode, };
 USE vokra-ops::fused_logmel::fused_log_mel_scalar|pub use fused_logmel::fused_log_mel_scalar;
 USE vokra-ops::hifigan::{ CalibrationStrategy, CalibrationTable, HifiGanCalibrator, HifiGanConfig, HifiGanPrecision, HifiGanSpectralChecker, HifiGanWeights, MrfBranchWeights, ResBlockLayer, SPECTRAL_CHECK_THRESHOLD, SpectralCheckResult, UpsampleStageWeights, hifigan_generator, }|pub use hifigan::{ CalibrationStrategy, CalibrationTable, HifiGanCalibrator, HifiGanConfig, HifiGanPrecision, HifiGanSpectralChecker, HifiGanWeights, MrfBranchWeights, ResBlockLayer, SPECTRAL_CHECK_THRESHOLD, SpectralCheckResult, UpsampleStageWeights, hifigan_generator, };
-USE vokra-ops::hpf::{HpfAttrs, hpf}|pub use hpf::{HpfAttrs, hpf};
+USE vokra-ops::hpf::{HpfAttrs, HpfState, hpf}|pub use hpf::{HpfAttrs, HpfState, hpf};
 USE vokra-ops::istft::istft|pub use istft::istft;
 USE vokra-ops::istft_streaming::{IstftStreamingState, istft_streaming_oneshot}|pub use istft_streaming::{IstftStreamingState, istft_streaming_oneshot};
 USE vokra-ops::kaldi_fbank::{KaldiFbankOpts, kaldi_fbank}|pub use kaldi_fbank::{KaldiFbankOpts, kaldi_fbank};


### PR DESCRIPTION
## Summary

**abi-surface (advisory) の drift 修正**。PR #10 (M5) と PR #8 (M4 v1.0-rc terminal) で追加された public API 面が `docs/abi/vokra-rust-public-api.v1.0-rc.list` に反映されていなかったため、直近数 PR で継続的に赤の状態。`scripts/rust-public-api-list.sh --update-snapshot` を実行して snapshot を rotate。

## 変更 (1 file only)

- `docs/abi/vokra-rust-public-api.v1.0-rc.list`: +139 items / -15 items

## 主な追加カテゴリ

| カテゴリ | 例 | 由来 |
|---|---|---|
| Consent manifest | `vokra-core::compliance::consent::{ConsentScope, SignatureStatus, parse, signature_status}` | M5-05 |
| Watermark auth | `vokra-core::compliance::level::authorize_embedding_for_tts` | M5-05 |
| License predicate | `vokra-core::compliance::license_class::{redistributable, requires_license_preserved}` | M5-07 / M5 |
| WFST decoder | `vokra-core::decode::wfst::decoder::{decode, decode_nbest, lattice, beam}` | M5-06 |
| Ring KV cache | `vokra-core::cache::ring::{advance, append_step, capacity, live_len, live_window, positions, pre_allocate, read_step, reset, storage_elements}` | M4 (Moshi) |
| GGUF schema stamp | `vokra-core::gguf::schema::{SCHEMA_VERSION, SchemaGeneration, KEY_SCHEMA_{PRODUCER,VERSION}}` | 2026-07-23 (M4/M5 combined) |
| Word timing | `vokra-core::decode::word_timing::{APPEND,PREPEND}_PUNCTUATIONS` | Whisper word-timestamp merge |

## Verify

- `scripts/rust-public-api-list.sh` → **OK** (snapshot unchanged + non_exhaustive audit passed)
- `scripts/rust-public-api-list.sh --self-test` → **OK**
- captured 613 fn / 155 struct / 58 enum / 19 trait / 3 type / 64 const / 0 static / 0 union / 97 use / 90 mod

## Semver 位置付け

v1.0-rc は prerelease semver (1.0.0-rc.N) ゆえ、prerelease ABI 政策で public API の add / rename / remove は自由 + changelog 記録推奨。実 C ABI 凍結は **M5-13 で v1.0 GA タグ時に発火** (現在非発火、`include/vokra.h` + `docs/abi/vokra.h.v1.0-rc-baseline.symbols` は不変)。本 PR は Rust public API snapshot の update-only で **C ABI 面は完全不変**。

## PR queue

- **本 PR (#13)**: abi-surface drift 解消
- **PR #12** (CI/CD reorg + OSS 品質担保): 本 PR merge 後に main で rebase → CI 再走 → abi-surface green で最終 merge 予定

## Test plan

- [x] Local `scripts/rust-public-api-list.sh` OK
- [x] Local `scripts/rust-public-api-list.sh --self-test` OK
- [x] pre-commit hook (fmt / forbidden-symbols / zero-deps / fixture-eol / pipefail lint) OK
- [ ] CI で abi-surface (advisory) が green になる (drift 解消 verify)
- [ ] Required 10 も全緑