### PR TITLE
chore: migrate Claude Code workflows to Codex

### DIFF
--- a/.agents/skills/add-audio-operator/SKILL.md
+++ b/.agents/skills/add-audio-operator/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: add-audio-operator
+description: Vokra の audio-dialect オペレータ（STFT/vocoder/flow sampler/codec decode/beam search 等）を新規追加するときに使う。vokra-ops での定義・vokra-backend-cpu のカーネル・属性設計・parity・GPL codec 回避のパターンを示す。
+---
+
+# audio-dialect オペレータを追加する
+
+「最新技術のオペレータ化」は Vokra の中核目標。op は**属性で挙動を明示**し、CPU を第一級 backend として必ず動かす。基本方針は `AGENTS.md` と本skillに従い、実装時は実コードと対応ドキュメントも確認する。
+
+## 1. 定義は `vokra-ops`、カーネルは各 backend（CPU 必須 / Metal / CUDA）
+
+- op の型・属性・shape 検査・reference forward を `crates/vokra-ops/` に定義。
+- 実カーネル（SIMD）は `crates/vokra-backend-cpu/`。**CPU は第一級 backend で必須**（全 backend の下限）。**runtime dispatch**（x86-64: SSE2 baseline→AVX2+FMA 主力、ARM64: NEON baseline→dotprod/i8mm）。RTF 最優先で `unsafe` + SIMD intrinsics を積極使用してよいが、**各 `unsafe` に `// SAFETY:` 必須**（`undocumented_unsafe_blocks = deny`）。公開 API 境界は safe に保つ。`unsafe` 許可 crate は `vokra-ops` / `vokra-backend-cpu` / `vokra-backend-metal` / `vokra-backend-cuda` / `vokra-capi` / `vokra-mmap`（crate root で `#![allow(unsafe_code)]`。`vokra-core` は unsafe-free）。
+- **GPU backend が要るなら 2 経路のどちらかに配線**（非対応 op は必ず明示 `UnsupportedOp`、**silent CPU fallback 禁止** = FR-EX-08）:
+  - **グラフ経路** — `vokra-core` の `Backend::eval_op`（default = `UnsupportedOp`）を `vokra-backend-metal` / `vokra-backend-cuda` が対応 op だけ override（`run_graph`（`vokra-core/src/runtime/`）が topo 順に駆動）。
+  - **imperative 経路（モデル hot op）** — `vokra-models/src/compute.rs` の `Compute` seam（Cpu/Metal/Cuda を enum dispatch、`HotOp` に列挙 = GEMM/GEMV/softmax/layer_norm/gelu/conv1d、`for_backend` が model 必要 op を全網羅しなければ `UnsupportedOp`）。Metal=objc_msgSend、CUDA=libcuda/libnvrtc の手書き生 FFI。metal/cuda は**既定 OFF の first-party optional feature** ゆえ zero-dep 不変条件は不変。音声 op 自体（STFT/vocoder 等）の GPU カーネルは現状ほぼ未配線で CPU 実行、GPU 化するなら上記いずれかに追加する。
+- **device 常駐融合（readback 削減パターン）**: 複数連続 op を 1 submission に融合するときは、**中間を DeviceTensor（`!Send` / `'ctx` / Drop で release）として device 上に保持**し、host readback を削減する（例: `MetalContext::encode_prenorm_stack` = n blocks の ln→attn→residual→ln→mlp→residual+final ln を 1 submission、encoder 全体で 6N+1→1 readback。`MetalDecodeSession` / `CudaDecodeSession` = decoder-step の self KV append + causal fused attn + cross attn + MLP を device 常駐化、logits のみ D2H）。融合実装は **per-op GPU 経路と bit-identical** が要件（新しい数値を持ち込まない、readback 位置のみを動かす）。parity は skill `numerical-parity` の GPU backend parity 節。
+
+## 2. 属性を明示的に設計する（暗黙のデフォルト禁止）
+
+音声 op は「暗黙の前提」が事故る。属性として明示する：
+
+- **`stft` / `istft`**: window(Hann/Hamming/Blackman-Harris/Kaiser)、hop_length、n_fft、center-padding、pad_mode、normalization('forward'/'backward'/'ortho')、causal-mode、real_input(RFFT で2倍高速)。**STFT ≠ FFT** — framing + window + normalization + causal の設計が本質（レビュアー C 指摘 #1）。
+- **vocoder**: `snake_activation` は internal_precision 属性（デフォルト FP32、BF16 mantissa 損失が問題）。**Vocos / BigVGAN は INT8 で崩壊 → fp16 必須**、HiFi-GAN は INT8 慎重。
+- **flow/diffusion sampler**: cfg_mode ∈ {none, split_batch, dual_forward}、cfg_scale、nfe、schedule ∈ {linear, sway, epss}。
+- **codec**: RVQ（paged block size 2-4）と FSQ（単段 GEMV）は別サブグラフ。
+- **search**（`beam_search`/`ctc_decode`/`rnnt_decode`）は **host-side runtime 関数**（model graph に埋めない、"contrib op" アンチパターン回避、FR-OP-40）。`crates/vokra-core/src/decode/` に置く。
+
+## 3. GPL / 非商用 codec を持ち込まない
+
+- **soxr / rubberband（GPL）禁止** → resample は speexdsp(BSD) resampler 設計ベースの自前実装。
+- FFT は pocketfft(BSD-3) アルゴリズムの自前 Rust 移植（`crates/vokra-ops/src/fft/`、`NOTICE` §3 に既記）。
+- **【2026-07-22 訂正】BigVGAN は MIT**（`github.com/NVIDIA/BigVGAN/LICENSE` = 標準 MIT `Copyright (c) 2024 NVIDIA CORPORATION`）。旧記述「Source Code License-NC で非商用ゆえ論文からスクラッチ再実装」の**非商用前提は失効**し、スクラッチ制約は解除 = reference の直接移植が MIT 帰属表示で可能（移植時は `crates/vokra-ops/THIRD_PARTY_LICENSES/bigvgan-LICENSE.txt` に MIT 全文を同 PR で同梱、`NOTICE` §1 + §9 / `docs/license-audit.md` BigVGAN 行）。
+- **EnCodec weight は CC-BY-NC → 公式 zoo 除外**。DAC/Mimi/WavTokenizer/X-Codec2 が商用 OK 候補。
+- 新 codec/依存の追加時は skill `license-audit` を通す。
+
+## 4. frontend 系は bit-exact
+
+- Mel フィルタは librosa/torchaudio/TF で bit-exact でない。frontend op は `vokra.frontend.*` metadata を検査し、不一致なら warn/fail（レビュアー C 指摘 #2）。Slaney/HTK 両対応。
+
+## 5. parity と検証
+
+→ skill `numerical-parity`（torch / scipy / librosa reference と照合、fixtures はオフライン生成をコミット）。最後に：
+
+```
+cargo test --workspace
+cargo clippy --all-targets -- -D warnings
+cargo fmt --all -- --check
+bash scripts/check-zero-deps.sh
+```

--- a/.agents/skills/add-speech-model/SKILL.md
+++ b/.agents/skills/add-speech-model/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: add-speech-model
+description: Vokra に新しい音声モデル（TTS / ASR / S2S / VC / Speaker-ID / VAD / 音楽生成 / 音声分離 / 音声 LLM）対応を追加するときに使う。native 自前再実装・GGUF 変換・数値 parity・ライセンス/法務/model-zoo ゲートまでの全手順とレッドラインを示す。
+---
+
+# 音声モデルを Vokra に追加する
+
+新規モデル対応 PR の標準手順。**設計レッドライン（下記）を跨ぐ実装は品質に関わらず却下**（CONTRIBUTING.md §5）。基本方針は `AGENTS.md` と本skillに従う。
+
+## 0. 事前判断（着手前に必ず）
+
+- **スコープ判定**: 音声 AI 全域が in-scope（2026-07-30 依頼者 override、旧「TTS/ASR/VAD/Speaker-ID のみ」の絞りは廃止）。**新たに含まれる**: 音楽生成（MusicGen / Stable Audio / ACE-Step 等）／音声分離（SepFormer / Demucs / TIGER 等）／音声 LLM（Voxtral / Qwen2-Audio / Moshi 等）。**out-of-scope 継続**: 汎用 LLM、CV、multimodal（vision 側）— [[project-scope-expansion-2026-07-30]]。
+- **ライセンス audit を先に通す** → skill `license-audit`。weight が **CC-BY-NC / CC-BY-NC-SA / 学習データ権利不明**なら公式 model zoo から除外し、engine 対応のみ・research flag 分離（例: F5-TTS, Fish-Speech は weight 非配布）。
+- 用途が **voice cloning（RVC / VC / speaker cloning の trigger 側）** なら core に入れない → 別リポジトリ `vokra-voiceclone-experimental`（ELVIS Act / NO FAKES Act、AGENTS.md 設計判断 #8）。**speaker embedding 抽出は core に残す**（zero-shot TTS 必須）。voice-clone の共通 op（F0 抽出等）は core に残し、trigger model のみ別リポへ。
+
+## 1. native 自前再実装（whisper.cpp 型）
+
+- モデル定義を Rust で自前実装し、**上流の safetensors checkpoint のみ**を使う（`torch.onnx.export` の dynamo/scriptmodule 分裂に耐性）。既存例: `crates/vokra-models/src/whisper/`（base〜large-v3）, `.../piper_plus/`, `.../silero_vad/`, `.../speaker/`（CAM++ speaker encoder）。
+- **GPU backend 対応は `Compute` seam 経由**（`vokra-models/src/compute.rs`）: モデルの hot op（GEMM/GEMV/softmax/layer_norm/gelu/conv1d）を CPU kernel 直呼びでなく `Compute` に通すと、feature=metal/cuda build 時に Metal/CUDA へ swap できる（既定 CPU、非対応 backend は明示 `UnsupportedOp` = silent CPU fallback 禁止 FR-EX-08）。Whisper / piper-plus / CAM++ は配線済み。GPU parity は device-gated で CPU を oracle にする（→ skill `numerical-parity`）。
+- **runtime に ONNX を絶対に入れない**（FR-LD-05、恒久）。onnxruntime / onnx / protobuf / prost / ort への依存禁止（deny.toml で ban 済み）。
+- **piper-plus 系は native 自前実装**（wrap 廃止・依頼者決定 2026-07-02）。G2P（8 言語）のみ当面 piper-plus 実装を流用。
+- **eSpeak-NG 禁止**（GPL-3.0）。G2P は piper-plus 独自 or IPA 辞書ベース。
+- ハイパラは **`vokra.*` GGUF metadata から読む**（ハードコード禁止、FR-LD-02 / FR-MD-02）。
+- Silero VAD のような recurrent/学習済み前処理を持つモデルは **1:1 保存の専用 subgraph**にし、汎用 audio-dialect op に落とさない（FR-LD-06 / NFR-QL-05）。
+
+## 2. GGUF オフライン変換（`vokra-convert`）
+
+- 上流 checkpoint → GGUF 変換は `crates/vokra-convert/` に追加。ONNX / protobuf を扱うのはこの**オフラインツールのみ**（runtime 側には持ち込まない）。
+- 音声固有 metadata は **`vokra.*` prefix の独自 chunk** で焼き込む（llama.cpp 本体との命名衝突回避、AGENTS.md 設計判断 #3）。frontend を持つモデルは `vokra.frontend.*`（n_fft/hop/win_length/window_type/mel_norm/htk_mode/fmin/fmax/n_mels/pad_mode/sample_rate 等）を必須で書く（bit-exact 再現、レビュアー C 指摘 #2）。
+
+### 2.1 事前 merge が要る checkpoint 形状
+
+以下は **vokra-cli convert に直渡しできない** — Python sidecar で事前処理してから渡す。
+
+- **sharded safetensors（`model.safetensors.index.json` + 複数 `model-*-of-*.safetensors`）**: `vokra-cli` は直渡し不可（"safetensors buffer truncated" で落ちる、例外は Voxtral の streaming reader だけ）。→ `tools/parity/<slug>_prepare_checkpoint.py` を書いて事前 merge。既存例は `kokoro_prepare_checkpoint.py` / `nemo_pt_to_safetensors.py`。**int64/f64/bool は f32/f16 に strip**（GGUF writer が受けない dtype を潰しておく）。[[project-vokra-cli-sharded-safetensors]]。
+- **tied embedding（shared tensor）**: `safetensors.torch.save_file` は複数 name が同一 `data_ptr` を指すと `RuntimeError`。Bark / XTTS-v2 / MOSS 変種の MLM head や LM head が該当。→ dedup が必須:
+  ```python
+  seen: dict[int, str] = {}
+  shared_pairs: list[tuple[str, str]] = []
+  for n, t in list(kept.items()):
+      ptr = t.data_ptr()
+      if ptr in seen:
+          shared_pairs.append((seen[ptr], n))
+          kept[n] = t.clone().contiguous()  # 別領域にコピーして collision 解消
+      else:
+          seen[ptr] = n
+  # shared_pairs は shared_pairs.json に audit trail として吐く（後で復元ロジックが要る）
+  ```
+  [[reference-safetensors-shared-tensor-dedup]]。
+- **5D 以上の tensor**: GGUF writer は現状 4D まで（>4D は `"too many dimensions: 5"` で hard-error）。Qwen2.5-Omni 系 multimodal adapter が該当し publish blocked。回避 = writer 拡張 or `reshape(5D → 4D + metadata)`、判断は M6 investigation phase。着手前に上流 tensor shape を `python -c "import safetensors; ..."` で確認して 5D を含むなら **converter に着手しない**。[[project-gguf-5d-tensor-limit]]。
+
+### 2.2 大モデル（>8 GB safetensors）は M1 iMac で変換しない
+
+- 依頼者機（M1 iMac 16 GB）で >8 GB safetensors を mmap すると swap が急伸して macOS が強制終了する（Voxtral-Small-24B 48 GB で swap 40 GB 到達実証）。→ **vast.ai へ escalate** → skill `vast-ai-workflow`。
+- 安全ライン: whisper-* / csm-1b（6.21 GB tight OK）/ kyutai-stt（5.23 GB）/ parakeet-* は M1 OK。要 vast.ai: Voxtral-Small-24B / Kimi-Audio-7B 系 / 30B+。
+- 既存 GGUF の provenance 差替のみなら `restamp_provenance`（mmap 読取 + `GgufStreamWriter` で tensor コピーせず metadata だけ差替、8.7 GB Voxtral を M1 16 GB で peak footprint 6.4 MB で実測）→ skill `publish-model-to-hf` §restamp。[[project-restamp-provenance]]。
+
+## 3. 新規 op が要るか（gap analysis）
+
+- 必要 op が既存（`vokra-ops` / `vokra-backend-cpu`）で揃うか確認。足りなければ skill `add-audio-operator`。Whisper base は gap ゼロだった（`whisper/mod.rs` の inventory 表を参照）。
+
+## 4. 数値 parity（必須）
+
+→ skill `numerical-parity`。PyTorch/onnxruntime reference と MEL loss / UTMOS / WER 等で照合。**モデル6種中3種以上で 5% 超劣化は品質ゲート違反（要調査・リリースブロック相当）**。fixtures は必ずオフライン生成・実データをコミット（捏造厳禁）。
+
+## 5. TTS / VC は法務チェックリスト
+
+- `docs/legal-compliance.md` を通す（EU AI Act Article 50 / California SB 942）。**watermark / C2PA 埋め込み（FR-CP-01 AudioSeal / FR-CP-02 C2PA）は 2026-07-04 依頼者ドロップで未実装**: `vokra-core` の `WatermarkConfig` は config 面のみで、`backend_status` は常に `Deferred`（埋め込み backend 未配線 — 偽の marker を付けない方針）。model-zoo 可否・weight license は下記 compliance gate（→ skill `license-audit`）で runtime 強制する。
+
+## 6. ドキュメント更新（同一 PR 内）
+
+- `docs/license-audit.md` に行追加（code/weight ライセンス・商用可否・学習データ由来）。
+- attribution / 配布条件があれば `NOTICE` に追記（例: Mimi は CC-BY 4.0 で credit 要）。
+- 対応表（AGENTS.md の「対応モデル」）と対応時期を更新。
+- 調査値・レイテンシ・パラメータ数は **出典必須**（ハルシネーション厳禁）。不明なら `docs/_research/*.md` を読み返す。
+
+## 7. 検証してコミット
+
+```
+cargo test --workspace
+cargo clippy --all-targets -- -D warnings
+cargo fmt --all -- --check
+bash scripts/check-forbidden-symbols.sh
+bash scripts/check-zero-deps.sh
+cargo deny check licenses advisories bans
+```
+
+CONTRIBUTING.md §4（Adding support for a new model）のチェックリストと突き合わせて漏れがないか最終確認する。

--- a/.agents/skills/license-audit/SKILL.md
+++ b/.agents/skills/license-audit/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: license-audit
+description: Vokra に新しいモデル weight・依存 crate・codec を追加する前後にライセンス/配布可否を監査するときに使う。deny.toml・docs/license-audit.md・NOTICE・model-zoo 除外・zero-dependency ルールを通す手順を示す。
+---
+
+# ライセンス audit を通す
+
+Vokra は Unity / Godot / 商用組み込みを標的にするため、ライセンス違反は致命的。**GPL/LGPL 混入 PR はマージ不可**（NFR-LC-04）。単一事実源は `docs/license-audit.md` と `deny.toml`。
+
+## 依存 crate（最優先ルール: zero-dependency）
+
+- **外部 crate を足さない**（NFR-DS-02）。runtime / C ABI / models は **first-party `vokra-*` crate のみ**。まず std / 自前実装で解決できないか検討。
+- どうしても必要なら設計レッドライン判断として escalate（`bash scripts/check-zero-deps.sh` が Cargo.lock を検査し、`vokra-*` 以外があれば fail）。
+- **`cargo add` は Codex hook でブロック**される（`.codex/hooks.json`）。
+- ライセンス許可域: **Apache-2.0 / MIT / BSD 系のみ**。GPL/LGPL は全面禁止。MPL-2.0（例: symphonia）は file-level copyleft を case-by-case 評価。
+- **protobuf / prost / onnx / onnxruntime / ort / tract-onnx は deny.toml で ban**（FR-LD-05: runtime は ONNX を絶対にロードしない）。新種が現れたら deny.toml に追記。
+
+## モデル weight
+
+- **CC-BY-NC / CC-BY-NC-SA / 学習データ権利不明 → 公式 model zoo から除外**。engine 対応のみ・research flag で weight 非配布（例: F5-TTS = CC-BY-NC 4.0、Fish-Speech = CC-BY-NC-SA 4.0、EnCodec weight = CC-BY-NC）。
+- 商用 OK 候補: DAC(MIT) / Mimi(CC-BY 4.0・**attribution 要**) / WavTokenizer(MIT) / X-Codec2(MIT) / Kokoro(Apache 2.0) / piper-plus(MIT・依頼者作)。
+- **Piper（OHF-Voice/piper1-gpl）は非対応**（GPL-3.0 + eSpeak-NG 二重汚染）。**eSpeak-NG（GPL-3.0）も core 非対応**。
+- **【2026-07-22 訂正】BigVGAN は MIT**（旧記述「NVIDIA Source Code License-NC → 論文からスクラッチ再実装」の**非商用前提は失効**、reference の直接移植が MIT 帰属表示で可能。AGENTS.md §Vocoder chain 参照）。旧「scratch reimpl」の `NOTICE` §1 記述は現在更新済。
+
+## LicenseClass の SPDX 不整合ケース（converter 側で hard-map）
+
+`vokra-core::compliance::LicenseClass` は SPDX 文字列から派生する（`from_license_str`）が、**SPDX 未登録のライセンス**は `Unknown` に落ち、upload gate 2/4（redistributable）で fail-closed refuse される。上流独自ライセンスの hard-map パターン:
+
+- **CPML（Coqui Public Model License）** = SPDX 未登録。converter 側で SPDX resolver より前に `NonCommercial` に hard-map（XTTS-v2 系、`crates/vokra-convert/` 内 model 実装で明示）。加えて publish は `--allow-noncommercial` 明示 + `fetch_license.sh --url <上流 LICENSE.txt>` で実文書同梱。[[reference-cpml-spdx-nonregistration]]。
+- **`from_license_str` の順序 = 特殊 → 一般で書く**（2026-07-23 latent bug 修正）: SA/AGPL/GPL の matcher を plain `cc-by` より先に置かないと `cc-by-sa-4.0` が `AttributionRequired` に誤分類される。新種を追加するときは pin test を追記（既存 pattern に倣う）。
+- **HF vocabulary は SPDX と別空間**: `license: MIT`（upper-case）は HF API で 400 reject、`mit` に lower-case + dual 表現は `other`。publish 時は `hf_license_tag()` normalize を通す（skill `publish-model-to-hf` §tier）。
+
+## compliance gate（runtime 強制、オフライン監査を補完）
+
+`docs/license-audit.md` は**オフライン監査**だが、runtime も weight license を強制する。
+
+- `vokra-core/src/compliance/` の `CompliancePolicy` + `LicenseClass` gate が **GGUF の `vokra.provenance.*` metadata**（`weight_license` / `license` / `model_id`）を読み、**CC-BY-NC 等の NC weight を research flag なしでロード拒否**する（`VokraError` を返す）。
+- research weight（F5-TTS / Fish-Speech / EnCodec）は **research flag を明示的に立てたときのみ**解禁（`CompliancePolicy::with_research_license`、または config level が Research / Disabled）。既定（Standard）は拒否。
+- 新 weight を公式 model-zoo に足すときは converter で `vokra.provenance.weight_license` に正準クラスを焼き込み、gate が読めるようにする（オフライン監査行と一致させる）。
+
+## codec / DSP
+
+- **soxr / rubberband（GPL）禁止** → speexdsp(BSD) / pocketfft(BSD-3) 設計ベースの自前実装。AEC は SpeexDSP(BSD) / WebRTC AEC3 port。
+
+## §3.1 sign-off の primary-source rule（fail-closed default、CC は勝手に埋めない）
+
+`docs/license-audit.md` §3.1 の sign-off 欄は **依頼者（owner）の判断印**。fail-closed default = 空欄のままロックされ続けることが正しい振る舞い。以下 2 条件が **両方揃った時のみ** CC 側で埋めてよい:
+
+1. **依頼者が明示的に「自主判断で埋めてよい」と言った**（session 内の直接発話 or AGENTS.md 記載、暗黙推定は禁止）
+2. **primary source で license class が clean と確認できた**:
+   - upstream repo の LICENSE ファイル本文（GitHub raw、fork の README ではない）
+   - authenticated HF API（`hf_hub_download` の meta 経由、README の「license:」だけを信じない）
+   - upstream publish の DOI / 論文ライセンス声明
+
+**署名は依頼者指示に従い `yousan`**（handle）+ 日付。判断根拠を row の右端に「(依頼者許可 = CC 判断)」で明記。片方でも欠けたら **空欄据置** — 現状の CC が埋めた row は monotonic に増えるだけで、fail-closed の default を破らない。
+
+**precedent 例**:
+- **CSM-1B ☑ Commercial** (2026-07-28): authenticated HF API で `license=apache-2.0` clean、README "Misuse and abuse" は非拘束 advisory precedent（Bark row 259 と同型）→ CC 判断で埋めた。
+- **VibeVoice-Large ☑ Rejected** (2026-07-28): authenticated HF API で HTTP 404 = microsoft が withdraw、Community mirror は権限を継承しないので mirror が何個あっても Rejected → fail-closed 正常機能。
+- **X-Codec-2 T4 Research-only** (2026-07-28): cc-by-nc-4.0 primary source、`--allow-noncommercial` 明示必須、初 precedent。
+- **Bark row 259 = 非拘束 advisory 前例**: HF `suno/bark` の README「for research purposes」文言は Apache-2.0 の下では拘束力を持たない advisory と判定、以降の類似モデル判定で cite。
+
+[[feedback-license-signoff-primary-source]]。sign-off の実務手順（publish gate との連携）は skill `publish-model-to-hf` §4 を参照。
+
+## 手順（新規追加 PR、同一 PR 内で完結させる）
+
+1. `docs/license-audit.md` に行追加（**code と weight 双方**のライセンス・商用可否・学習データ由来）。§3.1 sign-off 欄は **上記 primary-source rule** に従い、条件未達なら空欄据置。
+2. attribution / 配布条件があれば `NOTICE` に追記（credit 要・NC・scratch-reimpl の別を明記）。
+3. TTS/VC なら `docs/legal-compliance.md`（EU AI Act Art.50 / SB 942）も通す → skill `add-speech-model`。**watermark / C2PA 埋め込み（FR-CP-01/02）は 2026-07-04 依頼者ドロップで未実装**（`WatermarkConfig` は config 面のみ・`backend_status`=Deferred）。weight license は上記 compliance gate で強制。
+4. HF 公開する場合 → skill `publish-model-to-hf`（5-tier gate）。
+5. ゲートを走らせる:
+
+```
+cargo deny check licenses advisories bans
+cargo audit
+bash scripts/check-forbidden-symbols.sh
+bash scripts/check-zero-deps.sh
+python3 scripts/publish/signoff_match.py --self-test
+```
+
+CONTRIBUTING.md §3（dependency license policy）/ §4（new model）と突き合わせる。

--- a/.agents/skills/numerical-parity/SKILL.md
+++ b/.agents/skills/numerical-parity/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: numerical-parity
+description: Vokra の op / モデルを PyTorch など reference 実装と数値照合する parity テストを追加・更新するときに使う。**reference dumper を書く / parity の許容誤差 (atol/bound) を変更する / parity が落ちた** ときは必ず読む。オフライン reference 生成 → fixtures コミット → Rust parity テストの手順に加え、reference の独立性（自作 mirror は何も検証しない）と許容誤差を緩める前の判断基準を示す。
+---
+
+# 数値 parity テストを追加する
+
+reference 実装との数値一致は Vokra の品質背骨（NFR-QL-01）。**CI で Python / onnxruntime は一切実行しない** — reference fixtures はオフラインで生成してコミットする。reference-fixture parity は `parity` job（`cargo test -p vokra-parity`）、GPU backend の parity は `gpu-backends` job と各 backend/models crate（下記「GPU backend parity」）。
+
+## 大原則（捏造厳禁）
+
+- reference の数値は **必ず実際の reference 実装で生成**する。ライブラリが手元に無いなら **数値を発明しない** — `#[ignore]` の shell テストとして比較ロジックだけ書き、fixtures 生成後に有効化する（既存例: `tests/parity/tests/reference_ignored.rs`）。
+- 生成は **byte-reproducible**（固定 seed。既存の numpy 系は seed=1234）。版数を pin して再現性を担保。
+
+## 大原則 2: reference は「独立」でなければ何も検証しない
+
+**parity が緑でも、reference が独立でなければ検証はゼロ**。これは仮説ではなく実際に起きた（Kokoro、2026-07-16 / 修正 `92dbc92`）:
+
+> dumper が upstream package ではなく **実装と同じ理解で書かれた再実装**を叩いていた。両者は同じ誤りを共有していたので **9/9 tensor PASS**。しかし実際に合成した音声は **round-trip WER 1.0 = 完全に意味不明**だった。原因は 11 箇所（LeakyReLU slope、ALBERT 層数、decoder 入力、F0/N 配線、duration 式…）。**parity suite は 1 つも捕まえていない。**
+
+したがって dumper を書くときは:
+
+1. **upstream package を import する**（`import kokoro` / `from transformers import X`）。自分で層を書き直して「同じはず」の値を出してはいけない。**それは reference ではなく 2 つ目の実装**。
+2. **import できないなら loud abort**。「無ければ再実装に fallback」は最悪の分岐 — 静かに無意味な緑を作る（FR-EX-08 の精神）。
+3. dumper header に **何を import して何処に hook したか**を書く（例: `tools/parity/dump_kokoro_reference.py`）。
+4. upstream が無い / 使えない場合は **その旨を fixtures の README に明記**し、parity ではなく「self-consistency の pin」だと名乗る。名前を正しく付ければ、後任が過信しない。
+
+**匂いのチェック**: その reference は「自分の実装が間違っていたら**違う**値を出す」か？ 出さないなら reference ではない。
+
+## 大原則 3: 許容誤差は「広げる」方向に動かさない
+
+**測定値が bound を超えたとき、既定の行動は bound を上げることではない。** これも今日踏みかけた（Kokoro pcm、2026-07-19 / 撤回 `1419964`）:
+
+> Linux CI で pcm max が gate を 8.5% 超過。分布を見ると Linux は bulk ではむしろ高精度（mean が低い）で、違いは外れ値だけ — 「プラットフォーム差だから広げてよい」と判断しかけた。しかし **x86 の観測は 1 点しかなく**、その経路の x86 SIMD kernel は実機で走ったことがなかった。「プラットフォーム外れ値」と「局所的な kernel バグ」は集計統計では区別できない。撤回。
+
+判断基準:
+
+- **max ゲートは局所破損**を、**mean ゲートは系統ドリフト**を捕まえる。**max を緩めることは局所バグの検出力を捨てること**。
+- 「機構が説明できる」は**仮説**であって診断ではない。**最悪 bin を実際に見に行く**（その位置の値は? 近傍は? 別プラットフォームでも同じ位置か?）。
+- 1 プラットフォームの実測から導いた bound は**不完全**だが、それは「もう 1 点で広げてよい」を意味しない。**両方を説明する機構を特定してから**動かす。
+- 緩めるより **OPEN として記録して赤のまま残す**方が誠実なことが多い（advisory な suite ならブロッカーですらない）。
+- 動かす場合は **理論下限 × 1.5〜2**、rustdoc + ADR + CI YAML に **冗長に**根拠を記録（既存例: Kokoro decoder の branch-cut bound）。
+
+## 大原則 4: 環境を記録してから読む — 「flaky だから再実行」は最も危険な誤読
+
+大原則 3 の Kokoro pcm を追った実例。**2 段階で、1 段目の結論は自分で誤っていた**ので、その訂正込みで記録する。
+
+**1 段目（`c977e14`、部分的に誤り）**: kokoro に無関係な commit（skills/hooks のみ）を挟んだだけで報告される全テンソルが動いた — text_encoder 23% / decoder_pcm **175%（FAIL → PASS）**。原因は、この CI job が committed fixture を使わず**参照を毎回 runner 上の upstream torch から再生成**していたこと。比較の両辺が同じ runner で計算され、両方とも CPU feature で dispatch する（自前 ISA 選択 / MKL·oneDNN）。ここまでは正しい。しかし私はこれを「**run 間分散**」「別の draw」と表現した。
+
+**2 段目（`d3c5093`、訂正）**: 1 段目で追加した環境記録が、初回の run で 1 段目の枠組みを反証した。`cpu=AMD EPYC 7763 / isa=avx2 / torch=AVX2` の run が、3 commit 前の run を**全テンソル・全桁で bit-identical に再現**した。つまり **CPU クラス内では完全に決定的**で、分散でも draw でもない。実際の帰結は flakiness の逆:
+
+> **AVX2 runner なら 100% 落ち、AVX-512 runner なら 100% 通る。**「とりあえず再実行」は当たるマシンを引き直しているだけ。
+
+この誤りの方向性が重要: 「分散」「flaky」という語彙は**実在する欠陥を却下しやすくする方向**に効く。parity で最も避けたい失敗そのもの。
+
+決め手になった読み方:
+
+- **どのテンソルが動いたかを見る**。`text_encoder` は 4096 要素・前段・**decoder とコードを共有しない**。decoder kernel のバグでは動かせない。それが動いた時点で原因は環境側に確定する。**変動幅ではなく変動の「広がり方」が診断情報**。
+- **同一環境で bit-identical に再現するか**を見る。再現するなら決定的であり、**説明すべき対象が実在する**。再現しないなら初めて非決定性（スレッド数・並列 reduction 等）を疑う。
+- ただし**環境が同じことを確定するまで、決定的か否かは判定できない**。だから記録が先。
+
+手順として:
+
+1. **実行環境を記録する**（CPU model / ISA flags / nproc / `torch.backends.cpu.get_cpu_capability()`）。**数値を出す前**のステップに置き、`if: always()`、gate にはしない。記録が無ければ何も判定できない。
+2. **参照がどこで生成されているか確認する**。CI が参照を再生成しているなら「実装 vs 固定 oracle」ではなく「実装 vs **環境依存** oracle」。
+3. **1 点で bound を動かさない**（大原則 3）。ただし理由は「分散だから」ではなく「**環境が特定できていないから**」。
+4. **失敗したその実機上で切り分ける**。自前 SIMD だけを無効化して（Vokra なら `VOKRA_CPU_ISA=scalar`）参照はそのままに再測定する:
+   - **scalar ≈ SIMD** → 自前 kernel は無罪、差はアルゴリズム or 参照側
+   - **scalar << SIMD** → その ISA の micro-kernel が真犯人。**kernel を直す。bound は動かさない**
+
+   これは開発機が別 ISA のとき（M1 で x86 tile は実行不能）**CI でしか取れない測定**。失敗パス限定 + 非致命にして、既に確定した verdict を上書きしないこと。
+5. heavy-tailed な統計（~10^5 サンプルの max）を**観測に合わせて fit しない**。CPU クラスごとに 1 段ずつ gate が開き、検出力だけが失われる。**真犯人が kernel の可能性が残っている間に広げることは、その kernel バグが出す唯一の信号を消すこと**。
+
+## 手順
+
+1. **reference をオフライン生成**。crate は `tests/parity`（test-only、`publish = false`、`vokra-parity`）。
+   - 依存は `tests/parity/parity-requirements.txt` に pin（`numpy>=1.26,<3` が必須。`torch>=2.2` / `librosa>=0.10` / `scipy>=1.11` は optional）。**再生成時は版数を固定**。
+   - op 系: `uv run --project tools/parity python tests/parity/gen_parity_fixtures.py {all|stft|mel|dct}` (owner directive 2026-08-01「python は uv から実行」に準拠、Python 3.12 pin per pyproject.toml)。
+   - モデル系: 各 suite の `gen_reference.py`（例: `tests/parity/silero_vad/`, `tests/parity/piper_plus/`, `tools/parity/dump_whisper_reference.py`）。
+2. **fixtures を `tests/parity/<suite>/` にコミット**（`.f32` raw / `.txt` / `manifest.txt` / `README.md`）。各 suite の README に **reference 実装・入力・許容誤差**を明記（NFR-QL-01）。
+3. **Rust parity テストを書く**。
+   - **FP32: `atol = 0.01`**（`vokra_parity::FP32_ATOL`）。INT8: `atol = 0.05`（量子化パス導入後）。reference は f64、vokra は f32 である点に留意。
+   - モデル固有基準（MEL loss / UTMOS / WER / CER 等）は per-suite doc に記述。
+4. **検証**: `cargo test -p vokra-parity`（committed fixtures のみで green）。ignore shell は `cargo test -p vokra-parity -- --ignored`。
+
+## GPU backend parity（Metal / CUDA）
+
+GPU backend は **reference fixtures を持たず、CPU backend を oracle にする**（同じ per-(backend, op) kernel の別実装なので、CPU parity が通っていれば CPU が真値）。
+
+- **device-gate（skip、fail しない）**: Metal は `MetalContext::new` / `vokra_metal_probe`、CUDA は device probe で gate。device が無い host は skip（GGUF-gated の model parity と同じ「runner に実機が要る」方針）。CI の `gpu-backends` job は **Metal を Apple-silicon macOS runner で実行**、CUDA は GitHub に NVIDIA GPU が無いので build/lint のみ（実機 parity は **vast.ai RTX 4090**）。
+- **許容誤差は CPU parity と同じ FP32 `atol = 0.01`**。`vokra-backend-{metal,cuda}/tests/parity_{metal,cuda}.rs`（GEMM）と `parity_kernels_{metal,cuda}.rs`（gemv/softmax/layer_norm/gelu/conv1d）が GPU 出力を CPU kernel 出力と比較（観測誤差は遥かに tight）。
+- **fused op（`Compute::mlp_f32` / `attn_f32` / `encode_prenorm_stack` / decoder-step session）は per-op GPU 経路と bit-identical**（1 GPU submission で中間を device 常駐、readback 削減のみ＝新しい数値ではない）。CPU arm の `mlp_f32` は fusion 前の 3-kernel 列と bit-for-bit 一致（CPU parity 維持）。**causal fused attention は host mask+softmax と IEEE-754 bit-identical**（masked col が `exp(-inf)=0` で寄与ゼロ）。**device KV cache append は host project+concat と 7.15e-7 一致**（M1 実測）。
+- **e2e（`vokra-models/tests/parity_whisper.rs`、GGUF-gated）**: encoder / decoder logits は `atol = 0.01` 内、**greedy token 列は CPU と完全一致（`assert_eq`）** を要求（最も強い e2e 判定）。**whisper base full e2e greedy は Metal M1 と CUDA RTX 4090 の双方で CPU と完全一致（5/5 tokens）を実証済み**（Phase 3b、encoder 1.32e-3 / decoder logits 4.29e-5）。
+
+## 品質ゲート（忘れない）
+
+- v0.1 MVP でモデル6種中 **3種以上** が PyTorch reference 比で **MEL loss / UTMOS 5% 超劣化**した場合は品質ゲート違反（要調査・リリースブロック相当）。parity 劣化は音声品質に直結する。
+
+## 落とし穴
+
+- **STFT ≠ FFT**、**frontend は bit-exact でない**（librosa/torchaudio/TF で Mel フィルタが差異）。frontend 系は `vokra.frontend.*` を検査（レビュアー C 指摘 #1/#2）。
+- onnxruntime は内部で FP16→FP32 に cast することがある（piper parity は FP32 native で一致した実績）。reference の内部精度を確認してから許容誤差を決める。
+- **合成 weight の parity は「構造」しか守らない**。実 checkpoint + 実音声で初めて出る欠陥が実測 9 系統あった（2026-07-16/17 の実 weight 評価: Silero の rolling context 欠落で実音声検出 0、Voxtral converter が weightless GGUF を exit 0 で出力、CosyVoice2 の attention bias 欠落…）。合成 fixtures が緑でも **flip-the-switch を早く回す**。記録: `docs/bench-baselines/m1-real-weight-eval-2026-07-16/`。
+- **per-tensor の atol override は「理論下限」を騙りやすい**。Kokoro の `PROSODY_F0_ATOL = 0.05` は「architecturally 到達不可なので honest」と文書化されていたが、実際には **flawed reference の artifact** で、真の upstream に対しては 3.0e-3（default `ATOL = 0.01` の内側）だった。override を足す前に「reference は正しいか」を先に疑う。

--- a/.agents/skills/publish-model-to-hf/SKILL.md
+++ b/.agents/skills/publish-model-to-hf/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: publish-model-to-hf
+description: Vokra の GGUF を huggingface.co/vokra 配下に公式配布するときに使う。5-tier gate（catalog-reality / redistributable / provenance / §3.1 sign-off / allow-noncommercial）+ publish-one.sh / fetch_license.sh / upload.sh の chain + T4 (Research-only) precedent + restamp_provenance の低メモリ再刻印 + HF vocabulary normalize を示す。**手動 upload は禁止**、必ず publish-one.sh 経由。
+---
+
+# GGUF を huggingface.co/vokra に公開する
+
+**単一事実源**: `scripts/publish/publish-one.sh` のスクリプト冒頭コメント。本 skill はそれを skill 表現に翻訳したもの。実装との drift は script が SoT で本 skill を追随する。
+
+**大原則**: `hf` CLI や `huggingface_hub.upload_file` を CC が直接叩かない。**必ず `publish-one.sh` chain 経由**。理由 = 5 段 gate を bypass する経路が存在すると gate は fail-closed default を保てない。
+
+## 0. 事前判断（着手前）
+
+- **ライセンス audit を先に通す** → skill `license-audit`。§3.1 sign-off が空欄なら **publish しない**（gate 4 で fail-closed refuse される）。primary-source rule で埋められる条件が揃ってから戻る。
+- **モデルサイズ確認**: safetensors 合計 >8 GB は M1 iMac で処理しない → skill `vast-ai-workflow`。`publish-one.sh` の gate 7 が `--allow-large` or `VOKRA_PUBLISH_ON_VAST=1` なしで refuse する。[[feedback-large-models-on-vast-ai]]。
+- **既に GGUF がある場合**: 変換不要なら `restamp_provenance`（§7）で provenance だけ差替可能。
+
+## 1. 5 段 gate の全体像
+
+`publish-one.sh` が chain するのは以下 5 段。**全 gate を通ったモデルだけが `--push` で live 化**する。
+
+| # | Gate | 実装 | fail-closed 条件 |
+|---|------|------|----------------|
+| 1 | **catalog-reality** | `check-catalog-reality.sh` | `docs/license-audit.md` §3 で `★ 公式 zoo` 宣言があるのに実装（runtime/op/converter のどれも）が無い |
+| 2 | **redistributable** | `LicenseClass::redistributable()` + `make_model_card.py` | `RedistributionForbidden`（VOICEVOX/CSJ/JSUT・JVS）を publish しようとした |
+| 3 | **provenance stamp** | `upload.sh` refuse | GGUF に `vokra.provenance.*` が刻まれていない（converter を通っていない、または schema stamp 前の旧成果物） |
+| 4 | **§3.1 sign-off** | `signoff_match.py` | audit table の該当 row が blank（**空欄 = 「まだ誰も判断してない」= "no" ではない が publish は不可**） |
+| 5 | **allow-noncommercial** | `publish-one.sh` refuse | T4（Research-only）weight を `--allow-noncommercial` 明示なしで publish しようとした |
+
+加えて **Copyleft は gate 6a-6e**（AGPL / CC-BY-SA 等）で `--acknowledge-copyleft` + LICENSE + NOTICE + AGPL は SOURCE.md + card `license:` 一致を追加要求。
+
+## 2. Tier の判定
+
+| Tier | 例 | LicenseClass | 追加 flag | precedent |
+|------|-----|-------------|-----------|-----------|
+| T1 Commercial | whisper-large-v3 (MIT) / kokoro (Apache-2.0) | `Permissive` | なし | 大半 |
+| T2 CC-BY attribution | mimi (CC-BY 4.0) | `AttributionRequired` | NOTICE 同梱必須 | mimi (kyutai) |
+| T3 Copyleft | Style-Bert-VITS2 v2 (AGPL-3.0) / cc-by-sa-* | `Copyleft` | `--acknowledge-copyleft` + LICENSE + NOTICE + (AGPL は SOURCE.md) | SBV2 v2 |
+| T4 Research-only | X-Codec-2 (cc-by-nc-4.0) / F5-TTS / Fish-Speech | `NonCommercial` | `--allow-noncommercial` 明示 | **X-Codec-2 が初 precedent (2026-07-28)** |
+| T5 Rejected | VOICEVOX weight / VibeVoice-Large (404) | `RedistributionForbidden` | 公開不可 | VibeVoice fail-closed 実例 |
+
+**T4 の workflow は X-Codec-2 precedent（[[project-x-codec2-t4-precedent]]）を踏襲**: `fetch_license.sh --spdx cc-by-nc-4.0` で canonical LICENSE 実文書を同梱、`publish-one.sh --allow-noncommercial` で明示、card は `hf_license_tag()` で `other` に normalize（HF は cc-by-nc-* を独立 tag として受けないケースあり）。
+
+## 3. HF vocabulary の normalize（SPDX と別空間）
+
+- HF `license:` タグは lower-case（`MIT` → 400 reject、`mit` OK）+ dual 表現は `other`（SPDX の `MIT OR Apache-2.0` は HF では `other`）。
+- 正規化は `make_model_card.py` の `hf_license_tag()` に集約されている。CC が手で card front-matter を書かない — 常に generator 経由。
+- CPML は SPDX 未登録 → converter で `NonCommercial` に hard-map（→ skill `license-audit`）+ publish は T4 workflow。[[reference-cpml-spdx-nonregistration]]。
+
+## 4. §3.1 sign-off を埋める
+
+skill `license-audit` の primary-source rule に従う。CC 側で埋めていい条件（**両方**）:
+
+1. 依頼者が明示的に「自主判断で埋めてよい」と言った
+2. primary source で clean 確認（authenticated HF API meta / upstream LICENSE raw / DOI）
+
+**署名 = `yousan`** + 日付 + `(依頼者許可 = CC 判断)`。片方でも欠けたら空欄据置 = fail-closed 継続。埋めた row は `signoff_match.py --self-test` で機械検証（field 数 8 が正、pipe `|` が row 本文に入ると 9 になり parse 崩壊 → 過去 latent bug、row 318 で修正済）。
+
+## 5. publish-one.sh の呼び方
+
+```bash
+# .env から HF_TOKEN を明示 source（デフォルトの環境継承では拾わない場合あり）
+export HF=$(grep '^HF=' .env | cut -d= -f2-) && export HF_TOKEN="$HF"
+
+# T1 (Permissive) 例: whisper-large-v3
+scripts/publish/publish-one.sh \
+  --gguf ~/scratch/whisper-large-v3.gguf \
+  --repo vokra/whisper-large-v3 \
+  --license-spdx mit \
+  --push  # ← --push 無しは常時 dry-run。省略で staging のみ
+
+# T4 (Research-only) 例: X-Codec-2
+scripts/publish/publish-one.sh \
+  --gguf ~/scratch/xcodec2.gguf \
+  --repo vokra/xcodec2 \
+  --license-url https://raw.githubusercontent.com/.../LICENSE \
+  --allow-noncommercial \
+  --push
+
+# T3 (Copyleft AGPL) 例: SBV2 v2 base
+scripts/publish/publish-one.sh \
+  --gguf ~/scratch/sbv2-v2-base.gguf \
+  --repo vokra/style-bert-vits2-v2-base \
+  --license-spdx agpl-3.0 \
+  --acknowledge-copyleft \
+  --push
+```
+
+**dry-run default** = `--push` を明示しない限り stage のみ（gate 全通過を local で確認可能）。**publish は irreversible** = 一度 live 化した weight は minutes で mirror される、「あとで消せる」は復旧計画にならない。
+
+## 6. `fetch_license.sh` の使い分け
+
+upstream の LICENSE 実体をどこから取るかは、上流の配布形態で決まる:
+
+- **上流が LICENSE ファイルを ship している**: `--url <raw-github-url>` で fetch（**その copyright 行が retention 要件を満たすので、canonical に置換してはいけない**）
+- **上流が front-matter だけで LICENSE ファイルなし**: `--spdx <apache-2.0|mit|cc-by-4.0|cc-by-sa-4.0|cc-by-nc-4.0|agpl-3.0|...>` で canonical に取る
+- **canonical URL がない** (openmdw-1.1 等): `inline_license_text()` で inline shipped（現状 openmdw-1.1 のみ、追加する時は明示 audit trail を付ける）
+
+## 7. `restamp_provenance` — 低メモリ再刻印（tensor コピーなし）
+
+**用途**: 既存 GGUF に provenance schema を後付け、または license 表記を差替。**tensor は mmap 読取して byte-copy せず、metadata だけ差替える**。
+
+- 実測: **8.7 GB Voxtral を M1 16 GB で peak footprint 6.4 MB / RSS 5.4 GB (mmap pages) / swap 0** で再刻印可（[[project-restamp-provenance]]）。
+- 使い所: (a) 旧成果物に schema stamp（`vokra.schema.version` / `vokra.schema.producer`）を追加、(b) 依頼者判断で license class 変更、(c) 上流 fork 変更に伴う `vokra.provenance.upstream_hf` 更新。
+- **converter を再度回す必要はない** — provenance だけの差替なら restamp が正解、変換は tensor 全読みで RSS が跳ねる。
+- 実装は `crates/vokra-convert/` の `restamp_provenance`（`GgufStreamWriter` 経由）。Python 単発 script でも書けるが `hf_license_tag()` normalize と ordering を統一するために crate 経由推奨。
+
+## 8. HF_TOKEN の扱い
+
+- **CLI 引数で渡さない**（shell history + `ps` output に残る）
+- `.env` に `HF=hf_xxx` で保存（`.gitignore` 済 = 履歴に載らない、`git check-ignore .env` で確認可）
+- Session で使う時は `export HF=$(grep '^HF=' .env | cut -d= -f2-) && export HF_TOKEN="$HF"` で明示 source（環境継承だけでは拾わないケースあり）
+- 期限切れ or 403 なら **fresh token を新規発行**（既存を回転、CSM-1B publish で使った precedent）
+
+## 9. Precedent 集（判断の記憶）
+
+- **X-Codec-2 T4 初 precedent** (2026-07-28): cc-by-nc-4.0、`--allow-noncommercial`、`fetch_license --spdx cc-by-nc-4.0`。[[project-x-codec2-t4-precedent]]
+- **CSM-1B ☑ Commercial** (2026-07-28): 依頼者許可 = CC 判断、authenticated HF API で `license=apache-2.0`
+- **VibeVoice-Large Rejected** (2026-07-28): HF API 404 = microsoft withdraw = mirror が幾つあっても Rejected（fail-closed 正常）
+- **Bark row 259**: README 「for research purposes」は Apache-2.0 下で非拘束 advisory 前例（以降類似モデルで cite）
+- **§3.1 row 318 field-count fix**: 行本文の pipe `|` が `line.split("|")` を壊す latent bug（8→9 fields）。row を書く時は pipe を含まない言い回しに reword。
+- **Voxtral 8.7 GB を M1 で publish 成功**: restamp_provenance 経路で peak 6.4 MB（vast.ai 不要になった実例）
+
+## 10. Verify
+
+publish 前後で以下を通す:
+
+```bash
+scripts/publish/check-catalog-reality.sh
+python3 scripts/publish/signoff_match.py --self-test
+scripts/publish/publishability-report.py  # 各モデルの 5-tier 現況
+```
+
+`upload.sh --self-test` は script 内 test（LICENSE 未同梱 / §3.1 blank / provenance 未刻印 の refuse path）を回す。
+
+## 11. 出禁パターン（**やってはいけない**）
+
+- **`hf` CLI や `huggingface_hub.upload_folder` を CC が直接叩く**: gate を全て bypass、依頼者にも見えない unaudited publish になる
+- **§3.1 blank row を CC が勝手に埋める**: primary-source rule 違反、fail-closed default を破壊
+- **T4 weight を `--allow-noncommercial` なしで publish**: gate 5 が refuse するが、gate を bypass すると license 違反配布
+- **canonical LICENSE を canonical URL 側で置換**: 上流が独自 copyright を付けている場合、retention 要件違反
+- **`--push` を最初から付ける**: dry-run で gate 全通過を確認しない = pipe 経由の undetected error を live 化する

--- a/.agents/skills/vast-ai-workflow/SKILL.md
+++ b/.agents/skills/vast-ai-workflow/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: vast-ai-workflow
+description: メモリを食う作業を vast.ai へ逃がすときに使う。**≥2 GB のモデル artefact の変換 / 検証 / publish**、および **workspace 全体や `vokra-models` の cargo**（2026-08-16 に M1 iMac を OOM で再起動させた実績）が対象。`provision.sh` の 4 gotcha（hf_config.pth shim / huggingface_hub pre-0.30 pin / certifi / stack tool install）+ rent→provision→work→destroy lifecycle + 未 push コミットの git bundle 転送 + Voxtral streaming reader + FA v3 Hopper bakeoff の runbook を示す。
+---
+
+# vast.ai で大モデルを扱う
+
+**単一事実源**: `scripts/publish/vast-ai/provision.sh` + `docs/handoff/vast-ai-large-model-publish.md`。本 skill はそれを skill 表現に翻訳したもの。
+
+**大原則**: 依頼者機は **M1 iMac 16 GB**。ここでメモリを食う作業を走らせると swap が急伸し、**macOS が強制終了する**。実証は 2 系統:
+
+- **モデル artefact**: Voxtral-Small-24B (48 GB) の mmap で swap 40 GB 到達
+- **cargo**: 2026-08-16、`cargo test -p vokra-models --lib kyutai_stt` が exit 137 (OOM kill) → **macOS 再起動**
+
+→ どちらも **vast.ai へ escalate**。
+
+## 0. いつ vast.ai を使うか
+
+**閾値は 2 GB**（依頼者指示 2026-08-16）。実測 safe な範囲（whisper-* 2.9 GB / csm-1b 6.21 GB は変換実績あり）より意図的に厳しい。**誤ってブロックした代償は環境変数 1 個、誤って通した代償は再起動**だから。
+
+**要 vast.ai**:
+- **≥2 GB のモデル artefact の convert**（sharded の場合は shard 単体でなく**合計**で判定）
+- ≥2 GB GGUF の publish（30 Mbps outbound で数時間、vast.ai の 2.6 Gbps で数分）
+- **workspace 全体の cargo**（`--workspace` / `--all` / `-p` 無しの `cargo test`）
+- **`-p vokra-models` の cargo**（最大 crate、2026-08-16 の再起動の直接原因）
+- H100 / A100 が必要な bakeoff（FA v3 Hopper、CoreML/ANE は別 = 実機 Mac / iPhone）
+
+**M1 iMac で OK**:
+- 軽い crate 単体: `-p vokra-convert` / `-cli` / `-eval` / `-core` / `-ops`（`CARGO_BUILD_JOBS=1` 併用）
+- シェルゲート全般（`scripts/check-*.sh`）、`cargo fmt`、`cargo metadata`
+- **restamp_provenance 経路**: **8.7 GB Voxtral を peak 6.4 MB で publish 実績あり**（mmap 読取のみ、tensor コピーなし。→ skill `publish-model-to-hf` §7）。**tensor を触らず provenance だけ差し替えるなら 2 GB 閾値の例外**
+
+**強制されている**: `.codex/hooks/guard-local-memory.sh` が PreToolUse フックとして上記を**ブロック**する（`.codex/hooks.json` に登録済み、`--self-test` 19 ケース）。指針ではなく強制なのは、8 GB の memory を持ったまま重いコマンドを打った実績があるため。意図的に通す場合のみ `VOKRA_ALLOW_LOCAL_HEAVY=1` を前置する。
+
+[[feedback-large-models-on-vast-ai]] / [[feedback-no-local-workspace-cargo]]。
+
+## 1. Lifecycle（4 phase）
+
+1. **rent**: vast.ai 上で GPU instance を借りる（cheapest でも RAM ≥64 GB / disk ≥200 GB は必須、convert 用途なら GPU は 4090 で十分、H100 は FA v3 bench 用）
+2. **provision**: `scripts/publish/vast-ai/provision.sh` を SSH 上で実行（4 gotcha を pre-handle）
+3. **work**: `run-one.sh` per model or 直接 cargo コマンド
+4. **destroy**: **必ず `vastai destroy` で auto-destroy**（走らせっぱなしは $/h で課金継続、ADR §D6）
+
+## 2. Rent phase（vast.ai 側）
+
+```bash
+# 手元 CLI（vastai）で GPU offer 検索
+vastai search offers 'gpu_name=RTX_4090 rentable=true' --order 'dph_total'
+# ↑ 一番安いのを選ぶ
+
+vastai create instance <offer-id> \
+  --image nvidia/cuda:12.4.1-devel-ubuntu22.04 \
+  --disk 200 \
+  --ssh
+```
+
+**image 選定注意**: `nvidia/cuda:13.0.0` の stock image は 4 個の gotcha を含む（下記 §3）→ `12.4.1-devel-ubuntu22.04` が実績 stable。H100 bakeoff で 13.0.0 が必要な場合も `provision.sh` の `harden_vast_docker_image` が pre-handle する。
+
+## 3. Provision phase — 4 gotcha を pre-handle
+
+vast.ai の stock image が持つ 4 個の trap を `provision.sh` が **`install_uv` より前**に潰す。個別に対処するのは実績上 1 day 溶かす:
+
+| # | Gotcha | 症状 | Fix |
+|---|--------|------|-----|
+| A | **hf_config.pth site-packages shim** | Python startup shim が `HF_ENDPOINT` を malicious mirror `117.175.104.83:8081` に書換、全 large DL が 404 | `/usr/local/lib/python3.10/dist-packages/hf_config.pth` + `/usr/lib/python3/dist-packages/pip/_vendor/hf_config.pth` を削除 |
+| B | **huggingface_hub >= 0.30 non-xet regression** | xet-token routing が mirror 404 を投げる、`HF_HUB_DISABLE_XET` も一部 bypass | `pip install 'huggingface_hub<0.30'` で pin（**vast.ai 上のみ**、local は pin 不要） |
+| C | **certifi CA bundle 空/stale** | HTTPS 全般 fail | `certifi` を再植え付け |
+| D | **torch/numpy/safetensors が system layer に無い** | `python3 -c` fallback や `uv_cmd` fallback が missing modules で死ぬ | pre-install で torch + numpy + safetensors を system-level に置く |
+
+**呼び方**:
+```bash
+# vast.ai instance に SSH した後
+export HF_TOKEN='hf_xxxxxxxx'
+git clone https://github.com/ayutaz/vokra.git ~/vokra
+cd ~/vokra
+bash scripts/publish/vast-ai/provision.sh  # idempotent, rerun-safe
+```
+
+**idempotent**: rerun-safe。各 step が artifact を probe して skip する。`git pull` 後にも安全に再実行できる。
+
+[[reference-vast-ai-hf-config-pth-shim]] / [[reference-huggingface-hub-lt-030-vast-ai]]。
+
+## 4. Work phase
+
+### 4.1 Convert + publish 1 モデル
+
+```bash
+# provision 済 instance 上
+export VOKRA_PUBLISH_ON_VAST=1  # publish-one.sh gate 7 の implicit bypass
+scripts/publish/vast-ai/run-one.sh <slug>  # convert → stage → push chain
+```
+
+### 4.2 Voxtral streaming reader パターン（sharded safetensors、mmap 節約）
+
+- 通常は sharded safetensors を `tools/parity/<slug>_prepare_checkpoint.py` で事前 merge（→ skill `add-speech-model` §2.1）
+- **Voxtral だけは例外**: TextDecoder の `Vec<f32>` eager binding が ~15 GB 要求で M1 を殺していた root cause → `MappedTextBlocks` / `MappedHeads`（mmap + tiled transpose、lm_head streaming）で **peak 15 GB → 3.55 GB**。同じ pattern を他 sharded モデルに横展開する場合は先例として参照
+- 実装: `crates/vokra-models/src/voxtral/mapped_lazy.rs` 系。streaming 適用可能なモデルは事前 merge 不要（converter が sharded を直接読む）
+
+### 4.3 大モデルの publish 直行（H100 レンタル + 即 push）
+
+```bash
+# 大 GGUF を convert する必要がなく、既存 HF から DL → restamp → repush だけの場合
+# ローカル (M1 iMac) の restamp_provenance で peak 6.4 MB で完結する
+# → vast.ai を借りずに済む（Voxtral 8.7 GB で実証）
+```
+
+**vast.ai を借りる vs 借りない判断**: convert が要る = 借りる / provenance だけ = ローカル restamp。
+
+### 4.4 workspace 検証を逃がす（GPU も provision.sh も不要）
+
+`cargo test --workspace` をローカルで走らせられないときの実績レシピ（2026-08-16、**所要 ~25 分 / $0.03**）。**モデル変換ではないので GPU も HF token も `provision.sh` も要らない** — 必要なのは CPU と RAM だけ。
+
+```bash
+# 1. RAM で選ぶ（GPU 性能は無関係）。48 core / 125 GB が $0.082/hr だった
+vastai search offers 'rentable=true cpu_ram>=64 disk_space>=150 num_gpus=1' \
+  --order 'dph_total' --raw | python3 -c "
+import json,sys
+for o in json.load(sys.stdin)[:10]:
+    print(o['id'], o['dph_total'], o['cpu_cores_effective'], int(o['cpu_ram']/1024))"
+
+vastai create instance <offer-id> --image nvidia/cuda:12.4.1-devel-ubuntu22.04 \
+  --disk 150 --ssh --direct --label vokra-verify
+
+# 2. 接続は direct endpoint を使う（public_ipaddr + direct_port_start）。
+#    ssh_host/ssh_port 側は Connection refused になることがある
+vastai show instance <id> --raw | python3 -c "
+import json,sys; d=json.load(sys.stdin); print(d['public_ipaddr'], d['direct_port_start'])"
+
+# 3. Rust。--profile minimal は rustfmt/clippy を入れないので明示追加が要る
+curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+rustup component add rustfmt clippy
+```
+
+**未 push のコミットは push せずに bundle で渡す**（未検証コミットを remote branch に載せないため）:
+
+```bash
+# 手元
+git bundle create /tmp/wave.bundle <remote-tip>..HEAD   # docs 数本なら 20 KB 程度
+scp -P <port> /tmp/wave.bundle root@<ip>:/root/
+
+# vast.ai 側
+git clone -q --branch <branch> https://github.com/ayutaz/vokra.git vokra && cd vokra
+git fetch -q /root/wave.bundle HEAD:work && git checkout -q work
+git rev-parse --short HEAD    # 手元と一致することを必ず確認
+```
+
+**判定に使える実測値**: フル workspace = `6965 passed / 0 failed / 23 ignored / 234 suites`。ローカル並列実行で落ちる 2 件は **regression ではない** — `kyutai_stt` は正当に **155 秒**かかるため 180 秒タイムアウトに接触し、`csm_frame_loop_allocates_zero_after_open` は alloc カウンタが他スレッドに撹乱される。どちらも単独・大容量機では通る。
+
+検証が green なら、手元からの push は pre-push の重い経路を踏まないよう `VOKRA_SKIP_HOOKS=1` を使う。**無検証のまま bypass しないこと** — 根拠はリモート検証結果。
+
+## 5. Destroy phase（**必ず**）
+
+```bash
+# 手元 CLI から
+vastai destroy instance <instance-id>
+```
+
+**auto-destroy を仕込む**: measure が終わったら trap で自動 destroy する pattern（ADR §D6）:
+```bash
+# vast.ai instance 上
+trap 'vastai destroy instance $VAST_CONTAINERLABEL' EXIT
+# ↑ SSH セッション終了時に自動 destroy
+```
+
+**destroy 忘れは $/h で継続課金**。H100 は $1.7-2.5/h、8h 忘れると $15+ 溶ける。
+
+## 6. FA v3 Hopper bakeoff runbook（M4-07 実績）
+
+- **hardware**: H100 PCIe (SM 9.0, 80 GB VRAM)
+- **image**: nvidia/cuda:12.4.1-devel-ubuntu22.04
+- **session cost 実績**: $1.73 / 60 min（2026-08-10）
+- **手順**: `docs/m4-07-hopper-bench-handover.md` §3 / `provision.sh` + `cargo build --release -p vokra-cli -p vokra-backend-cuda` + `tools/parity/cuda_rtf_variance.sh --iters 10 --fa-mode {decomposed,v2,v3}`
+- **結果**: FA v3 で **5.7% e2e speedup** vs FA v2、causal parity 1.206e-2 / non-causal 1.026e-2（atol 0.02 内 60% / 51%）
+- **注意**: `provision.sh` の `crates/vokra-cli` sanity check が glob-based workspace で misfire するので、直接 `cargo build --release -p vokra-cli` を叩く
+
+## 7. 費用 vs 手間の判断
+
+| Task | vast.ai 費用目安 | 判断 |
+|------|--------------|------|
+| Voxtral-Small-24B convert + publish | RTX 4090 8h × $0.30/h = $2.4 | 妥当（M1 で試すと mac 強制終了 = 復旧に時間 loss） |
+| H100 FA v3 bakeoff | H100 60 min × $1.73/h = $1.73 | 妥当（M4-07 実績） |
+| **workspace 全体の cargo 検証** | **21 min × $0.082/h = $0.03**（実績） | **妥当**（ローカルは再起動、復旧コストが桁違い） |
+| provenance だけの差替 | $0（ローカル restamp、tensor 不読み） | **借りない** |
+| ≥2 GB checkpoint の convert | 借りる | 実測 safe でも**閾値どおり借りる**（2026-08-16 依頼者指示） |
+
+## 8. 出禁パターン
+
+- **「今回くらいはローカルで」**: これが 2026-08-16 に mac を再起動させた。8 GB 閾値の memory を持ったうえで `cargo test -p vokra-models` を打っている。**判断で防げなかったので hook で強制した** = `guard-local-memory.sh`。`VOKRA_ALLOW_LOCAL_HEAVY=1` は「測って安全と分かっている」ときだけで、「面倒だから」で使わない
+- **未検証のまま `VOKRA_SKIP_HOOKS=1` で push**: bypass の根拠はリモート検証結果であって、急いでいることではない
+- **vast.ai を借りっぱなしで放置**: $/h 課金継続、trap `vastai destroy` を必ず仕込む
+- **provision.sh を skip して pip 手打ちで頑張る**: 4 gotcha に順番にハマる（実績 1 day 溶かす）
+- **`huggingface_hub` を local と同じ最新版で使う**: vast.ai 上では <0.30 pin 必須（xet-token regression）、local との差分を明示的に持つ
+- **`HF_TOKEN` を CLI 引数で渡す**: shell history + `ps` に残る → 環境変数経由で
+- **borrowed instance で `.env` を書く**: destroy で消える + credential 漏洩リスク、環境変数を SSH セッション内で export
+
+## 9. Cross-reference
+
+- skill `publish-model-to-hf` — publish gate 5 段の詳細
+- skill `add-speech-model` — sharded safetensors 事前 merge / GGUF 5D limit
+- `scripts/publish/vast-ai/provision.sh` — 実装 (single source of truth)
+- `docs/handoff/vast-ai-large-model-publish.md` — 実運用 runbook
+- `docs/m4-07-hopper-bench-handover.md` — H100 bakeoff 実績
+- `docs/bench-baselines/vast-2026-08-10-h100/` — H100 measurement data

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,31 @@
+{
+  "description": "Vokra repository policy hooks for Codex.",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --show-toplevel)/.codex/hooks/pre_tool_use.sh\"",
+            "statusMessage": "Checking Vokra command policy",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "^(apply_patch|Edit|Write)$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/post_tool_use.py\"",
+            "statusMessage": "Formatting and checking Vokra edits",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -20,7 +20,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"$(git rev-parse --show-toplevel)/.codex/hooks/post_tool_use.py\"",
+            "command": "uv run --no-project python \"$(git rev-parse --show-toplevel)/.codex/hooks/post_tool_use.py\"",
             "statusMessage": "Formatting and checking Vokra edits",
             "timeout": 30
           }

--- a/.codex/hooks/block-cargo-add.sh
+++ b/.codex/hooks/block-cargo-add.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Codex PreToolUse hook (Bash): block commands that would add an external
+# dependency, which Vokra forbids (NFR-DS-02 — the workspace links only
+# first-party vokra-* path crates; the ONNX/protobuf families are additionally
+# banned in deny.toml). Currently blocks `cargo add`.
+#
+# Exit 2 = block the tool call and return the message to Codex.
+
+set -uo pipefail
+
+payload="$(cat)"
+
+cmd=""
+if command -v jq >/dev/null 2>&1; then
+    cmd="$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
+elif command -v python3 >/dev/null 2>&1; then
+    cmd="$(printf '%s' "$payload" \
+        | python3 -c 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("command",""))' \
+        2>/dev/null || true)"
+fi
+
+# Match `cargo add` as a command word (line start, or after ; & | or whitespace),
+# so a path or a comment mention of the string does not trip it.
+if printf '%s' "$cmd" | grep -Eq '(^|[;&|[:space:]])cargo[[:space:]]+add([[:space:]]|$)'; then
+    {
+        echo "Blocked: 'cargo add' introduces an external crate dependency, which Vokra"
+        echo "forbids (NFR-DS-02 — the workspace links only first-party vokra-* path"
+        echo "crates; ONNX/protobuf families are additionally banned in deny.toml)."
+        echo "Implement the capability in std / first-party code, or escalate it as a"
+        echo "design-red-line decision (CONTRIBUTING.md §3 / §5, AGENTS.md)."
+    } >&2
+    exit 2
+fi
+exit 0

--- a/.codex/hooks/block-pip-conda.sh
+++ b/.codex/hooks/block-pip-conda.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Codex PreToolUse hook (Bash): block Python package management commands
+# that bypass uv, which the project requires. Owner directive 2026-07-27
+# (memory feedback-python-uses-uv): Python は uv で管理する。pip / conda /
+# requirements.txt / python -m pip は使わない。pyproject.toml + uv.lock を
+# per-tree に置く。
+#
+# WHY THIS EXISTS
+#
+# `tools/parity/` and other per-tree Python sub-projects are uv-managed
+# (pyproject.toml + uv.lock, Python 3.12 pin). Ad-hoc `pip install` bypasses
+# the lockfile, breaks reproducibility, and diverges local vs vast.ai env.
+# The pre-commit hook already routes internal python calls through
+# `uv run --project tools/parity python ...`, but that only catches
+# committed scripts — not one-off Bash calls Codex may run.
+#
+# Blocked forms:
+#   * pip install
+#   * pip freeze
+#   * pip uninstall
+#   * pip3 install / pip3 freeze / pip3 uninstall
+#   * python -m pip <anything>
+#   * python3 -m pip <anything>
+#   * conda install / conda create / conda env create
+#
+# NOT blocked (legitimate uses):
+#   * uv add / uv run / uv sync / uv pip (uv-managed pip pass-through)
+#   * python3 <script>.py         (running an existing script)
+#   * python3 -c '...'            (inline eval)
+#
+# Vast.ai instance provisioning uses `pip install 'huggingface_hub<0.30'` via
+# scripts/publish/vast-ai/provision.sh (documented gotcha B). That script
+# runs on remote instance, not through Codex — this hook is Codex-only.
+#
+# Exit 2 = block the tool call and return the message to Codex.
+
+set -uo pipefail
+
+payload="$(cat)"
+
+cmd=""
+if command -v jq >/dev/null 2>&1; then
+    cmd="$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
+elif command -v python3 >/dev/null 2>&1; then
+    cmd="$(printf '%s' "$payload" \
+        | python3 -c 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("command",""))' \
+        2>/dev/null || true)"
+fi
+
+# Empty command? Let it through — no cargo-add-style spurious blocks.
+[ -n "$cmd" ] || exit 0
+
+# `uv pip` is legitimate (uv-managed pip surface). Peel it off before the
+# bare `pip` match below so a legitimate `uv pip install X` is not blocked.
+# Strip leading whitespace then check for uv pip prefix explicitly.
+stripped_cmd="$(printf '%s' "$cmd" | sed -E 's/^[[:space:]]+//')"
+case "$stripped_cmd" in
+    "uv pip "*|"uv pip"*) exit 0 ;;
+esac
+
+# Match forms as command words (line start, or after ; & | or whitespace),
+# so a path or a comment mention of the string does not trip it.
+#
+# Pattern A: bare pip / pip3 with mutation-verb (install/freeze/uninstall).
+#   pip install X          → BLOCK
+#   pip3 uninstall X       → BLOCK
+#   pip list               → allowed (read-only introspection)
+#   ./scripts/pip-helper.sh → NOT matched (not a command word)
+#
+# Pattern B: python -m pip / python3 -m pip (any sub-command).
+#   python -m pip install X    → BLOCK
+#   python3 -m pip freeze      → BLOCK
+#
+# Pattern C: conda (mutation-only).
+#   conda install X        → BLOCK
+#   conda create -n env    → BLOCK
+#   conda env create -f X  → BLOCK
+#   conda info             → allowed (read-only)
+matched=""
+if printf '%s' "$cmd" | grep -Eq '(^|[;&|[:space:]])pip3?[[:space:]]+(install|freeze|uninstall)([[:space:]]|$)'; then
+    matched="pip install/freeze/uninstall"
+elif printf '%s' "$cmd" | grep -Eq '(^|[;&|[:space:]])python3?[[:space:]]+-m[[:space:]]+pip([[:space:]]|$)'; then
+    matched="python -m pip"
+elif printf '%s' "$cmd" | grep -Eq '(^|[;&|[:space:]])conda[[:space:]]+(install|create|env[[:space:]]+create|env[[:space:]]+update|remove|uninstall)([[:space:]]|$)'; then
+    matched="conda install/create/remove"
+fi
+
+if [ -n "$matched" ]; then
+    {
+        echo "Blocked: '$matched' bypasses uv. Vokra manages Python with uv"
+        echo "(owner directive 2026-07-27, memory feedback-python-uses-uv):"
+        echo "  * uv add <pkg>         instead of pip install"
+        echo "  * uv sync              instead of pip install -r requirements.txt"
+        echo "  * uv run <script>      instead of python script.py (uses .venv)"
+        echo "  * uv pip <subcmd>      IS allowed (uv-managed pip surface)"
+        echo ""
+        echo "Per-tree layout: pyproject.toml + uv.lock, Python 3.12 pin"
+        echo "(uv python pin 3.12 + requires-python \">=3.12\")."
+        echo ""
+        echo "Bypass this hook only when the user explicitly says so — e.g.,"
+        echo "when reproducing a vast.ai provisioning step that must run pip"
+        echo "on the remote instance (scripts/publish/vast-ai/provision.sh)."
+    } >&2
+    exit 2
+fi
+exit 0

--- a/.codex/hooks/guard-local-memory.sh
+++ b/.codex/hooks/guard-local-memory.sh
@@ -1,0 +1,336 @@
+#!/usr/bin/env bash
+# Codex PreToolUse hook (Bash): refuse commands that have been measured
+# to exhaust this machine's memory, and say where to run them instead.
+#
+# WHY THIS EXISTS
+# ---------------
+# 2026-08-16: `cargo test -p vokra-models --lib kyutai_stt` was OOM-killed
+# (exit 137) on the maintainer's 16 GB M1 and **rebooted macOS**. A memory
+# note recording "offload >8 GB models to vast.ai" already existed and did
+# not prevent it: guidance is advisory, and an agent under task pressure
+# reaches for the local command anyway. Enforcement has to live where the
+# harness runs it, not where the agent remembers it.
+#
+# The threshold for model artefacts is 2 GB by maintainer instruction
+# (2026-08-16), which is deliberately stricter than the measured-safe set
+# (whisper-* at 2.9 GB and csm-1b at 6.21 GB have both converted locally).
+# Being stricter than measured is the point: the cost of a false block is
+# one env var, the cost of a false allow is a reboot.
+#
+# WHAT IT DOES NOT DO
+# -------------------
+# It does not police `git push`. The pre-push hook has its own fast paths,
+# and blocking pushes here would misfire on the docs-only path that works
+# fine. That gap is real and is called out in the maintainer handoff.
+#
+# ESCAPE HATCH
+#   VOKRA_ALLOW_LOCAL_HEAVY=1  — you have decided this specific run is safe.
+#
+# SELF-TEST
+#   bash .codex/hooks/guard-local-memory.sh --self-test
+#
+# Exit 2 = block the tool call and return the message to Codex.
+
+set -uo pipefail
+
+# Model artefacts at or above this size go to vast.ai, never local.
+readonly SIZE_LIMIT_BYTES=$((2 * 1024 * 1024 * 1024))
+
+# Crates measured to exhaust a 16 GB machine on their own. Empty today, and
+# that is a finding rather than an oversight.
+#
+# `vokra-models` was listed here because `cargo test -p vokra-models` OOM-killed
+# this machine. The cause turned out not to be the crate: three `kyutai_stt`
+# tests fell through to `KyutaiSttWeights::synthesized` at `stt_2_6b_en` scale
+# and allocated ~10 GB of f32 each, for assertions about a licence class and an
+# error message. With the fixtures moved to `tiny_for_tests`, the whole crate
+# runs 2532 tests in 36 s on this machine with no memory pressure.
+#
+# Keeping the block after fixing its cause would be a guard whose stated reason
+# is no longer true — the exact thing this repo keeps auditing out. An empty
+# regex matches nothing, so the `-p <crate>` leg is inert until something is
+# measured back into it.
+readonly HEAVY_CRATES=''
+
+emit_heavy_cargo_block() {
+    {
+        echo "Blocked: this cargo invocation has been measured to exhaust this"
+        echo "machine's memory (16 GB M1). On 2026-08-16 an equivalent command was"
+        echo "OOM-killed and rebooted macOS."
+        echo
+        echo "Matched: $1"
+        echo
+        echo "Run it on vast.ai instead — load the 'vast-ai-workflow' skill. A"
+        echo "48-core / 125 GB box costs about \$0.08/hr and ran the full workspace"
+        echo "(6965 tests) in minutes for \$0.03. Ship unpushed commits to it with"
+        echo "'git bundle create <f> <base>..HEAD' so nothing unverified is pushed."
+        echo
+        echo "Locally, scope to one light crate instead:"
+        echo "  CARGO_BUILD_JOBS=1 cargo test -p vokra-convert   # or -cli / -eval / -core"
+        echo
+        echo "If you have genuinely decided this run is safe, re-issue it with"
+        echo "VOKRA_ALLOW_LOCAL_HEAVY=1 prefixed."
+    } >&2
+}
+
+emit_large_artefact_block() {
+    {
+        echo "Blocked: this command reads a model artefact of $2 (>= 2 GB), which"
+        echo "the maintainer has directed must not be processed on this machine."
+        echo
+        echo "Path: $1"
+        echo
+        echo "Convert it on vast.ai — load the 'vast-ai-workflow' skill for the"
+        echo "rent -> provision -> work -> destroy lifecycle. Remember to destroy"
+        echo "the instance ('vastai destroy instance <id>'); it bills per hour."
+        echo
+        echo "Exception worth checking first: if you only need to change provenance"
+        echo "metadata and not the tensors, 'restamp_provenance' rewrites in-place"
+        echo "via mmap and has published an 8.7 GB file at 6.4 MB peak locally."
+        echo
+        echo "If you have genuinely decided this run is safe, re-issue it with"
+        echo "VOKRA_ALLOW_LOCAL_HEAVY=1 prefixed."
+    } >&2
+}
+
+human_size() {
+    awk -v b="$1" 'BEGIN { printf "%.1f GB", b / 1073741824 }'
+}
+
+# `stat` is not portable: macOS (BSD) wants -f '%z', Linux (GNU) wants -c '%s'.
+#
+# The first version tried BSD then fell back with `||`, which does not work and
+# CI caught it: GNU `stat -f` is not an error, it is a DIFFERENT valid option
+# (print filesystem status). So on Linux the BSD form SUCCEEDED, printed
+# filesystem info, the `||` never fired, and the arithmetic that consumed the
+# result died with "File: unbound variable". Every size check would have been
+# garbage rather than merely wrong.
+#
+# Two fixes, because exit status alone is not trustworthy here:
+#   1. try GNU first — BSD `stat -c` is genuinely invalid and fails cleanly,
+#      so the asymmetry now runs the safe way round;
+#   2. validate the answer is a plain integer regardless, and report 0 if not.
+file_size_bytes() {
+    local out
+    out="$(stat -c '%s' "$1" 2>/dev/null)" || out="$(stat -f '%z' "$1" 2>/dev/null)" || out=""
+    case "$out" in
+        '' | *[!0-9]*) echo 0 ;;
+        *) echo "$out" ;;
+    esac
+}
+
+# Size of a file, or the recursive sum for a directory (sharded safetensors
+# live as many files in one directory, and each shard alone can be under the
+# limit while the set is far over it).
+path_size_bytes() {
+    local p="$1" total=0 f
+    if [ -d "$p" ]; then
+        while IFS= read -r f; do
+            total=$((total + $(file_size_bytes "$f")))
+        done <<EOF
+$(find "$p" -type f \( -name '*.safetensors' -o -name '*.bin' -o -name '*.pt' \
+    -o -name '*.pth' -o -name '*.gguf' -o -name '*.ckpt' \) 2>/dev/null)
+EOF
+        echo "$total"
+    elif [ -f "$p" ]; then
+        file_size_bytes "$p"
+    else
+        echo 0
+    fi
+}
+
+# True when some command segment actually INVOKES a build-and-run cargo
+# subcommand, as opposed to merely containing the words. Segments are split on
+# ; && || | and newline; leading VAR=value assignments and a +toolchain are
+# skipped so `FOO=1 cargo +stable test` still matches.
+segment_invokes_heavy_cargo() {
+    printf '%s\n' "$1" \
+        | tr ';\n' '\n\n' \
+        | sed -e 's/&&/\n/g' -e 's/||/\n/g' -e 's/|/\n/g' \
+        | while IFS= read -r seg; do
+            # Drop leading whitespace, then leading NAME=VALUE assignments.
+            seg="${seg#"${seg%%[![:space:]]*}"}"
+            while printf '%s' "$seg" | grep -Eq '^[A-Za-z_][A-Za-z0-9_]*='; do
+                seg="${seg#* }"
+                seg="${seg#"${seg%%[![:space:]]*}"}"
+            done
+            printf '%s' "$seg" \
+                | grep -Eq '^cargo[[:space:]]+(\+[^[:space:]]+[[:space:]]+)?(test|build|clippy|bench|nextest)([[:space:]]|$)' \
+                && echo MATCH
+        done | grep -q MATCH
+}
+
+# ---------------------------------------------------------------- analysis --
+# Returns 0 and prints a reason when the command must be blocked.
+analyse() {
+    local cmd="$1"
+
+    # An explicit override anywhere in the command line is honoured.
+    if printf '%s' "$cmd" | grep -Eq '(^|[;&|[:space:]])VOKRA_ALLOW_LOCAL_HEAVY=1'; then
+        return 1
+    fi
+
+    # -- (a) memory-heavy cargo -------------------------------------------
+    # Only cargo subcommands that build and run test/bench binaries. `cargo
+    # fmt` and `cargo metadata` are cheap and must not be caught.
+    #
+    # `cargo` must be the FIRST WORD of a command segment, not merely present.
+    # Matching it anywhere blocked `echo 'run cargo test later'` — caught by
+    # this file's own self-test. A guard that trips on prose about a command
+    # gets switched off, and then it guards nothing.
+    if segment_invokes_heavy_cargo "$cmd"; then
+
+        if printf '%s' "$cmd" | grep -Eq '[[:space:]]--(workspace|all)([[:space:]]|$)'; then
+            echo "HEAVY_CARGO:workspace-wide scope (--workspace / --all)"
+            return 0
+        fi
+
+        # Skipped explicitly when the list is empty. Interpolating an empty
+        # string would leave `(...)` as an empty alternation, which matches
+        # the empty string — a regex that is one stray space away from
+        # blocking every `-p` invocation there is.
+        if [ -n "$HEAVY_CRATES" ] \
+            && printf '%s' "$cmd" | grep -Eq "[[:space:]]-p[[:space:]]+($HEAVY_CRATES)([[:space:]]|$)"; then
+            echo "HEAVY_CARGO:-p names a crate measured to exhaust this machine"
+            return 0
+        fi
+
+        # A bare `cargo test` in a virtual workspace IS the workspace. Treat
+        # "no -p and no --package" as workspace scope rather than assuming
+        # the caller meant something small.
+        if ! printf '%s' "$cmd" | grep -Eq '[[:space:]](-p|--package)[[:space:]]'; then
+            echo "HEAVY_CARGO:no -p given, which in this virtual workspace means every crate"
+            return 0
+        fi
+    fi
+
+    # -- (b) model artefacts at or over the limit --------------------------
+    # Candidate paths: values of --input/--config/--model/--output, plus any
+    # bare token that looks like a checkpoint. Quoting is not fully parsed;
+    # a path with spaces simply will not resolve and is left alone, which
+    # errs toward allowing rather than blocking on a mis-parse.
+    local tok prev="" size
+    for tok in $cmd; do
+        case "$prev" in
+            --input|--config|--model|--output|-i|-o) : ;;
+            *)
+                case "$tok" in
+                    *.safetensors|*.gguf|*.pt|*.pth|*.bin|*.ckpt) : ;;
+                    *) prev="$tok"; continue ;;
+                esac
+                ;;
+        esac
+        prev="$tok"
+
+        # Strip surrounding quotes a naive split leaves behind.
+        tok="${tok%\"}"; tok="${tok#\"}"
+        tok="${tok%\'}"; tok="${tok#\'}"
+        [ -e "$tok" ] || continue
+
+        size="$(path_size_bytes "$tok")"
+        if [ "${size:-0}" -ge "$SIZE_LIMIT_BYTES" ] 2>/dev/null; then
+            echo "LARGE_ARTEFACT:$tok:$(human_size "$size")"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+# --------------------------------------------------------------- self-test --
+# Plants each defect where the guard must see it. A guard that has stopped
+# being able to see one is worse than no guard: it certifies what it missed.
+if [ "${1:-}" = "--self-test" ]; then
+    fails=0
+    check() { # name expect-block command
+        local name="$1" expect="$2" c="$3" got
+        if analyse "$c" >/dev/null; then got=block; else got=allow; fi
+        if [ "$got" = "$expect" ]; then
+            printf '  ok    %-52s %s\n' "$name" "$got"
+        else
+            printf '  FAIL  %-52s expected %s, got %s\n' "$name" "$expect" "$got"
+            fails=$((fails + 1))
+        fi
+    }
+
+    echo "guard-local-memory --self-test"
+
+    # (a) heavy cargo — must block
+    check "cargo test --workspace"            block "cargo test --workspace"
+    check "bare cargo test (= workspace)"     block "cargo test"
+    check "cargo nextest run --workspace"     block "cargo nextest run --workspace"
+    check "cargo build --all"                 block "cargo build --all --release"
+    check "toolchain-pinned workspace test"   block "cargo +stable test --workspace"
+    check "chained after &&"                  block "cd /tmp && cargo test --workspace"
+
+    # (a) light cargo — must NOT block
+    # `-p vokra-models` is allowed again: the 10 GB synthesis that made it
+    # unrunnable was a test-fixture defect, now fixed (2532 tests / 36 s).
+    # This case also pins that an EMPTY heavy-crate list blocks nothing —
+    # interpolating it into the regex unguarded would match everything.
+    check "cargo test -p vokra-models"        allow "cargo test -p vokra-models --lib kyutai_stt"
+    check "cargo test -p vokra-convert"       allow "cargo test -p vokra-convert"
+    check "cargo test -p vokra-cli"           allow "CARGO_BUILD_JOBS=1 cargo test -p vokra-cli"
+    check "cargo fmt"                         allow "cargo fmt --all -- --check"
+    check "cargo metadata"                    allow "cargo metadata --no-deps"
+    check "override honoured"                 allow "VOKRA_ALLOW_LOCAL_HEAVY=1 cargo test --workspace"
+    check "unrelated command"                 allow "git status --short"
+    check "the word cargo in prose"           allow "echo 'run cargo test later'"
+
+    # (b) artefact size — needs real files on disk
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' EXIT
+    mkdir -p "$tmp/shards"
+    # Sparse files: apparent size is what stat reports, no disk is consumed.
+    dd if=/dev/null of="$tmp/small.safetensors" bs=1 count=0 seek=1000000 2>/dev/null
+    dd if=/dev/null of="$tmp/big.safetensors"   bs=1 count=0 seek=3000000000 2>/dev/null
+    # Each shard is under the limit; the set is over it.
+    dd if=/dev/null of="$tmp/shards/a.safetensors" bs=1 count=0 seek=1500000000 2>/dev/null
+    dd if=/dev/null of="$tmp/shards/b.safetensors" bs=1 count=0 seek=1500000000 2>/dev/null
+
+    check "3 GB checkpoint"                   block "vokra-cli convert --model whisper --input $tmp/big.safetensors"
+    check "sharded dir summing over limit"    block "vokra-cli convert --model x --input $tmp/shards"
+    check "1 MB checkpoint"                   allow "vokra-cli convert --model x --input $tmp/small.safetensors"
+    check "path that does not exist"          allow "vokra-cli convert --model x --input /nope/absent.safetensors"
+    check "big file but override set"         allow "VOKRA_ALLOW_LOCAL_HEAVY=1 vokra-cli convert --input $tmp/big.safetensors"
+
+    echo
+    if [ "$fails" -eq 0 ]; then
+        echo "guard-local-memory --self-test: OK"
+        exit 0
+    fi
+    echo "guard-local-memory --self-test: FAIL ($fails)"
+    exit 1
+fi
+
+# ------------------------------------------------------------------ driver --
+payload="$(cat)"
+
+cmd=""
+if command -v jq >/dev/null 2>&1; then
+    cmd="$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
+elif command -v python3 >/dev/null 2>&1; then
+    cmd="$(printf '%s' "$payload" \
+        | python3 -c 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("command",""))' \
+        2>/dev/null || true)"
+fi
+
+[ -n "$cmd" ] || exit 0
+
+# The environment variable may also be exported rather than inlined.
+[ "${VOKRA_ALLOW_LOCAL_HEAVY:-0}" = "1" ] && exit 0
+
+if reason="$(analyse "$cmd")"; then
+    case "$reason" in
+        HEAVY_CARGO:*)
+            emit_heavy_cargo_block "${reason#HEAVY_CARGO:}"
+            ;;
+        LARGE_ARTEFACT:*)
+            rest="${reason#LARGE_ARTEFACT:}"
+            emit_large_artefact_block "${rest%:*}" "${rest##*:}"
+            ;;
+    esac
+    exit 2
+fi
+
+exit 0

--- a/.codex/hooks/post_tool_use.py
+++ b/.codex/hooks/post_tool_use.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Codex PostToolUse policy for apply_patch/Edit/Write.
+
+The legacy PostToolUse payload exposed a file path directly. Codex's
+apply_patch tool exposes the patch text as ``tool_input.command`` instead, so
+this hook extracts changed paths before applying the same Rust-format and
+zero-dependency checks.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def git_root(cwd: str) -> Path | None:
+    result = subprocess.run(
+        ["git", "-C", cwd, "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return Path(result.stdout.strip())
+
+
+def changed_paths(tool_input: object) -> list[str]:
+    if not isinstance(tool_input, dict):
+        return []
+
+    paths: list[str] = []
+    for key in ("file_path", "path"):
+        value = tool_input.get(key)
+        if isinstance(value, str) and value:
+            paths.append(value)
+
+    command = tool_input.get("command")
+    if not isinstance(command, str):
+        return list(dict.fromkeys(paths))
+
+    patterns = (
+        r"^\*\*\* (?:Update|Add|Delete) File: (.+)$",
+        r"^\+\+\+ b/(.+)$",
+        r"^diff --git a/(\S+) b/(\S+)$",
+    )
+    for line in command.splitlines():
+        for index, pattern in enumerate(patterns):
+            match = re.match(pattern, line)
+            if not match:
+                continue
+            if index == 2:
+                paths.append(match.group(2))
+            else:
+                paths.append(match.group(1).strip())
+            break
+
+    return list(dict.fromkeys(paths))
+
+
+def resolve(root: Path, raw: str) -> Path:
+    path = Path(raw)
+    return path if path.is_absolute() else root / path
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, OSError):
+        return 0
+
+    cwd = payload.get("cwd") if isinstance(payload, dict) else None
+    root = git_root(cwd if isinstance(cwd, str) else os.getcwd())
+    if root is None:
+        return 0
+
+    paths = [resolve(root, path) for path in changed_paths(payload.get("tool_input"))]
+    feedback: list[str] = []
+
+    for path in paths:
+        if path.suffix != ".rs" or not path.is_file():
+            continue
+        result = subprocess.run(
+            ["rustfmt", "--edition", "2024", str(path)],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout).strip().splitlines()
+            feedback.append(
+                f"rustfmt failed for {path.relative_to(root)}"
+                + (f": {detail[-1]}" if detail else "")
+            )
+
+    if any(path.name in {"Cargo.toml", "Cargo.lock"} for path in paths):
+        checker = root / "scripts/check-zero-deps.sh"
+        if checker.is_file():
+            result = subprocess.run(
+                ["bash", str(checker)],
+                cwd=root,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if result.returncode != 0:
+                detail = (result.stdout + result.stderr).strip()
+                feedback.append(
+                    "zero-dependency check failed after Cargo metadata changed"
+                    + (f": {detail[-1200:]}" if detail else "")
+                )
+
+    if feedback:
+        print(
+            json.dumps(
+                {
+                    "hookSpecificOutput": {
+                        "hookEventName": "PostToolUse",
+                        "additionalContext": "\n".join(feedback),
+                    }
+                }
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/hooks/pre_tool_use.sh
+++ b/.codex/hooks/pre_tool_use.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Codex PreToolUse(Bash) policy dispatcher.
+#
+# The individual guards deliberately remain small and stdin-compatible with
+# the Codex hook payload. Exit 2 denies the pending Bash tool call.
+
+set -uo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+payload="$(cat)"
+
+for guard in \
+    block-cargo-add.sh \
+    block-pip-conda.sh \
+    guard-local-memory.sh
+do
+    if ! printf '%s' "$payload" | bash "$ROOT/.codex/hooks/$guard"; then
+        exit 2
+    fi
+done
+
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -54,8 +54,9 @@ integrations/vokra-godot/pkg/
 # NOTE: Cargo.lock is intentionally COMMITTED (CI reproducibility) and must
 # not be ignored — see docs/adr/0001-crate-layout.md.
 
-# Claude Code: the shared config (.claude/settings.json) and .claude/skills/
-# ARE committed as project policy; only personal/local overrides are ignored.
+# Agent configuration: Codex's AGENTS.md, .agents/skills/, and .codex/hooks.json
+# are committed as project policy. Claude compatibility files remain committed;
+# only personal/local overrides are ignored.
 .claude/settings.local.json
 
 # Client-private planning docs — removed from the repo AND from git history on

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# Vokra Codex project instructions
+
+This repository is maintained with Codex. Treat this file as the Codex-facing
+project guide. The older local `CLAUDE.md` is supplementary historical context;
+do not depend on Claude Code settings or hook behavior when working here.
+
+## Project invariants
+
+- Vokra is a Rust, audio-focused inference runtime and offline model converter.
+- Keep the runtime zero-dependency invariant: root `Cargo.lock` must contain
+  only first-party `vokra-*` crates. Do not use `cargo add`; implement with
+  existing first-party code or escalate the design decision.
+- Do not put ONNX/ONNX Runtime/protobuf runtime dependencies into the runtime.
+  Offline conversion tools may handle source formats when the established
+  converter pattern requires it.
+- GPU backends are optional. Unsupported operations must return an explicit
+  error; never add a silent CPU fallback.
+- Do not invent model shapes, licenses, provenance, parity numbers, or source
+  URLs. Preserve fail-closed license and publication gates.
+- Python tooling is managed per tree with `pyproject.toml`, `uv.lock`, and
+  Python 3.12. Prefer `uv run`/`uv sync`; do not use bare pip or conda.
+
+## Memory and large-model safety
+
+- Do not run workspace-wide cargo tests/builds/clippy locally on the maintainer
+  machine. Use the `vast-ai-workflow` skill and a remote machine for heavy
+  verification; destroy the instance afterward.
+- Treat model artifacts of 2 GB or larger (including the sum of shards) as
+  vast.ai work. The only narrow exception is provenance-only restamping through
+  the established mmap path, without touching tensor data.
+- Keep local verification package-scoped and serial (`CARGO_BUILD_JOBS=1`) when
+  it is known to be safe. The Codex PreToolUse hook enforces the broad guard;
+  do not bypass it unless the user explicitly authorizes that exact run.
+
+## Skill routing
+
+Use the repository skills in `.agents/skills/` when the task matches:
+
+- `$add-speech-model`: add a TTS/ASR/S2S/VAD/speaker/music/separation/audio-LLM
+  model, including converter, binder, license, and parity work.
+- `$add-audio-operator`: add an audio-dialect operator or backend kernel.
+- `$numerical-parity`: create or review reference fixtures and numerical gates.
+- `$license-audit`: inspect dependencies, weights, attribution, and publication
+  eligibility before changing model or codec support.
+- `$publish-model-to-hf`: publish only through the repository's gated script.
+- `$vast-ai-workflow`: convert, validate, publish, or benchmark memory-heavy
+  artifacts and workspace-scale Rust code remotely.
+
+Skills are guidance, not permission to skip tests or gates. Read the selected
+skill before acting and follow its referenced project files.
+
+## Verification and handoff
+
+- Inspect `git status` before editing and preserve unrelated user changes.
+- Prefer focused tests and repository shell gates locally. Use the remote
+  workflow for workspace-scale verification.
+- Run `git diff --check` and the relevant `scripts/check-*.sh` gates before
+  handoff. Report commands that were not run and why.
+- Keep documentation, license rows, provenance, and public API snapshots in
+  the same logical change as the implementation.
+- Do not commit, push, publish, or open a PR unless the user asks for that
+  external state change.
+
+The repository also contains legacy Claude configuration for users who still
+need it. Codex behavior is defined by this file, `.agents/skills/`, and the
+trusted hooks under `.codex/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,18 +166,24 @@ only sanctioned ways to reach outside the runtime graph:
   across a trait boundary (`vokra_piper_plus::Phonemizer`) — never linked into
   the runtime graph checked here.
 
-### Claude Code
+### Codex and Claude Code
 
-The repository is configured for [Claude Code](https://claude.ai/code) via
-committed `.claude/settings.json` and `.claude/skills/`:
+Codex is the primary agent for this repository. Codex reads the committed
+`AGENTS.md`, discovers reusable workflows under `.agents/skills/`, and loads
+the repository policy hooks from `.codex/hooks.json` after they are reviewed
+and trusted with `/hooks`.
 
-- **Hooks** keep Rust edits formatted (`rustfmt` on write), re-assert the
-  zero-dependency invariant after `Cargo.toml` / `Cargo.lock` edits, and
-  block `cargo add` (which would introduce an external dependency). The hook
-  scripts live in `scripts/claude-hooks/`.
-- **Skills** encode the recurring, policy-heavy workflows so they stay
-  consistent: `add-speech-model`, `add-audio-operator`, `numerical-parity`,
-  `license-audit`.
+- **Codex hooks** keep Rust edits formatted, re-assert the zero-dependency
+  invariant after Cargo metadata edits, block `cargo add` and bare pip/conda
+  mutations, and route workspace-scale cargo or 2 GB+ model work to vast.ai.
+- **Codex skills** encode the recurring policy-heavy workflows:
+  `add-speech-model`, `add-audio-operator`, `numerical-parity`,
+  `license-audit`, `publish-model-to-hf`, and `vast-ai-workflow`.
+- **Claude Code compatibility** remains available through the committed
+  `.claude/settings.json` and `.claude/skills/`; its legacy hook scripts live
+  in `scripts/claude-hooks/`. New Codex behavior must not depend on Claude-only
+  environment variables or lifecycle events.
 
-Personal, machine-local overrides go in `.claude/settings.local.json`
-(git-ignored).
+Machine-local approval settings are managed by Codex configuration and are
+not committed to the repository. Do not add credentials or personal overrides
+to the project policy files.


### PR DESCRIPTION
## 変更内容
- Codex向けの `AGENTS.md`、再利用可能なリポジトリ技能、ポリシーフックを追加
- 既存のClaude Code設定は互換用として維持し、Codexを主導線として文書化
- PostToolUseのPythonフックを `uv run --no-project python` 経由に統一

## 目的
Claude Codeセッションで整備されたワークフローを、現在のCodex運用へ安全に移行します。

## 検証
- `uv run --no-project python .codex/hooks/post_tool_use.py`
- pre-commit
- pre-push（`cargo clippy --all-targets -- -D warnings`、`cargo nextest run --profile pre-push --workspace`: 6,566 passed / 23 skipped）