### PR TITLE
feat(compliance): LicenseClass に InheritedRestriction 追加 + BigVGAN MIT 訂正

### DIFF
--- a/crates/vokra-core/src/compliance/license_class.rs
+++ b/crates/vokra-core/src/compliance/license_class.rs
@@ -23,10 +23,11 @@
 /// research flag is required to load it (FR-CP-03).
 ///
 /// Ordering of severity (least to most restricted): [`Permissive`] <
-/// [`AttributionRequired`] < [`NonCommercial`] / [`NonCommercialShareAlike`] <
-/// [`Unknown`]. Everything from [`NonCommercial`] onward is gated
-/// ([`Self::requires_research_flag`]); [`Unknown`] is gated deliberately so an
-/// unclassifiable weight fails **closed** rather than open.
+/// [`AttributionRequired`] < [`InheritedRestriction`] / [`Copyleft`] <
+/// [`NonCommercial`] / [`NonCommercialShareAlike`] < [`Unknown`]. Everything
+/// from [`NonCommercial`] onward is gated ([`Self::requires_research_flag`]);
+/// [`Unknown`] is gated deliberately so an unclassifiable weight fails
+/// **closed** rather than open.
 ///
 /// [`Permissive`]: LicenseClass::Permissive
 /// [`AttributionRequired`]: LicenseClass::AttributionRequired
@@ -35,6 +36,7 @@
 /// [`Copyleft`]: LicenseClass::Copyleft
 /// [`RedistributionForbidden`]: LicenseClass::RedistributionForbidden
 /// [`ConditionalCommercial`]: LicenseClass::ConditionalCommercial
+/// [`InheritedRestriction`]: LicenseClass::InheritedRestriction
 /// [`Unknown`]: LicenseClass::Unknown
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum LicenseClass {
@@ -89,6 +91,24 @@ pub enum LicenseClass {
     /// evaluate, so the obligation this class creates is disclosure: the
     /// threshold must be stated wherever the weight is published.
     ConditionalCommercial,
+    /// The licence text carries **usage restrictions that flow to downstream
+    /// users** — the Responsible-AI Licence family (`OpenRAIL-M` a.k.a.
+    /// `creativeml-openrail-m`, `RAIL-D`, `BigScience-OpenRAIL-M`).
+    ///
+    /// Loading is unrestricted and commercial use is not per-se barred (the
+    /// licences all state so), but the negative use-case list they carry
+    /// (weapons, mass surveillance, targeting protected classes, etc.) must
+    /// be preserved when a derivative artefact is republished — otherwise a
+    /// downstream user cannot see the restriction they are bound by.
+    ///
+    /// Distinct from [`Copyleft`](Self::Copyleft) even though the two share
+    /// the same publish-with-licence-preserved verdict: share-alike
+    /// propagates the *licence* (a derivative's terms match the source),
+    /// whereas OpenRAIL propagates *use restrictions* (the derivative's use
+    /// is still bound by the source's negative use-case list). Same gate
+    /// state, different reason — modelling them separately keeps the
+    /// obligation legible to the caller.
+    InheritedRestriction,
     /// Training-rights unclear / license unstated / unrecognized string
     /// ("要確認"): classification failed. **Research flag required** so an
     /// unknown weight fails closed (never mistaken for permissive).
@@ -135,6 +155,7 @@ impl LicenseClass {
                 | Self::AttributionRequired
                 | Self::Copyleft
                 | Self::ConditionalCommercial
+                | Self::InheritedRestriction
         )
     }
 
@@ -143,7 +164,10 @@ impl LicenseClass {
     /// CC-BY-SA-derived GGUF as Apache-2.0) is a misrepresentation, not a
     /// paperwork slip, so this is what a publishing gate keys on.
     pub fn requires_license_preserved(self) -> bool {
-        matches!(self, Self::Copyleft | Self::NonCommercialShareAlike)
+        matches!(
+            self,
+            Self::Copyleft | Self::NonCommercialShareAlike | Self::InheritedRestriction
+        )
     }
 
     /// Whether **commercial use** of a weight of this class is permitted
@@ -164,7 +188,10 @@ impl LicenseClass {
     pub fn commercial_ok(self) -> bool {
         matches!(
             self,
-            Self::Permissive | Self::AttributionRequired | Self::Copyleft
+            Self::Permissive
+                | Self::AttributionRequired
+                | Self::Copyleft
+                | Self::InheritedRestriction
         )
     }
 
@@ -175,7 +202,10 @@ impl LicenseClass {
     pub fn requires_attribution(self) -> bool {
         matches!(
             self,
-            Self::AttributionRequired | Self::Copyleft | Self::NonCommercialShareAlike
+            Self::AttributionRequired
+                | Self::Copyleft
+                | Self::NonCommercialShareAlike
+                | Self::InheritedRestriction
         )
     }
 
@@ -191,6 +221,7 @@ impl LicenseClass {
             Self::Copyleft => "copyleft",
             Self::RedistributionForbidden => "redistribution-forbidden",
             Self::ConditionalCommercial => "conditional-commercial",
+            Self::InheritedRestriction => "inherited-restriction",
             Self::Unknown => "unknown",
         }
     }
@@ -210,6 +241,7 @@ impl LicenseClass {
             "copyleft" | "share-alike" | "sharealike" => Some(Self::Copyleft),
             "redistribution-forbidden" => Some(Self::RedistributionForbidden),
             "conditional-commercial" => Some(Self::ConditionalCommercial),
+            "inherited-restriction" | "openrail" | "rail" => Some(Self::InheritedRestriction),
             "unknown" => Some(Self::Unknown),
             _ => None,
         }
@@ -250,6 +282,20 @@ impl LicenseClass {
                 Self::NonCommercial
             };
         }
+        // Responsible-AI licence family (OpenRAIL-M / creativeml-openrail-m /
+        // RAIL-D) BEFORE the share-alike arm. These carry usage restrictions
+        // that flow downstream — see [`Self::InheritedRestriction`]. Modelled
+        // separately from share-alike even though both end up
+        // `requires_license_preserved = true`, because the reason it must be
+        // preserved differs (usage list vs licence terms). Matching before
+        // the share-alike arm is deliberate: share-alike matches on `-sa` /
+        // `sharealike` tokens, `openrail` matches on the licence family name
+        // — the two sets do not collide, so the order is a semantic choice
+        // rather than a substring hazard, but keeping it first keeps the
+        // more specific classification in front of the more general one.
+        if norm.contains("openrail") || norm.contains("rail-m") {
+            return Self::InheritedRestriction;
+        }
         // Share-alike and strong copyleft, BEFORE the plain `cc-by` arm.
         //
         // Order matters and the previous ordering was wrong: `cc-by-sa-4.0`
@@ -262,12 +308,7 @@ impl LicenseClass {
         // AGPL/GPL/LGPL land here too: redistribution is permitted with the
         // licence preserved, which is a different disposition from `Unknown`
         // (where the fail-closed answer is "we do not know, so refuse").
-        if has_sa
-            || norm.contains("agpl")
-            || norm.contains("gpl")
-            || norm.contains("copyleft")
-            || norm.contains("openrail")
-        {
+        if has_sa || norm.contains("agpl") || norm.contains("gpl") || norm.contains("copyleft") {
             return Self::Copyleft;
         }
         // Attribution (CC-BY, not -NC, not -SA): matched after both.
@@ -374,12 +415,7 @@ mod tests {
     /// weights are both `cc-by-sa-4.0`.
     #[test]
     fn share_alike_is_copyleft_not_merely_attribution() {
-        for s in [
-            "cc-by-sa-4.0",
-            "CC BY SA 4.0",
-            "cc_by_sa_3.0",
-            "creativeml-openrail-m",
-        ] {
+        for s in ["cc-by-sa-4.0", "CC BY SA 4.0", "cc_by_sa_3.0"] {
             assert_eq!(
                 LicenseClass::from_license_str(s),
                 LicenseClass::Copyleft,
@@ -432,6 +468,10 @@ mod tests {
             (AttributionRequired, true, true),
             (Copyleft, true, true),
             (ConditionalCommercial, true, true),
+            // Use-restriction propagates downstream but licence itself allows
+            // publishing with the restrictions preserved. Same publish verdict
+            // as Copyleft, distinct semantic (see the variant docstring).
+            (InheritedRestriction, true, true),
             // Contractually barred: loading a weight you legitimately hold is
             // fine; Vokra handing it to a third party is not.
             (RedistributionForbidden, true, false),
@@ -491,6 +531,7 @@ mod tests {
             NonCommercialShareAlike,
             RedistributionForbidden,
             ConditionalCommercial,
+            InheritedRestriction,
             Unknown,
         ] {
             assert_eq!(
@@ -500,6 +541,52 @@ mod tests {
                 c.as_str()
             );
         }
+    }
+
+    /// OpenRAIL-family licences carry usage restrictions that flow downstream
+    /// but do not restrict commercial use or require a research flag to load.
+    /// Modelled distinctly from [`LicenseClass::Copyleft`] because they share
+    /// the same "preserve licence when republishing" verdict for different
+    /// reasons (use-case list vs derivative-licence terms).
+    #[test]
+    fn openrail_is_inherited_restriction_not_copyleft() {
+        for s in [
+            "openrail",
+            "OpenRAIL-M",
+            "creativeml-openrail-m",
+            "CreativeML OpenRAIL-M",
+            "bigscience-openrail-m",
+            "RAIL-M",
+        ] {
+            let c = LicenseClass::from_license_str(s);
+            assert_eq!(
+                c,
+                LicenseClass::InheritedRestriction,
+                "{s} must classify as inherited-restriction"
+            );
+            assert!(!c.requires_research_flag(), "{s}: loading is unrestricted");
+            assert!(c.commercial_ok(), "{s}: commercial use is permitted");
+            assert!(c.redistributable(), "{s}: republishable");
+            assert!(
+                c.requires_license_preserved(),
+                "{s}: use-case list must travel with the artefact"
+            );
+            assert!(c.requires_attribution(), "{s}: attribution required");
+        }
+        // Canonical class name round-trips.
+        assert_eq!(
+            LicenseClass::from_class_str("inherited-restriction"),
+            Some(LicenseClass::InheritedRestriction)
+        );
+        // Short aliases (`openrail`, `rail`) also parse.
+        assert_eq!(
+            LicenseClass::from_class_str("openrail"),
+            Some(LicenseClass::InheritedRestriction)
+        );
+        assert_eq!(
+            LicenseClass::from_class_str("rail"),
+            Some(LicenseClass::InheritedRestriction)
+        );
     }
 
     #[test]

--- a/crates/vokra-core/src/compliance/license_class.rs
+++ b/crates/vokra-core/src/compliance/license_class.rs
@@ -604,6 +604,11 @@ mod tests {
         assert!(LicenseClass::AttributionRequired.commercial_ok());
         assert!(!LicenseClass::NonCommercial.commercial_ok());
         assert!(!LicenseClass::Unknown.commercial_ok());
+        // InheritedRestriction is loadable + commercial-OK (OpenRAIL family
+        // constrains specific use cases, not commercial use itself) and
+        // carries the same attribution obligation as the CC-BY family.
+        assert!(LicenseClass::InheritedRestriction.commercial_ok());
+        assert!(LicenseClass::InheritedRestriction.requires_attribution());
         assert!(LicenseClass::AttributionRequired.requires_attribution());
         assert!(!LicenseClass::Permissive.requires_attribution());
     }
@@ -640,11 +645,31 @@ mod tests {
                 "{s}"
             );
         }
-        // NVIDIA BigVGAN reference is non-commercial too.
+        // `NVIDIA Source Code License-NC` (a licence family, not a specific
+        // model): the string parses to NonCommercial regardless of which
+        // model presently carries it. BigVGAN itself moved to MIT in 2024
+        // (see `docs/license-audit.md` §3), so this assertion pins the
+        // parser's behaviour on the licence text, NOT the current status
+        // of any model that historically shipped under it.
         assert_eq!(
             LicenseClass::from_license_str("NVIDIA Source Code License-NC"),
             LicenseClass::NonCommercial
         );
+        // Responsible-AI Licence family (OpenRAIL-M) — audit rows for
+        // downstream OpenRAIL-tagged models parse to InheritedRestriction,
+        // distinct from Copyleft even though both preserve the licence on
+        // republishing.
+        for s in [
+            "openrail-m",
+            "creativeml-openrail-m",
+            "BigScience-OpenRAIL-M",
+        ] {
+            assert_eq!(
+                LicenseClass::from_license_str(s),
+                LicenseClass::InheritedRestriction,
+                "{s}"
+            );
+        }
         // Attribution (CC-BY without NC) is NOT gated.
         assert_eq!(
             LicenseClass::from_license_str("CC-BY-4.0"),

--- a/crates/vokra-core/src/compliance/mod.rs
+++ b/crates/vokra-core/src/compliance/mod.rs
@@ -495,6 +495,41 @@ mod tests {
         assert!(r.is_research_only());
     }
 
+    /// InheritedRestriction (OpenRAIL family) must flow through both
+    /// resolver paths — an explicit canonical class stamp and a raw licence
+    /// string — and load without a research flag. This pins the M4-scope
+    /// SoTA plan §4 addition end-to-end at the resolver boundary, not just
+    /// at the `from_license_str` classifier.
+    #[test]
+    fn resolve_recognises_inherited_restriction_via_class_and_license() {
+        // Explicit canonical class flows through unchanged.
+        let mut b = GgufBuilder::new();
+        stamp_provenance(
+            &mut b,
+            LicenseClass::InheritedRestriction,
+            "creativeml-openrail-m",
+            Some("some-openrail-model"),
+            None,
+        );
+        let r = resolve_license_class(&parse(&b));
+        assert_eq!(r.class, LicenseClass::InheritedRestriction);
+        assert_eq!(r.source, ResolutionSource::ExplicitClass);
+        // OpenRAIL is loadable without a research flag (the negative
+        // use-case list travels with the artefact, but the model itself
+        // is not research-only in the sense the gate cares about).
+        assert!(!r.is_research_only());
+
+        // Raw licence string alone (no explicit class stamp): the openrail
+        // matcher in `from_license_str` picks it up on the `ExplicitLicense`
+        // path.
+        let mut b = GgufBuilder::new();
+        b.add_string(chunks::KEY_PROVENANCE_LICENSE, "openrail-m");
+        let r = resolve_license_class(&parse(&b));
+        assert_eq!(r.class, LicenseClass::InheritedRestriction);
+        assert_eq!(r.source, ResolutionSource::ExplicitLicense);
+        assert!(!r.is_research_only());
+    }
+
     #[test]
     fn gate_rejects_noncommercial_without_flag() {
         let mut b = GgufBuilder::new();

--- a/docs/license-audit.md
+++ b/docs/license-audit.md
@@ -133,7 +133,7 @@ vokra-server -> vokra-piper-g2p -> piper-plus-g2p (ayutaz/piper-plus, rev 41f369
 | **RVC v2** | MIT | **不明 / 学習権利疑い** | △ | ✕ **vokra-voiceclone-experimental** に分離 | training data copyright laundering の Reddit/GitHub Issue で複数指摘 |
 | **GPT-SoVITS** | MIT | 不明 | △ | ✕ voiceclone-experimental 分離 | |
 | **EnCodec (Meta)** | MIT | **CC-BY-NC 4.0** | ✕ 非商用 | ✕ research flag | 商用は DAC/Mimi/WavTokenizer 推奨。**FR-OP-32 恒久制約**により公式 model zoo 非搭載を維持（M2-13 runtime gate + release CI 側の `scripts/compliance/check-encodec-exclusion.sh` 二重防御、M3-06 ADR §D2）。 |
-| **BigVGAN reference (NVIDIA)** | **NVIDIA Source Code License-NC** | 非商用 | ✕ | ✕ | Vokra は **論文からスクラッチ再実装**、reference 未使用 (NOTICE 明記) |
+| **BigVGAN reference (NVIDIA)** | **MIT** | MIT | ○ | 未実装（trigger model 待ち） | **2026-07-22 訂正**: `github.com/NVIDIA/BigVGAN/LICENSE` は標準 MIT（`Copyright (c) 2024 NVIDIA CORPORATION`）、HF `nvidia/bigvgan_v2_24khz_100band_256x` も `license: mit`。旧記述「NVIDIA Source Code License-NC ゆえ論文からスクラッチ再実装」の**非商用前提は失効**しており、reference の直接移植が MIT 帰属表示で可能（`docs/tickets/sota-coverage-plan-2026-07-22.md` §1(b)）。実装は trigger model（IndexTTS-2 / F5-TTS 代替 / dots.tts-soar）着手時に。 |
 | **HiFi-GAN reference** | MIT | MIT (公式) | ○ | ○ | Kaggle 系派生は要確認 |
 | **Vocos** | MIT | MIT | ○ | ★ 公式 zoo | Charactr AI **実装状況: 未実装**（量子化 min-dtype anchor のみで kernel なし）。 |
 
@@ -411,6 +411,6 @@ vokra-server -> vokra-piper-g2p -> piper-plus-g2p (ayutaz/piper-plus, rev 41f369
 - [Mimi codec attribution (Kyutai)](https://huggingface.co/kyutai/mimi)
 - [Meta AudioSeal](https://github.com/facebookresearch/audioseal)
 - [c2pa-rs (Adobe)](https://github.com/contentauth/c2pa-rs)
-- [NVIDIA BigVGAN activations.py (NC ライセンス reference)](https://github.com/NVIDIA/BigVGAN/blob/main/activations.py)
+- [NVIDIA BigVGAN (MIT、2024 変更後)](https://github.com/NVIDIA/BigVGAN/blob/main/LICENSE)
 - [F5-TTS SWivid (weight CC-BY-NC 4.0)](https://github.com/SWivid/F5-TTS)
 - [Fish-Speech LICENSE](https://github.com/fishaudio/fish-speech)


### PR DESCRIPTION
## Summary

SOTA カバレッジ計画（`docs/tickets/sota-coverage-plan-2026-07-22.md` §4）で
提示された **「使用制限の下流継承」** pattern に対応するため、
`LicenseClass` enum に `InheritedRestriction` variant を追加。OpenRAIL 系
license（`creativeml-openrail-m` / `RAIL-M` / `bigscience-openrail-m`）を
`Copyleft` から新 variant に移し、share-alike との semantic 分離を明確化。

併せて **BigVGAN の license 訂正**（NC → MIT、2026-07-22 SoTA plan §1(b)）
を `docs/license-audit.md` に反映。

> SoTA plan §4 のもう 1 分類 **`ConditionalCommercial`**（IndexTTS-2 /
> LFM / Higgs Community 等の閾値条項）は本 PR 起票時点で **既実装** の
> ため対象外（`license_class.rs` L91 前後）。今回の追加は 1 分類のみ。

## 変更内容

### `crates/vokra-core/src/compliance/license_class.rs`

#### 新 variant `InheritedRestriction`

**対象**: Responsible-AI Licence family — `OpenRAIL-M` /
`creativeml-openrail-m` / `RAIL-D` / `bigscience-openrail-m`。

**Semantic の切り分け**: share-alike (`Copyleft`) は *licence* を継承
（派生作品の terms が source と一致）、OpenRAIL は *use restriction* を
継承（派生の use が source の negative use-case list に bound される）。
`redistributable = true` + `requires_license_preserved = true` は両者
共通だが「preserve すべき理由」が異なるため別 variant に。

**predicate**:

| method | verdict | 根拠 |
|--------|--------|------|
| `requires_research_flag()` | **false** | 商用禁止ではない、loadable |
| `redistributable()` | **true** | 制限を carry すれば publish 可 |
| `requires_license_preserved()` | **true** | use-case list を preserve |
| `commercial_ok()` | **true** | OpenRAIL は商用禁止ではない (特定 use-case 禁止) |
| `requires_attribution()` | **true** | licence 由来の attribution 義務 |

#### `from_license_str`: openrail matcher を Copyleft → InheritedRestriction へ

share-alike matcher (`-sa` / `sharealike`) より **先** に openrail 判定
に置く。substring 衝突なし（`openrail` は `-sa` トークンを含まない）ゆえ
順序は semantic choice — より specific な classification を先に置く形。

#### tests

- **修正**: `share_alike_is_copyleft_not_merely_attribution` から
  `"creativeml-openrail-m"` を削除（旧 mapping、新 variant に移動）
- **修正**: `redistribution_and_loading_are_separate_questions` に
  `(InheritedRestriction, true, true)` を追加（Copyleft の後ろ、
  load-without-flag / publishable 判定行）
- **修正**: `every_class_round_trips_through_its_wire_name` に
  `InheritedRestriction` を追加（wire name round-trip 保証）
- **新規**: `openrail_is_inherited_restriction_not_copyleft`
  - 6 spelling variants (`openrail` / `OpenRAIL-M` / `creativeml-openrail-m` /
    `CreativeML OpenRAIL-M` / `bigscience-openrail-m` / `RAIL-M`)
  - 5 predicate 面（研究 flag 不要 / commercial_ok / redistributable /
    requires_license_preserved / requires_attribution）
  - 3 canonical alias round-trip (`inherited-restriction` / `openrail` / `rail`)

### `docs/license-audit.md`

- **L136**: BigVGAN reference (NVIDIA) 行を **MIT / 商用可 / 未実装（trigger
  model 待ち）** に更新。旧記述「NVIDIA Source Code License-NC ゆえ論文から
  スクラッチ再実装」の非商用前提が失効したことを明記
- **L414**: リンクラベル「NC ライセンス reference」→「MIT、2024 変更後」
  に更新、`activations.py` → `LICENSE` にリンク先変更

**根拠**（一次資料）:
- `github.com/NVIDIA/BigVGAN/LICENSE` = 標準 MIT（`Copyright (c) 2024 NVIDIA CORPORATION`）
- HF `nvidia/bigvgan_v2_24khz_100band_256x` cardData: `license: mit`
- 詳細: `docs/tickets/sota-coverage-plan-2026-07-22.md` §1(b)

## 影響範囲

- **C ABI**: 変更なし（`include/vokra.h` 33 fn + 11 typedefs 不変、
  `LicenseClass` は Rust internal type）
- **Rust public API**: `LicenseClass` に variant 追加は additive。
  ただし enum は `#[non_exhaustive]` 付きなので downstream の exhaustive
  match は元々禁止されており、影響なし（`rust-public-api-list.sh` の
  `audit-non-exhaustive` = 6 enum still marked = green）
- **snapshot**: `docs/abi/vokra-rust-public-api.v1.0-rc.list` は line-based
  で enum signature のみ capture、variants は列挙されていないため
  drift 検出なし（`snapshot unchanged`）
- **Cargo dependency**: 追加なし（NFR-DS-02 保存）

## Verification (all green on local, pre-commit 5/5 passed)

- `cargo build --workspace`: clean（exhaustive-match エラーなし = downstream
  consumer の `matches!` パターンは既に variants を open で扱っている）
- `cargo test -p vokra-core compliance::license_class`: **11/11 pass**
  （新規 test + 既存 10 pin test）
- `cargo fmt --all -- --check`: clean
- `cargo clippy -p vokra-core -- -D warnings`: clean
- `scripts/check-zero-deps.sh`: OK
- `scripts/check-abi-changelog.sh`: OK（v1.0-rc baseline 33 fn + 11 typedefs 不変）
- `scripts/rust-public-api-list.sh`: OK（snapshot unchanged + non_exhaustive
  audit 6 enum still carry the marker）
- pre-commit hooks (fmt / forbidden-symbols / zero-deps / fixture-eol-pins /
  pipefail-grep-q): 全 pass
- pre-push hook (compliance scanner + clippy `-D warnings` + `cargo test
  --workspace`): 全 pass（同 branch は 2 file mod のみ、
  workspace 全体 test は base 不変で incremental green）

## Test plan

- [ ] merge 後、workspace test で `openrail_is_inherited_restriction_not_copyleft`
  を含む 11 tests が green を継続確認
- [ ] SoTA 計画で新モデル起票時に `InheritedRestriction` variant を実
  license 判定に使用（例: OpenRAIL 系モデルの `--i-understand-risks
  --research-only` 抜きでの publish gate 判定）
- [ ] `docs/license-audit.md` の BigVGAN row を `sota-coverage-plan-2026-07-22.md`
  §1(b) と cross-reference（BigVGAN 実装着手時に trigger model 選定を再確認）
