### PR TITLE
perf(ci): server-compat macos 30min → 5-10min + gpu-backends feature 別 cache 分離

### DIFF
--- a/.github/workflows/ci-platform.yml
+++ b/.github/workflows/ci-platform.yml
@@ -93,6 +93,13 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          # 2026-07-23 CI 高速化: feature 別 shared-key を明示。Swatinem のデフォルト
+          # は workflow + workspace + Cargo.lock hash なので、同一 OS の feature 違い
+          # (macos × metal vs macos × coreml、ubuntu × cuda vs ubuntu × qnn) が
+          # target/ dir で相互 pollution する。feature 別に cache tarball を分けて
+          # 各 arm を独立に warm 化する。godot-crossbuild.yml が同型パターン。
+          shared-key: gpu-backends-${{ matrix.os }}-${{ matrix.feature }}
       - name: Build (--features ${{ matrix.feature }})
         run: cargo build -p vokra-models -p vokra-cli --features ${{ matrix.feature }}
       - name: Clippy (--features ${{ matrix.feature }})

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -426,20 +426,50 @@ jobs:
         with:
           workspaces: |
             integrations/vokra-server
+          # 案 B (2026-07-23): matrix triple 別 cache key を明示。Swatinem のデフォルト
+          # key は workflow + workspace + Cargo.lock hash だが、triple 差 (musl vs
+          # aarch64-apple-darwin vs pc-windows-msvc) は自動で識別されないため、
+          # cache tarball が triple 間で相互 pollution する / 逆に PR 間で miss する。
+          # 明示指定で triple 別に分離して hit 率を上げる。
+          shared-key: server-compat-${{ matrix.triple }}
       - name: Install musl toolchain (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install -y musl-tools
-      - name: Cross-build vokra-server (release, ${{ matrix.triple }})
+      - name: Cross-build vokra-server (${{ matrix.triple }})
         # FR-SV-01 cross-target proof: the server binary must build on the
-        # three officially supported single-binary triples. macOS ARM64 is the
-        # native runner triple (no --target needed on apple-silicon runners
-        # but we pass it explicitly for symmetry); Windows uses the MSVC ABI;
-        # Linux uses musl for static linkage (see T19 for the static-link
-        # verification — this leg only proves the toolchain wiring compiles).
+        # three officially supported single-binary triples. macOS ARM64 は
+        # native runner triple (Windows は MSVC ABI、Linux は musl で静的 link
+        # 検証 = T19、この leg 自体は toolchain wiring が通ることの検証)。
+        #
+        # profile 選択 (2026-07-23 の CI 高速化 — 案 C):
+        #   - ubuntu-latest (run_tests: true) は compat tests を実 release で
+        #     回すため `--release` 必須。
+        #   - macos-latest / windows-latest (run_tests: false) は toolchain
+        #     wiring が通る検証だけで dev profile で目的達成 = release build
+        #     不要ゆえ dev に切り替えて 30 min 級の short-circuit を狙う。
+        #     実 release 面の性能検証は release.yml が担当。
+        #
+        # --target 選択 (2026-07-23 の CI 高速化 — 案 A):
+        #   - ubuntu-latest (musl) / windows-latest (MSVC) は cross-target 検証
+        #     のため必須。
+        #   - macos-latest 上の aarch64-apple-darwin は既に native triple ゆえ
+        #     `--target` を付けると `target/aarch64-apple-darwin/` 経由になって
+        #     Swatinem cache が per-target dir で別枠になり hit 率が下がる。
+        #     native path (`target/`) を使うため macos leg のみ --target を落とす。
         shell: bash
         run: |
-          cargo build --release \
-            --target ${{ matrix.triple }} \
+          set -euo pipefail
+          if [ "${{ matrix.run_tests }}" = "true" ]; then
+            PROFILE_ARG="--release"
+          else
+            PROFILE_ARG=""
+          fi
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            TARGET_ARG=""
+          else
+            TARGET_ARG="--target ${{ matrix.triple }}"
+          fi
+          cargo build $PROFILE_ARG $TARGET_ARG \
             -p vokra-server \
             --manifest-path integrations/vokra-server/Cargo.toml
       - name: cargo-deny (server crate, NFR-LC-04)


### PR DESCRIPTION
## 背景

PR #14 (dependabot bump) の CI 計測で **`server-compat (macos-latest, aarch64-apple-darwin, false)` が 33.7 min** = 次点の 11 倍で断トツの critical path と判明。CI 全体 wall time の実質的支配者。

## 修正内容

### Phase 1: `server-compat` macos (3 点セット、案 A+B+C)

`.github/workflows/ci-quality.yml`:

| 案 | 内容 | 見込み短縮 |
|---|---|---|
| A | `--target aarch64-apple-darwin` を **macos leg のみ削除** (native ARM64 と同じ triple、per-target dir 経由で cache miss していた) | -5〜10 min |
| B | `Swatinem/rust-cache@v2` に `shared-key: server-compat-${{ matrix.triple }}` 明示 (triple 別 tarball 分離) | -3〜8 min |
| C | `--release` → **dev profile (run_tests: false leg のみ)** (build 通り検証だけで release 不要、実 release 検証は release.yml が担当) | -8〜15 min |

**FR-SV-01「3 triple の build 通り検証」semantics は完全保持**。ubuntu (run_tests: true) は compat tests を実 release で回すため `--release` 維持。

### Phase 2: `gpu-backends` feature 別 cache 分離

`.github/workflows/ci-platform.yml`:

- `Swatinem/rust-cache@v2` に `shared-key: gpu-backends-${{ matrix.os }}-${{ matrix.feature }}` 明示
- 同一 OS の feature 違い (macos × metal vs coreml、ubuntu × cuda vs qnn) が target/ dir で相互 pollution していた問題を解消
- `godot-crossbuild.yml` の同型パターンを踏襲

## 期待効果

- **CI Quality workflow = 33.7 min → 5-10 min** (server-compat critical path 解消)
- gpu-backends 4 arm = warm cache 時に各 30-60 秒短縮 (副次的)
- CI 全体 wall time 30-40% 削減見込み

## Test plan

- [x] pre-commit + pre-push 全 green
- [ ] この PR の CI で `server-compat (macos-latest)` が 30 min 未満に短縮されること (初回 cold cache でも改善、warm 化した 2 回目 push で 5-10 min の想定)
- [ ] `gpu-backends` 4 arm 全 green
- [ ] 全 required check green + advisory 影響なし