### PR TITLE
chore(ci): PR #16 handoff 4 items CC 消化 (UTMOS pin + Whisper/Moshi snapshot + catalog 判断 + X-10 handoff)

### DIFF
--- a/.github/pins.yaml
+++ b/.github/pins.yaml
@@ -21,6 +21,24 @@
 #     locates the pin by string-match, not by line number, so a routine
 #     edit that shifts lines does NOT require pins.yaml churn — only a
 #     `pinned_value` change does.
+#
+# Deliberate non-entries (2026-07-23 decision, X-10-T05 companion):
+#   * glslang toolchain — the version (16.4.0) is pinned in
+#     `crates/vokra-backend-vulkan/kernels/precompiled/PROVENANCE` and
+#     cross-referenced in `.github/workflows/gpu-vulkan-parity.yml` comments;
+#     apt's `glslang-tools` is what CI actually installs, and its version is
+#     Ubuntu-image-derived, not a URL-addressable artefact. A catalog row
+#     would `drift_policy=skip` (same as `emsdk-toolchain`) and add
+#     dual-edit surface for zero drift coverage — Dependabot does not
+#     manage apt packages, so no automated bump could ever race with it.
+#   * Third-party GitHub Actions — bumped by `.github/dependabot.yml`'s
+#     `production-actions` group weekly (`chore(deps)` PRs). Registering
+#     them here would create a dual-edit obligation on every Dependabot PR
+#     (workflow + catalog) with no additional drift-detection benefit —
+#     Dependabot IS the drift detector for actions. MSRV-critical action
+#     pins (`dtolnay/rust-toolchain@1.89` / `pypa/cibuildwheel@v2.23.4`)
+#     are kept manual via `.github/dependabot.yml` `ignore:` and live in
+#     that file, not here.
 
 schema_version: 1
 
@@ -59,15 +77,15 @@ entries:
       license: MIT
     pinned_value:
       hf_id: openai/whisper-base
-      hf_revision: null              # WARN: currently on `main` (floating)
+      hf_revision: "e37978b90ca9030d5170a5c07aadb050351a65bb"
     drift_policy:
       upstream_mismatch: advisory
       mirror_mismatch: hard_fail
-      no_revision: warn              # drift detector emits ::warning:: until repinned
     notes: |
-      Also referenced by parity-whisper-real.yml:141 and web-wasm.yml:147
-      under the SAME repo_id. Pin an explicit HF commit SHA in WP X-10-T05
-      companion (all 3 workflows in one PR to stay atomic).
+      Same repo_id is also pinned by parity-whisper-real.yml (matrix `base`
+      leg) and web-wasm.yml. All three workflows carry the same 40-hex
+      revision from this landing so `check_pins_sync` covers them under
+      one entry. Snapshot pinned 2026-07-23 (X-10-T05 companion).
 
   - name: kokoro-82m
     kind: checkpoint
@@ -95,13 +113,13 @@ entries:
       license: MIT
     pinned_value:
       hf_id: openai/whisper-small
-      hf_revision: null
+      hf_revision: "973afd24965f72e36ca33b3055d56a652f456b4d"
     drift_policy:
       upstream_mismatch: advisory
       mirror_mismatch: hard_fail
-      no_revision: warn
     notes: |
       M4-14 carry-over. Opt-in via workflow_dispatch include_small.
+      Snapshot pinned 2026-07-23 (X-10-T05 companion).
 
   - name: whisper-medium
     kind: checkpoint
@@ -112,13 +130,12 @@ entries:
       license: MIT
     pinned_value:
       hf_id: openai/whisper-medium
-      hf_revision: null
+      hf_revision: "abdf7c39ab9d0397620ccaea8974cc764cd0953e"
     drift_policy:
       upstream_mismatch: advisory
       mirror_mismatch: hard_fail
-      no_revision: warn
     notes: |
-      M4-14 carry-over.
+      M4-14 carry-over. Snapshot pinned 2026-07-23 (X-10-T05 companion).
 
   - name: whisper-large-v3
     kind: checkpoint
@@ -129,13 +146,13 @@ entries:
       license: MIT
     pinned_value:
       hf_id: openai/whisper-large-v3
-      hf_revision: null
+      hf_revision: "06f233fe06e710322aca913c1bc4249a0d71fce1"
     drift_policy:
       upstream_mismatch: advisory
       mirror_mismatch: hard_fail
-      no_revision: warn
     notes: |
-      ~2.9 GB. M4-14 carry-over.
+      ~2.9 GB. M4-14 carry-over. Snapshot pinned 2026-07-23 (X-10-T05
+      companion).
 
   - name: whisper-large-v3-turbo
     kind: checkpoint
@@ -146,13 +163,13 @@ entries:
       license: MIT
     pinned_value:
       hf_id: openai/whisper-large-v3-turbo
-      hf_revision: null
+      hf_revision: "41f01f3fe87f28c78e2fbf8b568835947dd65ed9"
     drift_policy:
       upstream_mismatch: advisory
       mirror_mismatch: hard_fail
-      no_revision: warn
     notes: |
-      ~1.6 GB. Shares large-v3 51866 tokenizer.
+      ~1.6 GB. Shares large-v3 51866 tokenizer. Snapshot pinned 2026-07-23
+      (X-10-T05 companion).
 
   - name: moshiko-pytorch-bf16
     kind: checkpoint
@@ -164,13 +181,14 @@ entries:
       attribution_required: true
     pinned_value:
       hf_id: kyutai/moshiko-pytorch-bf16
-      hf_revision: main             # WARN: explicit `main` per file comment until T29
+      hf_revision: "2bfc9ae6e89079a5cc7ed2a68436010d91a3d289"
     drift_policy:
       upstream_mismatch: advisory
       mirror_mismatch: hard_fail
-      no_revision: warn
     notes: |
-      T29 sourcing pending; pin to snapshot SHA when landed. 15 GB.
+      Snapshot pinned 2026-07-23 (X-10-T05 companion) — the same commit
+      the mimi-codec entry below is already pinned to, which was already
+      the effective revision of the tokenizer file that entry hashes. 15 GB.
       Includes tokenizer_spm_32k_3.model + tokenizer-e351c8d8-checkpoint125.safetensors.
 
   - name: moshi-python
@@ -233,14 +251,14 @@ entries:
       license: MIT
     pinned_value:
       hf_id: openai/whisper-base
-      hf_revision: null
+      hf_revision: "e37978b90ca9030d5170a5c07aadb050351a65bb"
     drift_policy:
       upstream_mismatch: advisory
       mirror_mismatch: hard_fail
-      no_revision: warn
     notes: |
       Opt-in via workflow_dispatch run_whisper_e2e. Duplicate of the
-      whisper-base entry — sync in one PR when repinning.
+      whisper-base entry — the two hf_revision values MUST stay in lockstep.
+      Snapshot pinned 2026-07-23 (X-10-T05 companion).
 
   - name: emsdk-toolchain
     kind: toolchain
@@ -263,32 +281,36 @@ entries:
   - name: utmos22-strong
     kind: checkpoint
     owning_workflow: .github/workflows/parity-utmos.yml
-    owning_line: 0                  # source.env commit で埋まる (unlanded pin)
+    owning_line: 0                  # source.env-indirection: forward literal search skipped
     upstream:
       url: https://huggingface.co/spaces/sarulab-speech/UTMOS-demo
       license: MIT
     pinned_value:
-      sha256: null                  # source.env commit で埋まる
+      sha256: "44c57e3e4135a243b43d2c82b6a693fcd56f15f9ad0e1eb2a8b31fdecd3a49b8"
     drift_policy:
-      upstream_mismatch: skip       # unlanded pin — probe short-circuits in run_probes
+      upstream_mismatch: skip       # HF space resolve URL is content-addressed by construction; pins_probe cannot verify from the space URL alone (no resolve path) — kept skip until pins_probe supports HF space resolve pattern
       mirror_mismatch: hard_fail    # once mirror block populated (X-10 pattern extension)
     notes: |
-      UTMOS22-strong (SaruLab, MIT). Placeholder catalog entry for the
-      parity-utmos.yml `setup` job, which currently clean-skips because
-      tests/parity/utmos/source.env is not committed (waits on
-      docs/license-audit.md §3.1 UTMOS sign-off).
+      UTMOS22-strong (SaruLab, MIT). Landed 2026-07-23 with the
+      docs/license-audit.md §3.1 UTMOS sign-off (yousan ☑ Commercial); the
+      parity-utmos.yml setup gate flips ready=true from this commit onward.
 
-      Pin lands when owner commits source.env with CKPT_URL + CKPT_SHA256;
-      at that point owning_line moves to the actual line and pinned_value.sha256
-      absorbs the SHA. Until then drift_policy.upstream_mismatch=skip means
-      pins_probe.py records `skip` without hitting the network, and
-      check_pins_sync.py treats owning_line=0 as an "unlanded pin" sentinel
-      (forward literal search is skipped; the reverse leg still catches any
-      orphan SHA that lands in a workflow without a catalog entry).
+      Pin source-of-truth: tests/parity/utmos/source.env (not the workflow
+      yml — the workflow uses `source tests/parity/utmos/source.env` and
+      reads $CKPT_URL / $CKPT_SHA256 into its fetch + sha256 verification
+      step). That indirection is why owning_line stays 0: forward literal
+      search in the workflow yml would find nothing; check_pins_sync.py's
+      owning_line=0 sentinel keeps the forward leg skipped for source.env-
+      referenced pins. The SHA recorded here (44c57e3e...) MUST match
+      tests/parity/utmos/source.env CKPT_SHA256; editing either side
+      requires editing the other.
 
-      Reference SHA (informational only, NOT pinned by this entry): the
-      2026-07-17 campaign-2 utmos-probe measured
-      `44c57e3e4135a243b43d2c82b6a693fcd56f15f9ad0e1eb2a8b31fdecd3a49b8`
-      for `epoch=3-step=7459.ckpt`. See docs/license-audit.md §3 UTMOS row.
+      Measurement: 2026-07-17 campaign-2 utmos-probe fetched
+      epoch=3-step=7459.ckpt from HF space sarulab-speech/UTMOS-demo at
+      revision 47212055c2ec... and measured sha256 44c57e3e... The source.env
+      URL uses HF's `resolve/<40-hex>/` immutable resolve path pinned to
+      that revision, so the tarball is byte-stable even if the space's
+      `main` branch moves.
 
-      Tracked WPs: M4-18 T2 (defer-lift) + M5-15 T14 (converter, CC done).
+      Tracked WPs: M4-18 T2 (defer-lift) + M5-15 T14 (converter, CC done) +
+      M5-15 UTMOS COMPLETION.

--- a/.github/scripts/check_pins_sync.py
+++ b/.github/scripts/check_pins_sync.py
@@ -126,13 +126,20 @@ def check_forward(pins_path: Path) -> list[str]:
     for entry in entries:
         wf = REPO / entry["owning_workflow"]
         line = entry.get("owning_line") or 1
-        # `owning_line: 0` is the sentinel for "pin registered ahead of the
-        # workflow's source.env commit" (unlanded pin, e.g. UTMOS awaiting
-        # owner sign-off + weight URL). drift_policy.upstream_mismatch=skip
-        # short-circuits pins_probe.py for the same rows. The sync forward
-        # leg SKIPS forward-string search for these entries because the
-        # literal has not been committed to the workflow yet. It stays in
-        # the catalog so the reverse leg still refuses orphan pins.
+        # `owning_line: 0` is the "no forward literal search" sentinel. It
+        # covers two shapes:
+        #   (1) UNLANDED pin — pin registered in the catalog ahead of the
+        #       committing workflow value (e.g. LibriSpeech mirror before
+        #       vars.VOKRA_CORPUS_..._MIRROR_URL is set), and
+        #   (2) SOURCE.ENV-INDIRECTED pin — the workflow imports the pin
+        #       via `source <path>/source.env` (UTMOS pattern), so the
+        #       literal lives in the sourced file rather than the workflow
+        #       yml. A forward literal grep of the workflow would find
+        #       nothing even though the pin IS landed.
+        # drift_policy.upstream_mismatch=skip short-circuits pins_probe.py
+        # for shape (1); shape (2) still probes because the SHA is real.
+        # The reverse leg still refuses orphan pins under any workflow env
+        # naming pattern (`_SHA256`, `_REVISION`, `_GIT_SHA`).
         if entry.get("owning_line") == 0:
             continue
         if not wf.exists():

--- a/.github/workflows/nightly-asr-wer.yml
+++ b/.github/workflows/nightly-asr-wer.yml
@@ -141,6 +141,11 @@ env:
   # test asserts the two stay equal, so this cannot silently drift.
   WER_THRESHOLD: "0.06"
   HF_ID: openai/whisper-base
+  # Snapshot SHA (openai/whisper-base@main as of 2026-07-23). Pinned to
+  # eliminate the drift-detector `no_revision: warn` on this entry.
+  # pins.yaml `whisper-base` MUST carry the same value. web-wasm.yml uses
+  # the same repo_id and the same SHA (pins.yaml `whisper-base-wasm`).
+  HF_REVISION: "e37978b90ca9030d5170a5c07aadb050351a65bb"
   GGUF: whisper-base.gguf
   SPEAKER: "1272"
   CHAPTER: "128104"
@@ -243,6 +248,7 @@ jobs:
           from huggingface_hub import snapshot_download
           local = snapshot_download(
               repo_id=os.environ["HF_ID"],
+              revision=os.environ["HF_REVISION"],
               allow_patterns=["model.safetensors", "config.json", "normalizer.json"],
           )
           with open("/tmp/hf-paths.env", "w") as f:

--- a/.github/workflows/parity-moshi-real.yml
+++ b/.github/workflows/parity-moshi-real.yml
@@ -96,9 +96,11 @@ on:
       - "tools/parity/moshi_truncate.py"
 
 env:
-  # `main` until the T29 owner sourcing pins a snapshot revision.
+  # Snapshot SHA (kyutai/moshiko-pytorch-bf16@main as of 2026-07-23) —
+  # same commit the mimi-codec pin below already resolves to. pins.yaml
+  # `moshiko-pytorch-bf16` MUST carry the same value.
   MOSHIKO_REPO: kyutai/moshiko-pytorch-bf16
-  MOSHIKO_REVISION: main
+  MOSHIKO_REVISION: "2bfc9ae6e89079a5cc7ed2a68436010d91a3d289"
   # kyutai-labs/moshi main at the ADR M4-06 §D2 transcription date
   # (2026-07-15 fetch — loaders.py/_lm_kwargs etc.).
   MOSHI_GIT_SHA: e6a55d2722a65870ef52a6c9f6ecfc0e90f38362

--- a/.github/workflows/parity-whisper-real.yml
+++ b/.github/workflows/parity-whisper-real.yml
@@ -138,24 +138,27 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          include='{"size":"base","hf_id":"openai/whisper-base","env_var":"VOKRA_WHISPER_BASE_GGUF","fixture_dir":"tests/parity/whisper_base","gguf":"whisper-base.gguf"}'
+          include='{"size":"base","hf_id":"openai/whisper-base","hf_revision":"e37978b90ca9030d5170a5c07aadb050351a65bb","env_var":"VOKRA_WHISPER_BASE_GGUF","fixture_dir":"tests/parity/whisper_base","gguf":"whisper-base.gguf"}'
           # Non-base sizes are workflow_dispatch-only (runner-minutes
           # red-line: cron / PR triggers must never pull multi-GB HF
           # checkpoints). Field contracts: env_var mirrors the Rust
           # harness's size_env_var(), fixture_dir its fixtures_dir_for(),
-          # hf_id the dumper's SUPPORTED_MODELS (M4-14-T05).
+          # hf_id the dumper's SUPPORTED_MODELS (M4-14-T05). hf_revision is
+          # a snapshot SHA that MUST match pins.yaml `whisper-{size}` and is
+          # threaded into snapshot_download so the CI cache key ties to
+          # the exact commit, not `main` (X-10-T05 companion).
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             if [ "${{ github.event.inputs.include_small }}" != "false" ]; then
-              include="${include},"'{"size":"small","hf_id":"openai/whisper-small","env_var":"VOKRA_WHISPER_SMALL_GGUF","fixture_dir":"tests/parity/whisper_small","gguf":"whisper-small.gguf"}'
+              include="${include},"'{"size":"small","hf_id":"openai/whisper-small","hf_revision":"973afd24965f72e36ca33b3055d56a652f456b4d","env_var":"VOKRA_WHISPER_SMALL_GGUF","fixture_dir":"tests/parity/whisper_small","gguf":"whisper-small.gguf"}'
             fi
             if [ "${{ github.event.inputs.include_medium }}" != "false" ]; then
-              include="${include},"'{"size":"medium","hf_id":"openai/whisper-medium","env_var":"VOKRA_WHISPER_MEDIUM_GGUF","fixture_dir":"tests/parity/whisper_medium","gguf":"whisper-medium.gguf"}'
+              include="${include},"'{"size":"medium","hf_id":"openai/whisper-medium","hf_revision":"abdf7c39ab9d0397620ccaea8974cc764cd0953e","env_var":"VOKRA_WHISPER_MEDIUM_GGUF","fixture_dir":"tests/parity/whisper_medium","gguf":"whisper-medium.gguf"}'
             fi
             if [ "${{ github.event.inputs.include_large_v3 }}" != "false" ]; then
-              include="${include},"'{"size":"large-v3","hf_id":"openai/whisper-large-v3","env_var":"VOKRA_WHISPER_LARGE_V3_GGUF","fixture_dir":"tests/parity/whisper_large_v3","gguf":"whisper-large-v3.gguf"}'
+              include="${include},"'{"size":"large-v3","hf_id":"openai/whisper-large-v3","hf_revision":"06f233fe06e710322aca913c1bc4249a0d71fce1","env_var":"VOKRA_WHISPER_LARGE_V3_GGUF","fixture_dir":"tests/parity/whisper_large_v3","gguf":"whisper-large-v3.gguf"}'
             fi
             if [ "${{ github.event.inputs.include_turbo }}" != "false" ]; then
-              include="${include},"'{"size":"turbo","hf_id":"openai/whisper-large-v3-turbo","env_var":"VOKRA_WHISPER_TURBO_GGUF","fixture_dir":"tests/parity/whisper_turbo","gguf":"whisper-turbo.gguf"}'
+              include="${include},"'{"size":"turbo","hf_id":"openai/whisper-large-v3-turbo","hf_revision":"41f01f3fe87f28c78e2fbf8b568835947dd65ed9","env_var":"VOKRA_WHISPER_TURBO_GGUF","fixture_dir":"tests/parity/whisper_turbo","gguf":"whisper-turbo.gguf"}'
             fi
           fi
           echo "matrix={\"include\":[${include}]}" >> "$GITHUB_OUTPUT"
@@ -231,6 +234,10 @@ jobs:
     env:
       SIZE: ${{ matrix.size }}
       HF_ID: ${{ matrix.hf_id }}
+      # Snapshot SHA per size (X-10-T05 companion). MUST match pins.yaml
+      # `whisper-{size}` hf_revision. Read by snapshot_download so the
+      # HF cache key is content-addressed, not floating on `main`.
+      HF_REVISION: ${{ matrix.hf_revision }}
       ENV_VAR: ${{ matrix.env_var }}
       FIXTURE_DIR: ${{ matrix.fixture_dir }}
       GGUF: ${{ matrix.gguf }}
@@ -325,6 +332,7 @@ jobs:
           # the WhisperProcessor / model.generate paths use.
           local_dir = snapshot_download(
               repo_id=repo_id,
+              revision=os.environ["HF_REVISION"],
               allow_patterns=[
                   "model.safetensors",
                   "config.json",

--- a/.github/workflows/web-wasm.yml
+++ b/.github/workflows/web-wasm.yml
@@ -124,6 +124,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     if: github.event_name == 'workflow_dispatch' && inputs.run_whisper_e2e
+    env:
+      # Snapshot SHA (openai/whisper-base@main as of 2026-07-23). MUST
+      # match pins.yaml `whisper-base-wasm` hf_revision and stay in
+      # lockstep with nightly-asr-wer.yml env.HF_REVISION.
+      WHISPER_BASE_REVISION: "e37978b90ca9030d5170a5c07aadb050351a65bb"
     steps:
       - uses: actions/checkout@v7
 
@@ -142,9 +147,11 @@ jobs:
           . /tmp/vokra-py-web/bin/activate
           pip install --quiet "huggingface_hub>=0.23"
           python3 - <<'PYEOF'
+          import os
           from huggingface_hub import snapshot_download
           local_dir = snapshot_download(
               repo_id="openai/whisper-base",
+              revision=os.environ["WHISPER_BASE_REVISION"],
               allow_patterns=[
                   "model.safetensors", "config.json", "generation_config.json",
                   "preprocessor_config.json", "tokenizer.json", "tokenizer_config.json",

--- a/docs/handoff/x-10.md
+++ b/docs/handoff/x-10.md
@@ -1,0 +1,333 @@
+# X-10 LibriSpeech dev-clean self-mirror — owner handoff
+
+**Position vs the fix that landed 2026-07-23**: `fix/nightly-asr-wer-2026-07-23`
+made every LibriSpeech drift on OpenSLR advisory (`::warning::` + `corpus_ok=false`
++ downstream clean-skip). That silenced the noisy red **without** hiding the
+Score WER gate — WER breach still exits 1. X-10 is the follow-up that reduces
+how often the advisory even fires, by putting the tarball on a mirror Vokra
+controls. Nothing here softens Score WER or the advisory contract.
+
+**CC status (2026-07-23)**: everything code-side is landed —
+
+- `.github/workflows/nightly-asr-wer.yml` reads `DEV_CLEAN_URL` /
+  `DEV_CLEAN_SHA256` from `vars.VOKRA_CORPUS_LIBRISPEECH_MIRROR_URL` /
+  `..._SHA256` with an OpenSLR fallback that keeps working with the vars unset.
+- `.github/pins.yaml`'s `librispeech-dev-clean` row has a `mirror:` block
+  scaffolded (`null` fields) so `corpus-drift-detector.yml` will start probing
+  the mirror the moment the row is filled — no workflow edit needed.
+- `.github/pins-allowlist.txt` is empty; the two vars are the only knob that
+  changes anything.
+- `docs/license-audit.md` §3.2 has the LibriSpeech row landed with an **empty**
+  sign-off column (fail-closed). §3.2's landing note is explicit that the empty
+  row blocks the mirror upload until the row is signed.
+
+**What is owner-only (T02 + T03 + §3.2 sign-off)**: an HF `HF_TOKEN` with write
+scope on `huggingface.co/vokra`; the `gh api …/actions/variables` call that
+requires repo-admin auth; and a §3.1-style redistribution judgement that CC
+does not pre-fill (see `feedback-license-signoff-primary-source` — `☑ Commercial`
+on this row is the owner's decision, not CC's default).
+
+## 1. §3.2 sign-off (do this first — it gates the upload)
+
+Open `docs/license-audit.md` §3.2 (LibriSpeech dev-clean row landed
+2026-07-23). Fill:
+
+- **Owner sign-off (YYYY-MM-DD)** → today's date.
+- **Approval** → `☑ Commercial (redistribute OK, attribution 要)`.
+  - Primary source: OpenSLR resource 12 page (<https://www.openslr.org/12/>)
+    plus Panayotov et al. 2015 (ICASSP). CC-BY 4.0 permits commercial use,
+    modification, and redistribution; the only obligation is attribution
+    (which the mirror README + NOTICE below already discharge). `☐ Rejected`
+    would be the correct call only if you specifically want to keep the
+    project off any LibriSpeech-derived corpus, which contradicts the ASR
+    WER gate the nightly workflow already runs on it — flag CC to remove
+    the corpus consumer if that is the intent.
+
+Everything downstream (T02 upload / T03 vars / drift detector escalation /
+initial dispatch) refuses to fire until this row is signed.
+
+## 2. Prepare the mirror payload (local, no push yet)
+
+Any staging directory is fine — the layout is what matters. Suggested
+location `staging/librispeech-dev-clean-mirror/`:
+
+```
+staging/librispeech-dev-clean-mirror/
+├── dev-clean.tar.gz          # the byte-identical tarball (see §2.1)
+├── LICENSE                    # canonical CC-BY 4.0 text (see §2.2)
+├── NOTICE                     # Vokra attribution + upstream credit (§2.3)
+├── SOURCE.md                  # upstream URL + re-fetch recipe (§2.4)
+└── README.md                  # HF dataset card front-matter (§2.5)
+```
+
+### 2.1 Fetch the tarball, verify byte-identity
+
+```bash
+mkdir -p staging/librispeech-dev-clean-mirror
+cd staging/librispeech-dev-clean-mirror
+curl -fLO https://www.openslr.org/resources/12/dev-clean.tar.gz
+python3 - <<'PY'
+import hashlib, sys
+h = hashlib.sha256(open("dev-clean.tar.gz", "rb").read()).hexdigest()
+EXPECTED = "76f87d090650617fca0cac8f88b9416e0ebf80350acb97b343a85fa903728ab3"
+print(f"actual: {h}")
+print(f"pinned: {EXPECTED}")
+sys.exit(0 if h == EXPECTED else 1)
+PY
+```
+
+If SHA differs, **stop**: X-10 requires the mirror to be byte-identical to the
+pinned baseline. A different SHA means either OpenSLR re-tarred the corpus
+(in which case `tools/eval/librispeech_wer.py` `CALIBRATIONS` needs
+re-measuring — a separate WP, not this one) or the download was interrupted
+(re-try `curl`). Do not repack.
+
+### 2.2 LICENSE (canonical CC-BY 4.0 legalcode)
+
+`scripts/publish/fetch_license.sh` already knows the canonical URL:
+
+```bash
+scripts/publish/fetch_license.sh --spdx cc-by-4.0 LICENSE
+```
+
+That writes `creativecommons.org/licenses/by/4.0/legalcode.txt` verbatim. Do
+not shorten it — CC-BY 4.0 requires the full text travel with the
+redistribution.
+
+### 2.3 NOTICE (attribution the mirror is redistributing under)
+
+```text
+LibriSpeech dev-clean, CC-BY 4.0, redistributed by the Vokra project as a
+byte-identical mirror of the upstream OpenSLR tarball.
+
+Cite:
+  Panayotov, V., Chen, G., Povey, D., & Khudanpur, S. (2015). LibriSpeech: An
+  ASR corpus based on public domain audio books. In 2015 IEEE International
+  Conference on Acoustics, Speech and Signal Processing (ICASSP)
+  (pp. 5206-5210). IEEE.
+
+Upstream URL:
+  https://www.openslr.org/resources/12/dev-clean.tar.gz
+
+Byte-identity is enforced by SHA256 (see SOURCE.md); a repacked tarball
+would defeat the point of the mirror and is refused by every CI probe that
+consumes this dataset.
+
+Vokra project attribution: https://github.com/ayutaz/vokra
+```
+
+### 2.4 SOURCE.md (re-fetch recipe + provenance)
+
+```markdown
+# LibriSpeech dev-clean — Vokra mirror provenance
+
+**Byte-identical mirror**. This tarball is bit-for-bit identical to the
+OpenSLR canonical file; the CI probes assert that.
+
+## Upstream
+
+- URL: https://www.openslr.org/resources/12/dev-clean.tar.gz
+- Corpus: LibriSpeech ASR corpus (Panayotov et al., 2015)
+- License: CC-BY 4.0 (see LICENSE, attribution in NOTICE)
+
+## Byte-identity
+
+- Size: 337,926,286 bytes
+- SHA256: `76f87d090650617fca0cac8f88b9416e0ebf80350acb97b343a85fa903728ab3`
+
+## Re-fetch recipe
+
+```bash
+curl -fLO https://www.openslr.org/resources/12/dev-clean.tar.gz
+sha256sum dev-clean.tar.gz  # must match the SHA above
+```
+
+## Vokra-side consumers
+
+- `.github/workflows/nightly-asr-wer.yml` (Whisper base advisory RTF + WER
+  gate; 8-utterance slice chapter 128104 speaker 1272)
+- `tools/eval/librispeech_wer.py` (CALIBRATIONS baseline is measured against
+  the same SHA)
+
+If this mirror ever drifts from OpenSLR, the WER calibration must be re-
+measured before repinning — see `docs/tickets/m5/X-10-librispeech-corpus-
+self-mirror.md`.
+```
+
+### 2.5 README.md (HF dataset card front-matter)
+
+```markdown
+---
+license: cc-by-4.0
+task_categories:
+  - automatic-speech-recognition
+language:
+  - en
+size_categories:
+  - 100K<n<1M
+source_datasets:
+  - openslr/librispeech_asr
+tags:
+  - librispeech
+  - asr
+  - vokra-corpus-mirror
+---
+
+# LibriSpeech dev-clean (Vokra mirror)
+
+Byte-identical CC-BY 4.0 redistribution of the OpenSLR canonical tarball
+`https://www.openslr.org/resources/12/dev-clean.tar.gz` (337,926,286 bytes,
+SHA256 `76f87d090650617fca0cac8f88b9416e0ebf80350acb97b343a85fa903728ab3`).
+
+## Why this mirror
+
+The Vokra project's nightly ASR-WER workflow consumes this corpus. Upstream
+CDN availability is not a Vokra concern, so a byte-identical mirror keeps
+the nightly stable while preserving every CC-BY 4.0 attribution obligation
+(see NOTICE and LICENSE).
+
+## Citation
+
+Panayotov, V., Chen, G., Povey, D., & Khudanpur, S. (2015). LibriSpeech: An
+ASR corpus based on public domain audio books. In 2015 IEEE International
+Conference on Acoustics, Speech and Signal Processing (ICASSP)
+(pp. 5206-5210). IEEE.
+
+## Not for repacking
+
+Vokra CI probes enforce byte-identity by SHA256. Repacking (recompressing,
+adding files, renaming) defeats the mirror's contract and is refused by
+downstream verification.
+```
+
+## 3. Push to `huggingface.co/datasets/vokra/librispeech-dev-clean-mirror`
+
+The existing `scripts/publish/upload.sh` targets model repos (GGUF + card).
+Corpus datasets use `repo_type="dataset"` and a different card contract, so
+call `huggingface_hub` directly rather than reusing `upload.sh`:
+
+```bash
+export HF_TOKEN=…            # your token with write on huggingface.co/vokra
+python3 - <<'PY'
+from huggingface_hub import HfApi
+api = HfApi()
+api.create_repo(
+    repo_id="vokra/librispeech-dev-clean-mirror",
+    repo_type="dataset",
+    exist_ok=True,
+    private=False,
+)
+api.upload_folder(
+    folder_path="staging/librispeech-dev-clean-mirror",
+    repo_id="vokra/librispeech-dev-clean-mirror",
+    repo_type="dataset",
+    commit_message="X-10-T02: byte-identical mirror of OpenSLR dev-clean.tar.gz + CC-BY 4.0 attribution",
+)
+PY
+```
+
+That is the same shape the model publications use — `create_repo(exist_ok=True)`
++ `upload_folder` — with `repo_type="dataset"` instead of the default model
+repo. The `HF_TOKEN` is never on the command line (do not export it via a
+history-visible command in a shared shell).
+
+Immediately after the push completes, verify the mirror serves the byte-
+identical file:
+
+```bash
+MIRROR_URL="https://huggingface.co/datasets/vokra/librispeech-dev-clean-mirror/resolve/main/dev-clean.tar.gz"
+curl -fL -o /tmp/dev-clean.mirror.tar.gz "$MIRROR_URL"
+sha256sum /tmp/dev-clean.mirror.tar.gz  # must equal the OpenSLR SHA
+```
+
+If HF's resolve URL differs (some datasets go through LFS with a different
+path — HF Hub is consistent about the `resolve/<rev>/<file>` shape, but the
+final `<rev>` may need to be a snapshot SHA rather than `main` for
+immutability), record the exact URL that returns the byte-identical file for
+T03.
+
+## 4. Register the two repo variables (T03)
+
+Once the mirror serves the byte-identical file:
+
+```bash
+gh api -X POST repos/ayutaz/vokra/actions/variables \
+  -f name=VOKRA_CORPUS_LIBRISPEECH_MIRROR_URL \
+  -f value="$MIRROR_URL"
+
+gh api -X POST repos/ayutaz/vokra/actions/variables \
+  -f name=VOKRA_CORPUS_LIBRISPEECH_MIRROR_SHA256 \
+  -f value=76f87d090650617fca0cac8f88b9416e0ebf80350acb97b343a85fa903728ab3
+```
+
+The `nightly-asr-wer.yml` env-block reads these via `${{ vars.… || fallback
+}}` today; existing workflow runs pick them up on the next run without a
+workflow edit. If you prefer variable over the earlier ADR's "secret vs
+variable" question — the URL and SHA are both public, so `variable` is the
+right choice (the SHA is already committed to `.github/pins.yaml` and to
+`tools/eval/librispeech_wer.py`).
+
+## 5. Populate the `mirror:` block in `.github/pins.yaml`
+
+Edit `.github/pins.yaml`'s `librispeech-dev-clean` row, replacing the `null`
+scaffold with the live values:
+
+```yaml
+    mirror:
+      url: "https://huggingface.co/datasets/vokra/librispeech-dev-clean-mirror/resolve/main/dev-clean.tar.gz"
+      hf_revision: null       # or the resolve-time snapshot SHA if you pin
+      sha256: "76f87d090650617fca0cac8f88b9416e0ebf80350acb97b343a85fa903728ab3"
+      same_as_upstream: true
+```
+
+Once populated, `check_pins_sync.py` requires the workflow to either contain
+the mirror SHA verbatim OR to reference `vars.VOKRA_CORPUS_…_MIRROR_…` (the
+existing seam already does the latter, so no workflow edit is needed).
+`corpus-drift-detector.yml` immediately escalates `mirror_mismatch` to
+`hard_fail` — Vokra owns the mirror, so a mismatch there is a real defect.
+
+## 6. Initial workflow_dispatch (owner-executed)
+
+Run each once and confirm green (or an honest skip with an annotation):
+
+- `corpus-drift-detector.yml` — 13 catalog entries probed; the LibriSpeech row
+  should now probe the mirror (was `advisory` on upstream, now `hard_fail` on
+  mirror + `advisory` on upstream). Expected: green.
+- `pins-sync-check.yml` — forward + reverse legs. Expected: green (this doc
+  is the reference for the sync-check's expected state; the mirror-SHA is
+  covered by the workflow's `vars.…` reference per §5).
+- `parity-rvq-real.yml` — Mimi + DAC leg. Not X-10-specific, but the fix PR
+  included the §8.2 canonical advisory downgrade on these steps, so the
+  initial dispatch is part of the same handoff bundle.
+
+Do NOT promote `pins-sync-check.yml` to a required branch-protection context
+yet. The fix PR's plan is a **4-week soak** at `continue-on-error: true`
+before that decision — that soak buys real evidence that Dependabot bumps
+and routine workflow edits do not race the reverse leg.
+
+## 7. Failure / restore paths
+
+- **Mirror repo compromised or accidentally deleted**: unset both repo
+  variables (`gh variable delete VOKRA_CORPUS_LIBRISPEECH_MIRROR_URL` /
+  `..._SHA256`). The `nightly-asr-wer.yml` env-block silently falls back to
+  OpenSLR, and the advisory posture keeps the job green. Re-upload the
+  tarball to the same repo (byte-identical to preserve the pinned SHA);
+  re-register the variables. **Do not repack** — that would force a WER
+  baseline re-measurement.
+- **HF Hub bandwidth quota fires**: unlikely on a 322 MB dataset in the free
+  tier, but if it does, the same fallback keeps CI green. GitHub Release
+  fallback (§option (ii) in the X-10 ADR) is the escape hatch — same
+  procedure, different host, same SHA.
+- **Attribution obligation drift**: if you change the NOTICE or LICENSE
+  wording on the mirror repo, re-verify the CC-BY 4.0 attribution still
+  discharges (author + license + link). CC will not police the mirror
+  contents post-hand-off; a periodic manual re-check is the only defense.
+
+## Cross-references
+
+- `docs/tickets/m5/X-10-librispeech-corpus-self-mirror.md` — the full spec
+  (gitignore-local). This handoff is the owner-facing extract.
+- `docs/license-audit.md` §3.2 — the sign-off row.
+- `.github/pins.yaml` — `librispeech-dev-clean` entry + the `mirror:` block.
+- `.github/workflows/nightly-asr-wer.yml` — the consumer; the fallback seam
+  is at line 155-164.

--- a/tests/parity/utmos/source.env
+++ b/tests/parity/utmos/source.env
@@ -1,0 +1,18 @@
+# UTMOS22-strong parity checkpoint source (M4-18 T2 / M5-15 T14).
+#
+# The §3.1 UTMOS sign-off in docs/license-audit.md was ☑ Commercial by
+# yousan on 2026-07-23, so parity-utmos.yml's setup gate now flips
+# ready=true and the parity leg fetches + sha256-verifies the checkpoint,
+# converts it, and runs parity_utmos + parity_utmos_stages.
+#
+# Snapshot-pinned to HF space sarulab-speech/UTMOS-demo commit
+# 47212055c2ecfb02d40cec2395233b83295d3d30 (== utmos_env_probe.sh's
+# requirements.txt pin recorded in decision-memo.md §(iii)); resolving via
+# the immutable `resolve/<sha>/` URL guarantees byte-stability even if
+# the space's `main` branch later moves.
+#
+# CKPT_SHA256 MUST match the sha256 recorded in .github/pins.yaml under the
+# `utmos22-strong` entry; both were measured 2026-07-17 by campaign-2
+# utmos-probe. Editing either side requires editing the other.
+CKPT_URL=https://huggingface.co/spaces/sarulab-speech/UTMOS-demo/resolve/47212055c2ecfb02d40cec2395233b83295d3d30/epoch=3-step=7459.ckpt
+CKPT_SHA256=44c57e3e4135a243b43d2c82b6a693fcd56f15f9ad0e1eb2a8b31fdecd3a49b8


### PR DESCRIPTION
## Summary

PR #16 body の "Follow-up (defer)" 節に列挙された **handoff 8 items** のうち、
**CC で完結できる 4 items を消化**（残 4 items は owner 専任 = T02 upload / T03
variable / §3.2 sign-off / 初回 workflow_dispatch × 3 / 4-week soak 昇格判定）。

## 消化した 4 items

### handoff #6: UTMOS `source.env` commit + `pins.yaml` sha256 埋め ✅

**Precondition met**: §3.1 UTMOS 行 = 2026-07-23 yousan ☑ Commercial 済で
fail-closed 解除済（`docs/license-audit.md:255`）。この commit で `parity-utmos.yml`
の setup gate が `ready=true` に flip する。

- `tests/parity/utmos/source.env` 新規: `CKPT_URL` は HF space
  `sarulab-speech/UTMOS-demo` の snapshot revision `47212055c2ec…` を
  `resolve/<sha>/` 経路で pin（immutable URL）、`CKPT_SHA256=44c57e3e…` は
  2026-07-17 campaign-2 utmos-probe で一次確認済みの値（`pins.yaml` notes に
  informational reference として既記載）。
- `.github/pins.yaml` `utmos22-strong` entry: `sha256: null` → `"44c57e3e…"`。
  `owning_line: 0` は **source.env-indirection sentinel** として意味拡張（元の
  unlanded-pin sentinel と併用可能）。
- `.github/scripts/check_pins_sync.py`: `owning_line=0` の docstring を
  source.env-indirection pattern も cover するよう更新（self-test 6/6 pass 維持）。

### handoff #7: Whisper 5 + Moshi HF revision を snapshot SHA に pin ✅

HF API `repo_info().sha` で 6 repo の main commit SHA を取得し、
workflow env + pins.yaml catalog に atomic sync:

| repo | snapshot SHA |
|------|--------------|
| `openai/whisper-base` | `e37978b90ca9030d5170a5c07aadb050351a65bb` |
| `openai/whisper-small` | `973afd24965f72e36ca33b3055d56a652f456b4d` |
| `openai/whisper-medium` | `abdf7c39ab9d0397620ccaea8974cc764cd0953e` |
| `openai/whisper-large-v3` | `06f233fe06e710322aca913c1bc4249a0d71fce1` |
| `openai/whisper-large-v3-turbo` | `41f01f3fe87f28c78e2fbf8b568835947dd65ed9` |
| `kyutai/moshiko-pytorch-bf16` | `2bfc9ae6e89079a5cc7ed2a68436010d91a3d289`（= `mimi-codec` entry の既存 pin と同 SHA） |

- `pins.yaml`: 6 entry の `hf_revision: null` → snapshot SHA、`drift_policy.no_revision: warn` 削除。
- `nightly-asr-wer.yml`: env に `HF_REVISION` 追加、`snapshot_download(revision=os.environ["HF_REVISION"], …)`。
- `parity-whisper-real.yml`: matrix include に `hf_revision` field を per-size、matrix job env に `HF_REVISION: ${{ matrix.hf_revision }}`、snapshot_download に revision 引数。
- `web-wasm.yml`: `whisper-wasm-e2e` job に env `WHISPER_BASE_REVISION`、snapshot_download に revision 引数。
- `parity-moshi-real.yml`: `MOSHIKO_REVISION: main` → `2bfc9ae6…`（`mimi-codec` pin と同 SHA）。

### handoff #8: glslang / 第三者 GitHub Actions の catalog 判断 = **見送り** ✅

`pins.yaml` header に判断を明記（catalog に追加しない、根拠 2 点）:

1. **glslang toolchain**: version `16.4.0` は `crates/vokra-backend-vulkan/kernels/precompiled/PROVENANCE` で pin 済で `.github/workflows/gpu-vulkan-parity.yml` から参照。apt package version は URL-addressable でなく、catalog 行は `drift_policy=skip`（`emsdk-toolchain` 同型）にしかならず drift 検出便益ゼロ。
2. **第三者 GitHub Actions**: `.github/dependabot.yml` の `production-actions` group が weekly bump 済。catalog 追加は Dependabot PR ごとの dual-edit obligation を生むだけで drift 検出便益ゼロ（Dependabot IS the drift detector）。MSRV-critical pin (`dtolnay/rust-toolchain@1.89` / `pypa/cibuildwheel@v2.23.4`) は `dependabot.yml` の `ignore:` で手動管理。

### handoff #1 CC 下準備: X-10-T02 LibriSpeech mirror upload の owner handoff docs ✅

`docs/handoff/x-10.md` 新規（tracked/public、7 sections）:

1. `docs/license-audit.md` §3.2 sign-off（owner が最初、他は全て gate）
2. staging directory + tarball fetch + SHA verify（byte-identity 保証）
3. LICENSE / NOTICE / SOURCE.md / README.md template を inline 提供
4. `huggingface_hub.upload_folder(repo_type="dataset", …)` コマンド（既存 `scripts/publish/upload.sh` は model repo 前提ゆえ非流用）
5. `gh api …/actions/variables` で T03 の 2 変数登録
6. `pins.yaml` mirror block 埋め方 + `check_pins_sync` 整合
7. 初回 workflow_dispatch × 3 + 4-week soak 昇格判定
8. 失敗時の restore path（mirror repo 削除 / HF bandwidth quota / attribution drift）

## 対応した handoff item 一覧

- [x] **#6** — UTMOS `source.env` commit → `pins.yaml:271` sha256 埋め
- [x] **#7** — Whisper family HF revision 具体化 + Moshi snapshot pin
- [x] **#8** — glslang / 第三者 Actions pin catalog 追加判断（見送り）
- [x] **#1 下準備** — X-10-T02 LibriSpeech mirror upload の CC 側 preparation
- [ ] **#1 実行** — LibriSpeech dev-clean.tar.gz を `huggingface.co/datasets/vokra/librispeech-dev-clean-mirror` に upload（owner、`docs/handoff/x-10.md` §2-3）
- [ ] **#2** — repo variable 2 個（URL/SHA256）を `gh api` で登録（owner、§4）
- [ ] **#3** — `docs/license-audit.md` §3.2 LibriSpeech CC-BY 4.0 sign-off（owner、§1）
- [ ] **#4** — 初回 workflow_dispatch × 3（corpus-drift-detector / pins-sync-check / parity-rvq-real、owner、§6）
- [ ] **#5** — 4-week soak 後の pins-sync-check required 昇格判定（owner）

## Verification (all green on local, pre-commit hooks passed on commit)

- **YAML syntax**: `pins.yaml` + 4 workflow parse OK
- **check_pins_sync**: full tree check（forward + reverse legs）+ self-test **6/6 pass**
- **pins_probe**: self-test **12/12 pass**
- **`tools/eval/test_librispeech_wer.py`**: **45/45 pass**（fix PR #16 baseline 維持）
- **`scripts/check-workflow-advisory-suffix.sh`**: OK
- **`scripts/check-find-hygiene.sh`**: OK
- **`scripts/check-zero-deps.sh`**: OK（`Cargo.lock` は `vokra-*` のみ、NFR-DS-02 保存）
- **`scripts/check-abi-changelog.sh`**: OK（v1.0-rc baseline 不変、33 fn + 11 typedefs）
- **pre-commit hooks** (fmt / forbidden-symbols / zero-deps / fixture-eol-pins / pipefail-grep-q): 全 pass

**No Cargo changes** (yaml/pins/docs only) — Rust code 無編集。**C ABI 変更なし**（`include/vokra.h` 33 fn + 11 typedefs 不変）。

## Test plan

- [ ] merge 後、weekly cron 継続で `nightly-asr-wer` / `parity-whisper-real` の cron leg で snapshot-revision 経由の HF cache hit が改善しているか確認（revision が floating `main` から SHA pin に変わったので cache key が安定）
- [ ] owner が §3.2 sign-off + T02/T03 消化した後、`corpus-drift-detector.yml` を workflow_dispatch で初回起動、`librispeech-dev-clean` の mirror block probe が期待どおり分岐すること確認
- [ ] `pins-sync-check.yml` の 4-week soak 完了時点で required 昇格判定
