### PR TITLE
chore(hooks): pre-push に docs-only fast-path + cargo-nextest fallback

### DIFF
--- a/.githooks/lib-fastpath.sh
+++ b/.githooks/lib-fastpath.sh
@@ -1,0 +1,85 @@
+# .githooks/lib-fastpath.sh
+#
+# Diff-shape classifier for the pre-push fast-paths. Sourced by
+# `.githooks/pre-push` (production) and `scripts/test-pre-push-fastpath.sh`
+# (regression tests). Not standalone-executable — always sourced.
+#
+# Two functions:
+#
+#   * `diff_base` — echoes the commit id to diff HEAD against, or fails
+#     (returns 1, prints nothing). Prefers the tracking upstream; falls
+#     back to origin/main.
+#
+#   * `is_docs_only_diff` — sets `fastpath_reason` and returns 0 if every
+#     file changed since `diff_base` matches a documentation-shape pattern.
+#     Otherwise returns 1 with the reason set to the first offending file.
+#     `VOKRA_HOOK_DEEP=1` forces a non-zero return regardless of diff.
+
+# shellcheck disable=SC2034  # fastpath_reason is set for callers to read.
+
+fastpath_reason=""
+
+diff_base() {
+    local upstream
+    if upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null); then
+        if [ -n "$upstream" ] && git rev-parse --verify "$upstream" >/dev/null 2>&1; then
+            git merge-base HEAD "$upstream"
+            return 0
+        fi
+    fi
+    if git rev-parse --verify origin/main >/dev/null 2>&1; then
+        git merge-base HEAD origin/main
+        return 0
+    fi
+    return 1
+}
+
+is_docs_only_diff() {
+    if [ "${VOKRA_HOOK_DEEP:-0}" = "1" ]; then
+        fastpath_reason="VOKRA_HOOK_DEEP=1 (forcing deep path)"
+        return 1
+    fi
+    local base
+    if ! base=$(diff_base 2>/dev/null); then
+        fastpath_reason="cannot determine diff base — taking the deep path"
+        return 1
+    fi
+    if [ -z "$base" ]; then
+        fastpath_reason="empty diff base — taking the deep path"
+        return 1
+    fi
+    local files
+    files=$(git diff --name-only "$base" HEAD)
+    if [ -z "$files" ]; then
+        fastpath_reason="no files changed since $base — taking the deep path"
+        return 1
+    fi
+    local trigger=""
+    while IFS= read -r f; do
+        # SAFETY: any of these paths, if touched, means the change may affect
+        # compiled output OR the hook itself. Keep this list conservative;
+        # over-inclusion loses the fast-path, under-inclusion loses safety.
+        case "$f" in
+            # Rust / build (highest priority — must not skip):
+            *.rs|Cargo.toml|Cargo.lock|rust-toolchain*|deny.toml|.cargo/*|build.rs)
+                trigger="$f"; break ;;
+            # Scripts / tooling that may be exercised elsewhere in the hook or in tests:
+            scripts/*|tools/*|.githooks/*)
+                trigger="$f"; break ;;
+            # Test fixtures / harness (may bind test output):
+            tests/*|integrations/*)
+                trigger="$f"; break ;;
+            # Documentation-shape files → OK to skip:
+            docs/*|.github/*|*.md|*.yml|*.yaml|.gitattributes|.gitignore|.editorconfig|LICENSE|NOTICE|README|CONTRIBUTING*|CHANGELOG*|include/*.h)
+                ;;
+            # Everything else → deep path (safe default).
+            *) trigger="$f"; break ;;
+        esac
+    done <<<"$files"
+    if [ -n "$trigger" ]; then
+        fastpath_reason="deep path required (first non-docs file: $trigger)"
+        return 1
+    fi
+    fastpath_reason="only documentation-shape files changed since $base"
+    return 0
+}

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -5,6 +5,27 @@
 # for something reproducible locally ("run the same commands before pushing",
 # CONTRIBUTING.md §2). Slower than pre-commit. Bypass with `git push
 # --no-verify` or VOKRA_SKIP_HOOKS=1.
+#
+# ITERATION-SPEED FAST-PATHS (2026-07-23):
+#
+# * Fast-path (a): if the diff since the tracking upstream (or origin/main
+#   when the branch is brand-new) touches ONLY documentation-shape files
+#   (docs/**, .github/**, *.md, *.yml, *.yaml, dotfiles that never affect
+#   compilation), the clippy + test legs SKIP. The compliance scanner
+#   sigpipe test always runs (5 s) — it is trivially cheap and is not
+#   dependent on the diff.
+#
+# * Fast-path (c): when the deep path DOES run, `cargo nextest run
+#   --workspace` is used when `cargo-nextest` is on the developer's PATH
+#   (~60% faster than `cargo test`, https://nexte.st). Missing tool falls
+#   back to `cargo test --workspace` with a one-line install hint — never
+#   a hard error. `cargo nextest` does NOT execute doc-tests, so `cargo
+#   test --workspace --doc` runs alongside it.
+#
+# Neither fast-path silently substitutes correctness: (a) prints why it
+# skipped, (c) prints which runner it chose, and both are visible in the
+# hook output. Force the full check regardless of diff content with
+# VOKRA_HOOK_DEEP=1 (or VOKRA_SKIP_HOOKS=1 for the pre-existing bypass).
 
 set -euo pipefail
 
@@ -16,17 +37,62 @@ fi
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
-# ~5 s, and first so a broken compliance gate is reported before the multi-minute
-# clippy/test legs. Proves the NVIDIA non-bundle scanners still REJECT a package
-# whose nm dump exceeds the pipe buffer — the SIGPIPE fail-open they shipped with.
+# ---------------------------------------------------------------------------
+# Fast-path (a): is every file in the push diff documentation-shape?
+#
+# The classifier lives in .githooks/lib-fastpath.sh so the regression test
+# `scripts/test-pre-push-fastpath.sh` can source and drive it directly. An
+# empty diff or an unresolvable base falls through to the DEEP path — never
+# fast — so a broken symbolic ref cannot accidentally silence the gate.
+# ---------------------------------------------------------------------------
+
+# shellcheck source=lib-fastpath.sh
+source "$ROOT/.githooks/lib-fastpath.sh"
+
+# ---------------------------------------------------------------------------
+# Step 1 always runs: ~5 s, and first so a broken compliance gate is
+# reported before the multi-minute clippy/test legs. Proves the NVIDIA
+# non-bundle scanners still REJECT a package whose nm dump exceeds the pipe
+# buffer — the SIGPIPE fail-open they shipped with.
+# ---------------------------------------------------------------------------
+
 echo "pre-push [1/3]: compliance scanner fail-open regression test"
 bash scripts/compliance/test-nvidia-scanner-sigpipe.sh
 
-echo "pre-push [2/3]: cargo clippy --all-targets -- -D warnings"
+# ---------------------------------------------------------------------------
+# Fast-path branch.
+# ---------------------------------------------------------------------------
+
+if is_docs_only_diff; then
+    echo "pre-push [2/3]: SKIP cargo clippy — $fastpath_reason"
+    echo "pre-push [3/3]: SKIP cargo test  — $fastpath_reason"
+    echo "pre-push: OK (fast-path — override with VOKRA_HOOK_DEEP=1)"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Deep path.
+# ---------------------------------------------------------------------------
+
+echo "pre-push [2/3]: cargo clippy --all-targets -- -D warnings  ($fastpath_reason)"
 cargo clippy --all-targets -- -D warnings
 
-echo "pre-push [3/3]: cargo test --workspace"
-cargo test --workspace
+# Fast-path (c): prefer cargo-nextest for the workspace test leg when
+# available. Fall back to `cargo test --workspace` with a hint so a missing
+# tool never blocks the push.
+if command -v cargo-nextest >/dev/null 2>&1; then
+    echo "pre-push [3/3]: cargo nextest run --workspace"
+    cargo nextest run --workspace
+    # `cargo nextest` does not run doc-tests; run them via `cargo test --doc`
+    # so behaviour matches `cargo test --workspace`.
+    echo "pre-push [3/3]: cargo test --workspace --doc  (doc-tests not covered by nextest)"
+    cargo test --workspace --doc
+else
+    echo "pre-push [3/3]: cargo test --workspace"
+    echo "  hint: install cargo-nextest to parallelise this leg (~60% faster):"
+    echo "        cargo install cargo-nextest --locked"
+    cargo test --workspace
+fi
 
 # NOTE: this hook does NOT compile the metal/cuda/vulkan-gated targets. Feature
 # unification during `cargo test --workspace` reaches some of them but is not a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,13 +115,31 @@ bash scripts/install-git-hooks.sh   # sets core.hooksPath -> .githooks
 ```
 
 - **pre-commit** (fast, no compile): `cargo fmt --all -- --check`,
-  `scripts/check-forbidden-symbols.sh`, `scripts/check-zero-deps.sh`.
-- **pre-push** (full, mirrors CI's compiling checks):
-  `cargo clippy --all-targets -- -D warnings`, `cargo test --workspace`.
+  `scripts/check-forbidden-symbols.sh`, `scripts/check-zero-deps.sh`,
+  `scripts/check-fixture-eol-pins.sh`, `scripts/compliance/lint-pipefail-grep-q.py`.
+- **pre-push** (compiling, mirrors CI):
+  `scripts/compliance/test-nvidia-scanner-sigpipe.sh` (always),
+  `cargo clippy --all-targets -- -D warnings`,
+  `cargo test --workspace` (or `cargo nextest run --workspace` + `cargo
+  test --workspace --doc` when `cargo-nextest` is installed locally —
+  ~60% faster on the workspace test leg; the hook falls back to plain
+  `cargo test` when it is missing, never a hard error).
 
-Bypass a run with `git commit --no-verify` / `git push --no-verify`, or
-`VOKRA_SKIP_HOOKS=1 git ...`. Uninstall with
-`git config --unset core.hooksPath`.
+**Fast-paths for iteration speed.** The pre-push hook classifies the diff
+since the tracking upstream (or `origin/main` for brand-new branches). When
+every file changed is documentation-shape (`docs/**`, `.github/**`,
+`*.md`, `*.yml` / `*.yaml`, `include/*.h`, root dotfiles / `LICENSE` /
+`NOTICE` / `README` / `CONTRIBUTING` / `CHANGELOG`), the clippy + test
+legs are **skipped**; the compliance scanner still runs. Any `.rs`,
+`Cargo.toml`, `Cargo.lock`, `scripts/`, `tools/`, `tests/`,
+`integrations/`, `.githooks/` change or an unrecognised extension puts the
+hook back on the full path. Force the full path regardless of diff shape
+with `VOKRA_HOOK_DEEP=1`. Skip everything (including the compliance
+scanner) with `git push --no-verify` or `VOKRA_SKIP_HOOKS=1`. The
+classifier lives in `.githooks/lib-fastpath.sh` and its behaviour is
+pinned by `scripts/test-pre-push-fastpath.sh` (17 cases).
+
+Uninstall with `git config --unset core.hooksPath`.
 
 `scripts/check-zero-deps.sh` enforces the **zero-external-dependency**
 invariant (NFR-DS-02): `Cargo.lock` must contain only first-party `vokra-*`

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -14,8 +14,21 @@ cd "$ROOT"
 git config core.hooksPath .githooks
 
 echo "Installed: core.hooksPath -> .githooks"
-echo "  pre-commit (fast):  cargo fmt --check, forbidden symbols, zero-dependency invariant"
-echo "  pre-push  (full):   cargo clippy -D warnings, cargo test --workspace"
+echo "  pre-commit (fast):  cargo fmt --check, forbidden symbols, zero-dependency invariant,"
+echo "                      fixture-eol pins, pipefail/grep-q lint"
+echo "  pre-push  (compiling):"
+echo "    * compliance scanner sigpipe test (always, ~5 s)"
+echo "    * cargo clippy --all-targets -- -D warnings"
+echo "    * cargo test --workspace   (or cargo nextest run --workspace + cargo test --doc"
+echo "                                if cargo-nextest is installed; ~60% faster)"
+echo
+echo "Iteration-speed fast-paths (silent skip forbidden — reason is always printed):"
+echo "  * documentation-only diffs (docs/**, .github/**, *.md, *.yml, *.yaml, etc.)"
+echo "    skip clippy + test; the compliance scanner still runs."
+echo "  * VOKRA_HOOK_DEEP=1 forces the full check regardless of diff shape."
+echo
+echo "Optional (recommended): install cargo-nextest for the parallel test runner:"
+echo "  cargo install cargo-nextest --locked"
 echo
 echo "Bypass once:  git commit --no-verify   /   git push --no-verify"
 echo "Or per-run:   VOKRA_SKIP_HOOKS=1 git ..."

--- a/scripts/test-pre-push-fastpath.sh
+++ b/scripts/test-pre-push-fastpath.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# scripts/test-pre-push-fastpath.sh
+#
+# Regression test for the .githooks/pre-push docs-only fast-path.
+#
+# Sources .githooks/lib-fastpath.sh (production classifier) and drives
+# `is_docs_only_diff` per case by shadowing `git diff --name-only` and
+# `diff_base` in a subshell. No real git activity, no cargo — the test runs
+# in milliseconds and can sit inside `scripts/verify.sh` or a CI leg without
+# added cost.
+#
+# Cases exercise both directions of the classifier:
+#   * docs-only inputs must land on fast-path (return 0)
+#   * anything Rust-adjacent must land on deep-path (return 1)
+#   * defensive inputs (empty diff, VOKRA_HOOK_DEEP=1) must land on deep-path
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+pass=0
+fail=0
+
+# One test case: name, expected verdict ("fast" | "deep"), diff-line list
+# (newline-separated, may be empty), optional env override (e.g.
+# "VOKRA_HOOK_DEEP=1"). The diff line list is fed to a fake
+# `git diff --name-only` inside a subshell so the real repo is not touched.
+run_case() {
+    local name="$1"
+    local expected="$2"
+    local files="$3"
+    local envvar="${4:-}"
+
+    local verdict
+    verdict=$(
+        set +e
+        if [ -n "$envvar" ]; then
+            export "${envvar?}"
+        fi
+        # shellcheck source=../.githooks/lib-fastpath.sh
+        source "$ROOT/.githooks/lib-fastpath.sh"
+
+        # Shadow the two calls the classifier makes.
+        FAKE_FILES="$files"
+        diff_base() { echo "fake-base"; }
+        git() {
+            if [ "${1:-}" = "diff" ] && [ "${2:-}" = "--name-only" ]; then
+                if [ -n "$FAKE_FILES" ]; then
+                    printf '%s\n' "$FAKE_FILES"
+                fi
+            else
+                command git "$@"
+            fi
+        }
+
+        if is_docs_only_diff; then
+            echo "fast"
+        else
+            echo "deep"
+        fi
+    )
+
+    if [ "$verdict" = "$expected" ]; then
+        pass=$((pass + 1))
+        printf 'OK   %-52s → %s\n' "$name" "$verdict"
+    else
+        fail=$((fail + 1))
+        printf 'FAIL %-52s expected=%s got=%s\n' "$name" "$expected" "$verdict"
+    fi
+}
+
+echo "test-pre-push-fastpath: 17 cases"
+echo
+
+# --- FAST-PATH cases (all inputs are docs-shape) ---
+run_case "single markdown file" \
+    "fast" \
+    "CLAUDE.md"
+
+run_case "several docs files" \
+    "fast" \
+    "$(printf 'docs/handoff/x-10.md\ndocs/license-audit.md\n.github/workflows/ci.yml\n')"
+
+run_case "yaml catalog only" \
+    "fast" \
+    ".github/pins.yaml"
+
+run_case "generated C header (include/*.h)" \
+    "fast" \
+    "include/vokra.h"
+
+run_case "root dotfiles (gitignore/gitattributes/editorconfig)" \
+    "fast" \
+    "$(printf '.gitattributes\n.gitignore\n.editorconfig\n')"
+
+run_case "LICENSE + NOTICE + README + CHANGELOG" \
+    "fast" \
+    "$(printf 'LICENSE\nNOTICE\nREADME.md\nCHANGELOG.md\n')"
+
+# --- DEEP-PATH cases (anything Rust-adjacent kills the fast-path) ---
+run_case ".rs kills fast-path" \
+    "deep" \
+    "$(printf 'docs/foo.md\ncrates/vokra-core/src/lib.rs\n')"
+
+run_case "Cargo.toml kills fast-path" \
+    "deep" \
+    "Cargo.toml"
+
+run_case "crate Cargo.toml kills fast-path (path pattern *.toml)" \
+    "deep" \
+    "crates/vokra-core/Cargo.toml"
+
+run_case "scripts/ kills fast-path" \
+    "deep" \
+    "scripts/check-zero-deps.sh"
+
+run_case "tools/ kills fast-path" \
+    "deep" \
+    "tools/eval/librispeech_wer.py"
+
+run_case ".githooks/ (hook self-change) kills fast-path" \
+    "deep" \
+    ".githooks/pre-push"
+
+run_case "tests/ kills fast-path" \
+    "deep" \
+    "tests/fixtures/audio/README.md"
+
+run_case "integrations/ kills fast-path" \
+    "deep" \
+    "integrations/vokra-server/Cargo.toml"
+
+run_case "unrecognised extension kills fast-path" \
+    "deep" \
+    "web/pkg/index.html"
+
+# --- DEFENSIVE cases (must fall through to deep) ---
+run_case "empty diff falls through to deep" \
+    "deep" \
+    ""
+
+run_case "VOKRA_HOOK_DEEP=1 forces deep on docs-only input" \
+    "deep" \
+    "CLAUDE.md" \
+    "VOKRA_HOOK_DEEP=1"
+
+echo
+if [ "$fail" -eq 0 ]; then
+    echo "test-pre-push-fastpath: OK (${pass} cases)"
+    exit 0
+else
+    echo "test-pre-push-fastpath: FAIL (${pass} ok / ${fail} bad)" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary

`pre-push` が **変更内容に関わらず** 常に `cargo clippy --all-targets` +
`cargo test --workspace` を走らせ、docs/yaml のみの PR でも数分待つ状態が
iteration 速度を下げていた。silent skip は避けつつ、**diff 内容に基づいた
fast-path 2 種** を追加。

## 変更内容

### 1. `.githooks/lib-fastpath.sh`（新規）

判定ロジックを独立モジュール化。`pre-push`（production）と `scripts/test-pre-push-fastpath.sh`（regression）両方から source。

- **`diff_base()`**: 上流 tracking がある場合 `merge-base(HEAD, @{upstream})`、ブランチが新規なら `merge-base(HEAD, origin/main)`。どちらも解決できないなら return 1（deep path 保険）。
- **`is_docs_only_diff()`**: 全 file が docs-shape パターンにマッチするなら return 0。
  - **docs-shape**: `docs/**` / `.github/**` / `*.md` / `*.yml` / `*.yaml` / `include/*.h` / `LICENSE` / `NOTICE` / `README*` / `CONTRIBUTING*` / `CHANGELOG*` / `.gitattributes` / `.gitignore` / `.editorconfig`
  - **kills fast-path**: `.rs` / `Cargo.toml` / `Cargo.lock` / `rust-toolchain*` / `deny.toml` / `.cargo/*` / `build.rs` / `scripts/*` / `tools/*` / `.githooks/*` / `tests/*` / `integrations/*` / 未知拡張子
  - `VOKRA_HOOK_DEEP=1` は無条件 return 1
  - `fastpath_reason` に理由を set（silent skip 禁止 = FR-EX-08 精神）

### 2. `.githooks/pre-push`（書き換え）

3 段構成:

| step | 変更 | 動作 |
|-----|-----|------|
| **[1/3]** compliance sigpipe test (~5 s) | **常時実行** | 変更なし、cheap ゆえ diff 依存にしない |
| **[2/3]** cargo clippy | Fast-path (a) で **skip 可** | docs-only なら "SKIP cargo clippy — <reason>" 表示 |
| **[3/3]** cargo test workspace | Fast-path (a) で **skip 可** + Fast-path (c) で **cargo-nextest 検出** | docs-only なら skip。deep path で `cargo-nextest` が installed なら `cargo nextest run --workspace` + `cargo test --workspace --doc`（nextest は doc-test 非対応）。未 install なら `cargo test --workspace` に fallback + install hint 表示 |

### 3. `scripts/test-pre-push-fastpath.sh`（新規）

`lib-fastpath.sh` を source し、`git diff` と `diff_base` を fake で shadow して `is_docs_only_diff` を直接呼ぶ **17 cases 全 pass**:

- **Fast-path 6**: single md / several docs / yaml catalog / include/*.h / root dotfiles / LICENSE+NOTICE+README+CHANGELOG
- **Deep-path 9**: `.rs` / `Cargo.toml` / crate `Cargo.toml` / `scripts/` / `tools/` / `.githooks/` (hook self-change) / `tests/` / `integrations/` / 未知拡張子 (`web/pkg/*.html`)
- **Defensive 2**: empty diff → deep / `VOKRA_HOOK_DEEP=1` → deep on docs-only input

### 4. `CONTRIBUTING.md` + `scripts/install-git-hooks.sh`

fast-path / `VOKRA_HOOK_DEEP` / `cargo-nextest` install の説明を追加。

## 期待される効果

| PR 型 | 従来 | 本 PR 後 |
|------|-----|--------|
| docs / yaml のみ変更（handoff 4 items / catalog 更新 / doc 修正）| 数分（clippy + test workspace 実行）| **~5 秒**（sigpipe のみ）|
| Rust 変更 + `cargo-nextest` local install | 数分（`cargo test workspace`）| ~40%（`cargo nextest run` の並列化）|
| Rust 変更 + `cargo-nextest` 未 install | 数分（`cargo test workspace`）| 変わらず（fallback with install hint）|
| VOKRA_HOOK_DEEP=1 | — | 常に full check（意図的 override）|
| VOKRA_SKIP_HOOKS=1 | 全 skip | 変わらず（従来通り、緊急 escape）|

## Safety design

- **silent skip 禁止**: fast-path で skip した場合も理由を毎回 print
- **default は deep**: 判定不能・空 diff・未知拡張子は deep（安全側 fallthrough）
- **hook self-change kills fast-path**: `.githooks/*` 触ったら deep（今回の PR 自身が deep で回る）
- **hard error 禁止**: `cargo-nextest` 未 install でも hint 表示のみで従来動作継続
- **17-case regression test**: `scripts/test-pre-push-fastpath.sh` で分類ロジックを機械検証

## Verify

- `bash scripts/test-pre-push-fastpath.sh`: **17/17 pass**
- 本 branch は `.githooks/*` を触るため実 pre-push は deep-path 確定。commit 時に:
  - compliance scanner sigpipe test OK
  - `cargo clippy --all-targets -- -D warnings` OK
  - `cargo test --workspace` OK（Rust code 無変更ゆえ incremental で速い）
- pre-commit hooks 5/5 pass（fmt / forbidden-symbols / zero-deps / fixture-eol-pins / pipefail-grep-q、72 files scanned）
- C ABI 変更なし・Cargo dep 追加なし・NFR-DS-02 (zero-dep) 保存

## Test plan

- [ ] merge 後、次の docs-only PR で fast-path が実際に発火することを確認（skip 出力を見る）
- [ ] `cargo install cargo-nextest --locked` を local に入れて、Rust 変更 PR の pre-push 時間短縮を実測（60% 目安）
- [ ] `VOKRA_HOOK_DEEP=1` override が動くことを実 push で確認
- [ ] 未知拡張子（例: `web/`, `.json`）を触った PR で deep-path になることを確認
