### PR TITLE
fix(claude): enforce uv compatibility

### DIFF
--- a/.claude/skills/add-speech-model/SKILL.md
+++ b/.claude/skills/add-speech-model/SKILL.md
@@ -47,7 +47,7 @@ description: Vokra に新しい音声モデル（TTS / ASR / S2S / VC / Speaker-
   # shared_pairs は shared_pairs.json に audit trail として吐く（後で復元ロジックが要る）
   ```
   [[reference-safetensors-shared-tensor-dedup]]。
-- **5D 以上の tensor**: GGUF writer は現状 4D まで（>4D は `"too many dimensions: 5"` で hard-error）。Qwen2.5-Omni 系 multimodal adapter が該当し publish blocked。回避 = writer 拡張 or `reshape(5D → 4D + metadata)`、判断は M6 investigation phase。着手前に上流 tensor shape を `python -c "import safetensors; ..."` で確認して 5D を含むなら **converter に着手しない**。[[project-gguf-5d-tensor-limit]]。
+- **5D 以上の tensor**: GGUF writer は現状 4D まで（>4D は `"too many dimensions: 5"` で hard-error）。Qwen2.5-Omni 系 multimodal adapter が該当し publish blocked。回避 = writer 拡張 or `reshape(5D → 4D + metadata)`、判断は M6 investigation phase。着手前に上流 tensor shape を `uv run --project tools/parity python -c "import safetensors; ..."` で確認して 5D を含むなら **converter に着手しない**。[[project-gguf-5d-tensor-limit]]。
 
 ### 2.2 大モデル（>8 GB safetensors）は M1 iMac で変換しない
 

--- a/.claude/skills/license-audit/SKILL.md
+++ b/.claude/skills/license-audit/SKILL.md
@@ -75,7 +75,7 @@ cargo deny check licenses advisories bans
 cargo audit
 bash scripts/check-forbidden-symbols.sh
 bash scripts/check-zero-deps.sh
-python3 scripts/publish/signoff_match.py --self-test
+uv run --no-project --python 3.12 python scripts/publish/signoff_match.py --self-test
 ```
 
 CONTRIBUTING.md §3（dependency license policy）/ §4（new model）と突き合わせる。

--- a/.claude/skills/publish-model-to-hf/SKILL.md
+++ b/.claude/skills/publish-model-to-hf/SKILL.md
@@ -127,7 +127,7 @@ publish 前後で以下を通す:
 
 ```bash
 scripts/publish/check-catalog-reality.sh
-python3 scripts/publish/signoff_match.py --self-test
+uv run --no-project --python 3.12 python scripts/publish/signoff_match.py --self-test
 scripts/publish/publishability-report.py  # 各モデルの 5-tier 現況
 ```
 

--- a/scripts/claude-hooks/block-cargo-add.sh
+++ b/scripts/claude-hooks/block-cargo-add.sh
@@ -13,9 +13,9 @@ payload="$(cat)"
 cmd=""
 if command -v jq >/dev/null 2>&1; then
     cmd="$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
-elif command -v python3 >/dev/null 2>&1; then
+elif command -v uv >/dev/null 2>&1; then
     cmd="$(printf '%s' "$payload" \
-        | python3 -c 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("command",""))' \
+        | UV_CACHE_DIR="${TMPDIR:-/tmp}/vokra-uv-cache" uv run --no-project --python 3.12 python -c 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("command",""))' \
         2>/dev/null || true)"
 fi
 

--- a/scripts/claude-hooks/block-pip-conda.sh
+++ b/scripts/claude-hooks/block-pip-conda.sh
@@ -21,29 +21,66 @@
 #   * pip3 install / pip3 freeze / pip3 uninstall
 #   * python -m pip <anything>
 #   * python3 -m pip <anything>
+#   * python3 <script>.py / python3 -c '...' (direct local execution)
 #   * conda install / conda create / conda env create
 #
 # NOT blocked (legitimate uses):
 #   * uv add / uv run / uv sync / uv pip (uv-managed pip pass-through)
-#   * python3 <script>.py         (running an existing script)
-#   * python3 -c '...'            (inline eval)
 #
 # Vast.ai instance provisioning uses `pip install 'huggingface_hub<0.30'` via
 # scripts/publish/vast-ai/provision.sh (documented gotcha B). That script
 # runs on remote instance, not through Claude Code — this hook is Claude-only.
 #
+# SELF-TEST
+#   bash scripts/claude-hooks/block-pip-conda.sh --self-test
+#
 # Exit 2 = block the tool call and return the message to Claude.
 
 set -uo pipefail
+
+if [ "${1:-}" = "--self-test" ]; then
+    fails=0
+    check() {
+        local name="$1" expect="$2" command="$3" got
+        if printf '{"tool_input":{"command":"%s"}}' "$command" \
+            | bash "$0" >/dev/null 2>&1; then
+            got=allow
+        else
+            got=block
+        fi
+        if [ "$got" = "$expect" ]; then
+            printf '  ok    %-40s %s\n' "$name" "$got"
+        else
+            printf '  FAIL  %-40s expected %s, got %s\n' "$name" "$expect" "$got"
+            fails=$((fails + 1))
+        fi
+    }
+
+    echo "block-pip-conda --self-test"
+    check "direct python script" block "python3 scripts/check.py"
+    check "direct python inline" block "python3 -c print(1)"
+    check "uv run python" allow "uv run --project tools/parity python scripts/check.py"
+    check "bare pip install" block "pip install pyyaml"
+    check "uv pip install" allow "uv pip install pyyaml"
+    check "conda create" block "conda create -n test-env"
+    check "python word in prose" allow "echo python3 scripts/check.py"
+
+    if [ "$fails" -eq 0 ]; then
+        echo "block-pip-conda --self-test: OK"
+        exit 0
+    fi
+    echo "block-pip-conda --self-test: FAIL ($fails)"
+    exit 1
+fi
 
 payload="$(cat)"
 
 cmd=""
 if command -v jq >/dev/null 2>&1; then
     cmd="$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
-elif command -v python3 >/dev/null 2>&1; then
+elif command -v uv >/dev/null 2>&1; then
     cmd="$(printf '%s' "$payload" \
-        | python3 -c 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("command",""))' \
+        | UV_CACHE_DIR="${TMPDIR:-/tmp}/vokra-uv-cache" uv run --no-project --python 3.12 python -c 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("command",""))' \
         2>/dev/null || true)"
 fi
 
@@ -67,7 +104,9 @@ esac
 #   pip list               → allowed (read-only introspection)
 #   ./scripts/pip-helper.sh → NOT matched (not a command word)
 #
-# Pattern B: python -m pip / python3 -m pip (any sub-command).
+# Pattern B: direct Python execution, or python -m pip (any sub-command).
+#   python3 script.py             → BLOCK
+#   python3 -c '...'              → BLOCK
 #   python -m pip install X    → BLOCK
 #   python3 -m pip freeze      → BLOCK
 #
@@ -77,7 +116,26 @@ esac
 #   conda env create -f X  → BLOCK
 #   conda info             → allowed (read-only)
 matched=""
-if printf '%s' "$cmd" | grep -Eq '(^|[;&|[:space:]])pip3?[[:space:]]+(install|freeze|uninstall)([[:space:]]|$)'; then
+segment_has_direct_python() {
+    printf '%s\n' "$1" \
+        | tr ';\n' '\n' \
+        | sed -e 's/&&/\n/g' -e 's/||/\n/g' -e 's/|/\n/g' \
+        | while IFS= read -r segment; do
+            segment="${segment#"${segment%%[![:space:]]*}"}"
+            while printf '%s' "$segment" | grep -Eq '^[A-Za-z_][A-Za-z0-9_]*='; do
+                segment="${segment#* }"
+                segment="${segment#"${segment%%[![:space:]]*}"}"
+            done
+            printf '%s' "$segment" \
+                | grep -Eq '^python3?([[:space:]]|$)' \
+                && echo MATCH
+        done \
+        | grep -q MATCH
+}
+
+if segment_has_direct_python "$cmd"; then
+    matched="direct python invocation"
+elif printf '%s' "$cmd" | grep -Eq '(^|[;&|[:space:]])pip3?[[:space:]]+(install|freeze|uninstall)([[:space:]]|$)'; then
     matched="pip install/freeze/uninstall"
 elif printf '%s' "$cmd" | grep -Eq '(^|[;&|[:space:]])python3?[[:space:]]+-m[[:space:]]+pip([[:space:]]|$)'; then
     matched="python -m pip"

--- a/scripts/claude-hooks/format-rust.sh
+++ b/scripts/claude-hooks/format-rust.sh
@@ -14,9 +14,9 @@ payload="$(cat)"
 file=""
 if command -v jq >/dev/null 2>&1; then
     file="$(printf '%s' "$payload" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)"
-elif command -v python3 >/dev/null 2>&1; then
+elif command -v uv >/dev/null 2>&1; then
     file="$(printf '%s' "$payload" \
-        | python3 -c 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("file_path",""))' \
+        | UV_CACHE_DIR="${TMPDIR:-/tmp}/vokra-uv-cache" uv run --no-project --python 3.12 python -c 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("file_path",""))' \
         2>/dev/null || true)"
 fi
 

--- a/scripts/claude-hooks/guard-deps.sh
+++ b/scripts/claude-hooks/guard-deps.sh
@@ -15,9 +15,9 @@ payload="$(cat)"
 file=""
 if command -v jq >/dev/null 2>&1; then
     file="$(printf '%s' "$payload" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)"
-elif command -v python3 >/dev/null 2>&1; then
+elif command -v uv >/dev/null 2>&1; then
     file="$(printf '%s' "$payload" \
-        | python3 -c 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("file_path",""))' \
+        | UV_CACHE_DIR="${TMPDIR:-/tmp}/vokra-uv-cache" uv run --no-project --python 3.12 python -c 'import sys,json; print(json.load(sys.stdin).get("tool_input",{}).get("file_path",""))' \
         2>/dev/null || true)"
 fi
 


### PR DESCRIPTION
## What changed

- port the remaining Claude Code compatibility changes from `feat/audit-followup-cc-wave1-2026-08-14` onto current `main`
- route Claude hook JSON fallbacks through `uv run --no-project --python 3.12`
- block direct local `python` / `python3` commands in the Claude Bash guard, matching the Codex policy
- update Claude-facing skill commands to use uv
- add a self-test for the Claude Python/package-manager guard

## Why

The old audit branch cannot be merged safely as a whole: its first 121 commits were already squash-merged by #29, its Codex migration was merged by #32, and a direct merge now has substantial conflicts. The only useful residual delta is Claude compatibility parity for the repository's uv-only Python policy.

The stricter current-main VAST policy is intentionally preserved. This PR does not import the old branch's temporary allowance for local `vokra-models` Cargo.

## Validation

- `bash scripts/claude-hooks/block-pip-conda.sh --self-test`
- `bash -n scripts/claude-hooks/{block-cargo-add,block-pip-conda,format-rust,guard-deps}.sh`
- `shellcheck scripts/claude-hooks/{block-cargo-add,block-pip-conda,format-rust,guard-deps}.sh`
- `UV_CACHE_DIR=/private/tmp/vokra-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/vokra-pycache bash scripts/check-workflow-hygiene.sh`
- pre-commit five-gate suite
- `git diff --check`

The local pre-push compile suite was intentionally skipped because changes under `scripts/` force a workspace-wide Cargo run, which this repository requires to run remotely/VAST on the maintainer's 16 GB Mac. GitHub Actions remains the authoritative compile/test gate.

Source branch retained until this PR merges: `feat/audit-followup-cc-wave1-2026-08-14` at `8811f4d`.