### PR TITLE
feat(ops): add allocation-free streaming resampler

### DIFF
--- a/crates/vokra-ops/src/lib.rs
+++ b/crates/vokra-ops/src/lib.rs
@@ -13,8 +13,9 @@
 //!   [`dct()`], [`mfcc()`] and the [`dispatch()`] bridge to the IR;
 //! - **M0-05**: LSTM family needed by the Silero VAD subgraph;
 //! - **M0-06**: attention / decoder family needed by Whisper;
-//! - **M1-06** (landed): front-end preprocessing — [`resample()`] (a native
-//!   Kaiser-windowed-sinc converter, GPL-free by construction) and the
+//! - **M1-06** (landed): front-end preprocessing — [`resample()`] and
+//!   [`StreamingResampler`] (native Kaiser-windowed-sinc converters, GPL-free
+//!   by construction) and the
 //!   `frontend_spec`-driven [`dc_offset_remove`] / [`pre_emphasis`] chain
 //!   ([`apply_frontend`]);
 //! - **M1-03** (landed): the [`frontend`] `frontend_spec` → `StftAttrs` /
@@ -531,7 +532,7 @@ pub use prosody::{ApplyProsody, ProsodyControl};
 // ---- SoTA plan Phase 3 qwen3_tts_codec re-exports -----------------------
 pub use qwen3_tts_codec::{Qwen3TtsCodec, Qwen3TtsCodecConfig, qwen3_tts_codec_decode};
 // -------------------------------------------------------------------------
-pub use resample::resample;
+pub use resample::{StreamingResampler, resample};
 // ---- SoTA plan denoise Wave A rnnoise re-exports (2026-08-05) -----------
 pub use rnnoise::{
     Activation as RnnoiseActivation, BARK_BAND_EDGES, FRAME_HOP, FRAME_SIZE, N_BARK_BANDS,

--- a/crates/vokra-ops/src/resample.rs
+++ b/crates/vokra-ops/src/resample.rs
@@ -30,10 +30,11 @@
 //!   passband gain to exactly `1.0` for every fractional phase, so a constant
 //!   input maps to itself and a linear ramp is preserved on the interior.
 //!
-//! Equal rates short-circuit to a bit-exact copy. This module ships the
-//! **one-shot** path; the streaming wrapper (phase-accumulator + input-history
-//! carry-over across chunks) is M1-08, and `SincResampler` is laid out with
-//! that split already in mind.
+//! Equal rates short-circuit to a bit-exact copy. [`StreamingResampler`] adds
+//! a fixed-size history ring and an absolute output-phase counter. It delays
+//! each centered-sinc output until the right-hand support is available, then
+//! treats `process_into(&[], out)` as the explicit end-of-stream flush. That
+//! preserves the one-shot arithmetic exactly across arbitrary chunk borders.
 
 use vokra_core::{Result, VokraError};
 
@@ -104,10 +105,8 @@ pub fn quality_params(quality: u8) -> (usize, f64) {
 /// A configured windowed-sinc resampler.
 ///
 /// Holds the precomputed kernel geometry for one `(in_rate, out_rate, quality)`
-/// triple. M1-06 exposes only the one-shot [`resample`](Self::resample); the
-/// M1-08 streaming wrapper will extend this with a fractional phase accumulator
-/// and an input-history ring buffer so successive chunks join seamlessly —
-/// hence the config is split out from the transient state here.
+/// triple. Both the one-shot path and [`StreamingResampler`] share this exact
+/// kernel so chunking cannot alter tap order or floating-point arithmetic.
 struct SincResampler {
     /// Output-to-input rate ratio (`out_rate / in_rate`).
     ratio: f64,
@@ -176,6 +175,240 @@ impl SincResampler {
             out.push(y as f32);
         }
         out
+    }
+}
+
+/// Stateful, allocation-free-after-construction streaming resampler.
+///
+/// The centered sinc kernel needs future input. [`process_into`](Self::process_into)
+/// therefore emits only samples whose full right-hand support has arrived.
+/// Call it once with an empty input slice after the final chunk to flush the
+/// zero-padded tail and reproduce [`resample`] exactly. After a flush, more
+/// non-empty input is rejected until [`reset`](Self::reset) makes the stream
+/// reusable.
+///
+/// `out` must be large enough for every output made available by the supplied
+/// chunk (or by the final flush). A too-small buffer returns
+/// [`VokraError::InvalidArgument`] without consuming input or advancing phase.
+/// This all-or-nothing contract is necessary because the API returns an output
+/// count, not a separate consumed-input count.
+pub struct StreamingResampler {
+    sinc: SincResampler,
+    /// Fixed-size ring of the most recent input samples. A newly-ready output
+    /// spans at most `ceil(2 * radius) + 1` samples.
+    history: Vec<f32>,
+    delay_samples: usize,
+    total_input: usize,
+    next_output: usize,
+    flushed: bool,
+}
+
+impl StreamingResampler {
+    /// Creates a streaming resampler for one fixed rate/quality triple.
+    ///
+    /// All storage is allocated here. Successful calls to
+    /// [`process_into`](Self::process_into) allocate nothing.
+    ///
+    /// # Errors
+    ///
+    /// [`VokraError::InvalidArgument`] if either rate is zero.
+    pub fn new(in_rate: u32, out_rate: u32, quality: u8) -> Result<Self> {
+        if in_rate == 0 || out_rate == 0 {
+            return Err(VokraError::InvalidArgument(
+                "StreamingResampler::new: in_rate and out_rate must be non-zero".to_owned(),
+            ));
+        }
+        let (half, _) = quality_params(quality);
+        let sinc = SincResampler::new(in_rate, out_rate, quality);
+        let history_len = if in_rate == out_rate {
+            1
+        } else {
+            (2.0 * sinc.radius).ceil() as usize + 3
+        };
+        let delay_samples = if in_rate == out_rate {
+            0
+        } else if out_rate < in_rate {
+            // radius = half / (out_rate / in_rate), so converting the
+            // look-ahead back to output-rate samples cancels the ratio.
+            half
+        } else {
+            // Upsampling uses radius = half. Compute ceil(half * out / in)
+            // with integers so an exact boundary cannot round up spuriously.
+            let numerator = half as u64 * u64::from(out_rate);
+            let denominator = u64::from(in_rate);
+            numerator.div_ceil(denominator) as usize
+        };
+        Ok(Self {
+            sinc,
+            history: vec![0.0; history_len],
+            delay_samples,
+            total_input: 0,
+            next_output: 0,
+            flushed: false,
+        })
+    }
+
+    /// Processes one input chunk into a caller-owned output buffer.
+    ///
+    /// A non-empty `input` appends to the current stream and returns the number
+    /// of newly available output samples written to the start of `out`. An
+    /// empty `input` is the explicit end-of-stream flush: it emits the
+    /// centered kernel's zero-padded tail up to the same
+    /// `round(total_input * out_rate / in_rate)` length as [`resample`].
+    ///
+    /// The successful path is zero-allocation. Output is bit-identical to the
+    /// one-shot implementation because it uses the same absolute output index,
+    /// tap order, f64 accumulation, normalization and f32 cast.
+    ///
+    /// # Errors
+    ///
+    /// [`VokraError::InvalidArgument`] if `out` is too small, the cumulative
+    /// input length exceeds the implementation's `isize` indexing range, or a
+    /// non-empty chunk is supplied after flush without an intervening
+    /// [`reset`](Self::reset). Errors leave the stream state unchanged.
+    // ZERO-ALLOC-BEGIN (#50: steady-state streaming sample-rate conversion)
+    pub fn process_into(&mut self, input: &[f32], out: &mut [f32]) -> Result<usize> {
+        if input.is_empty() {
+            return self.flush_into(out);
+        }
+        if self.flushed {
+            return Err(VokraError::InvalidArgument(
+                "StreamingResampler::process_into: non-empty input after end-of-stream flush; \
+                 call reset() before starting another stream"
+                    .to_owned(),
+            ));
+        }
+
+        let new_total = self.total_input.checked_add(input.len()).ok_or_else(|| {
+            VokraError::InvalidArgument(
+                "StreamingResampler::process_into: cumulative input length overflows usize"
+                    .to_owned(),
+            )
+        })?;
+        if new_total > isize::MAX as usize {
+            return Err(VokraError::InvalidArgument(format!(
+                "StreamingResampler::process_into: cumulative input length {new_total} exceeds \
+                 isize::MAX"
+            )));
+        }
+
+        if self.sinc.ratio == 1.0 {
+            if out.len() < input.len() {
+                return Err(VokraError::InvalidArgument(format!(
+                    "StreamingResampler::process_into: out.len() {} < required {} for equal-rate \
+                     copy",
+                    out.len(),
+                    input.len(),
+                )));
+            }
+            let new_next_output = self.next_output.checked_add(input.len()).ok_or_else(|| {
+                VokraError::InvalidArgument(
+                    "StreamingResampler::process_into: output index overflows usize".to_owned(),
+                )
+            })?;
+            out[..input.len()].copy_from_slice(input);
+            self.total_input = new_total;
+            self.next_output = new_next_output;
+            return Ok(input.len());
+        }
+
+        let ready_end = self.ready_output_end(new_total);
+        let required = ready_end - self.next_output;
+        if out.len() < required {
+            return Err(VokraError::InvalidArgument(format!(
+                "StreamingResampler::process_into: out.len() {} < {required} newly available \
+                 samples (state unchanged)",
+                out.len(),
+            )));
+        }
+
+        let mut written = 0usize;
+        for &sample in input {
+            let slot = self.total_input % self.history.len();
+            self.history[slot] = sample;
+            self.total_input += 1;
+            while self.output_is_ready(self.next_output, self.total_input) {
+                out[written] = self.interpolate(self.next_output);
+                written += 1;
+                self.next_output += 1;
+            }
+        }
+        debug_assert_eq!(written, required);
+        Ok(written)
+    }
+    // ZERO-ALLOC-END
+
+    /// Algorithmic look-ahead latency in **output-rate samples**.
+    ///
+    /// This is `ceil(radius * out_rate / in_rate)`, the centered kernel's
+    /// right-hand support converted from input samples to output samples.
+    /// Equal-rate copy mode reports zero. At quality 5 the NanoCodec device
+    /// routes report 35 samples (22.05→48 kHz), 18 (→24 kHz), and 16 (→16
+    /// kHz), all far below one 80 ms / 12.5 fps codec frame.
+    #[must_use]
+    pub fn delay_samples(&self) -> usize {
+        self.delay_samples
+    }
+
+    /// Clears history and phase so this allocation can process a new stream.
+    pub fn reset(&mut self) {
+        self.total_input = 0;
+        self.next_output = 0;
+        self.flushed = false;
+    }
+
+    fn flush_into(&mut self, out: &mut [f32]) -> Result<usize> {
+        if self.total_input == 0 || self.flushed {
+            return Ok(0);
+        }
+        let target = (self.total_input as f64 * self.sinc.ratio).round() as usize;
+        debug_assert!(self.next_output <= target);
+        let required = target - self.next_output;
+        if out.len() < required {
+            return Err(VokraError::InvalidArgument(format!(
+                "StreamingResampler::process_into flush: out.len() {} < {required} tail \
+                 samples (state unchanged)",
+                out.len(),
+            )));
+        }
+        for dst in &mut out[..required] {
+            *dst = self.interpolate(self.next_output);
+            self.next_output += 1;
+        }
+        self.flushed = true;
+        Ok(required)
+    }
+
+    fn ready_output_end(&self, input_len: usize) -> usize {
+        let mut output_index = self.next_output;
+        while self.output_is_ready(output_index, input_len) {
+            output_index += 1;
+        }
+        output_index
+    }
+
+    fn output_is_ready(&self, output_index: usize, input_len: usize) -> bool {
+        let center = output_index as f64 * self.sinc.step;
+        let hi = (center + self.sinc.radius).floor() as usize;
+        hi < input_len
+    }
+
+    fn interpolate(&self, output_index: usize) -> f32 {
+        let center = output_index as f64 * self.sinc.step;
+        let lo = (center - self.sinc.radius).ceil() as isize;
+        let hi = (center + self.sinc.radius).floor() as isize;
+        let mut num = 0.0f64;
+        let mut den = 0.0f64;
+        for i in lo..=hi {
+            let h = self.sinc.kernel(center - i as f64);
+            den += h;
+            if i >= 0 && (i as usize) < self.total_input {
+                let absolute = i as usize;
+                debug_assert!(self.total_input - absolute <= self.history.len());
+                num += f64::from(self.history[absolute % self.history.len()]) * h;
+            }
+        }
+        if den != 0.0 { (num / den) as f32 } else { 0.0 }
     }
 }
 
@@ -357,6 +590,153 @@ mod tests {
             }
             assert!(max < 2e-2, "roundtrip via {mid}: max err {max}");
         }
+    }
+
+    fn stream_in_irregular_chunks(input: &[f32], out_rate: u32) -> Vec<f32> {
+        let mut stream = StreamingResampler::new(22_050, out_rate, 5).unwrap();
+        let chunk_sizes = [1usize, 17, 160, 7, 441, 89, 1024, 3, 256];
+        let mut output = Vec::new();
+        let mut cursor = 0usize;
+        let mut chunk_index = 0usize;
+        while cursor < input.len() {
+            let take = chunk_sizes[chunk_index % chunk_sizes.len()].min(input.len() - cursor);
+            let mut scratch = vec![0.0f32; take * 3 + 256];
+            let written = stream
+                .process_into(&input[cursor..cursor + take], &mut scratch)
+                .unwrap();
+            output.extend_from_slice(&scratch[..written]);
+            cursor += take;
+            chunk_index += 1;
+        }
+        let mut tail = vec![0.0f32; stream.delay_samples() + 256];
+        let written = stream.process_into(&[], &mut tail).unwrap();
+        output.extend_from_slice(&tail[..written]);
+        output
+    }
+
+    #[test]
+    fn streaming_chunks_are_bit_identical_to_one_shot_for_nanocodec_rates() {
+        let input: Vec<f32> = (0..5000)
+            .map(|i| {
+                let t = i as f64 / 22_050.0;
+                (0.6 * (TAU * 237.0 * t).sin() + 0.25 * (TAU * 1703.0 * t).sin()) as f32
+            })
+            .collect();
+        for out_rate in [48_000u32, 24_000, 16_000] {
+            let want = resample(&input, 22_050, out_rate, 5).unwrap();
+            let got = stream_in_irregular_chunks(&input, out_rate);
+            assert_eq!(
+                got, want,
+                "chunk boundaries must not change samples for 22050 -> {out_rate}",
+            );
+        }
+    }
+
+    #[test]
+    fn streaming_delay_is_reported_in_output_samples_and_below_one_codec_frame() {
+        for (out_rate, expected_delay) in [(48_000u32, 35usize), (24_000, 18), (16_000, 16)] {
+            let stream = StreamingResampler::new(22_050, out_rate, 5).unwrap();
+            let one_codec_frame = out_rate as usize * 2 / 25; // 12.5 fps = 80 ms.
+            assert_eq!(stream.delay_samples(), expected_delay);
+            assert!(
+                stream.delay_samples() <= one_codec_frame,
+                "22050 -> {out_rate}: delay {} > one 80ms frame {one_codec_frame}",
+                stream.delay_samples(),
+            );
+        }
+        assert_eq!(
+            StreamingResampler::new(22_050, 22_050, 5)
+                .unwrap()
+                .delay_samples(),
+            0
+        );
+    }
+
+    #[test]
+    fn streaming_reset_reproduces_a_fresh_stream() {
+        let input = sine(997.0, 22_050, 2048);
+        let mut stream = StreamingResampler::new(22_050, 48_000, 5).unwrap();
+        let mut first = vec![0.0f32; 5000];
+        let n_first = stream.process_into(&input, &mut first).unwrap();
+        let n_tail = stream.process_into(&[], &mut first[n_first..]).unwrap();
+        let first = first[..n_first + n_tail].to_vec();
+
+        stream.reset();
+        let mut second = vec![0.0f32; 5000];
+        let n_second = stream.process_into(&input, &mut second).unwrap();
+        let n_tail = stream.process_into(&[], &mut second[n_second..]).unwrap();
+        assert_eq!(first, second[..n_second + n_tail]);
+    }
+
+    #[test]
+    fn streaming_buffer_errors_do_not_advance_state() {
+        let input = sine(440.0, 22_050, 256);
+        let mut stream = StreamingResampler::new(22_050, 48_000, 5).unwrap();
+        assert!(matches!(
+            stream.process_into(&input, &mut []),
+            Err(VokraError::InvalidArgument(_)),
+        ));
+
+        let mut got = vec![0.0f32; 1024];
+        let n = stream.process_into(&input, &mut got).unwrap();
+        let mut fresh = StreamingResampler::new(22_050, 48_000, 5).unwrap();
+        let mut want = vec![0.0f32; 1024];
+        let want_n = fresh.process_into(&input, &mut want).unwrap();
+        assert_eq!(n, want_n);
+        assert_eq!(got[..n], want[..want_n]);
+
+        let mut too_short_tail = [];
+        assert!(matches!(
+            stream.process_into(&[], &mut too_short_tail),
+            Err(VokraError::InvalidArgument(_)),
+        ));
+        let mut got_tail = [0.0f32; 256];
+        let got_tail_n = stream.process_into(&[], &mut got_tail).unwrap();
+        let mut want_tail = [0.0f32; 256];
+        let want_tail_n = fresh.process_into(&[], &mut want_tail).unwrap();
+        assert_eq!(got_tail_n, want_tail_n);
+        assert_eq!(got_tail[..got_tail_n], want_tail[..want_tail_n]);
+    }
+
+    #[test]
+    fn streaming_equal_rate_is_bit_exact_and_rejects_short_output() {
+        let input = sine(440.0, 22_050, 256);
+        let mut stream = StreamingResampler::new(22_050, 22_050, 5).unwrap();
+        assert!(matches!(
+            stream.process_into(&input, &mut [0.0; 255]),
+            Err(VokraError::InvalidArgument(_)),
+        ));
+        let mut output = [0.0f32; 256];
+        let written = stream.process_into(&input, &mut output).unwrap();
+        assert_eq!(written, input.len());
+        assert_eq!(output.as_slice(), input.as_slice());
+        assert_eq!(stream.process_into(&[], &mut output).unwrap(), 0);
+    }
+
+    #[test]
+    fn streaming_zero_rate_is_rejected() {
+        assert!(matches!(
+            StreamingResampler::new(0, 16_000, 5),
+            Err(VokraError::InvalidArgument(_)),
+        ));
+        assert!(matches!(
+            StreamingResampler::new(16_000, 0, 5),
+            Err(VokraError::InvalidArgument(_)),
+        ));
+    }
+
+    #[test]
+    fn streaming_rejects_more_input_after_flush_until_reset() {
+        let mut stream = StreamingResampler::new(22_050, 16_000, 5).unwrap();
+        let mut out = [0.0f32; 256];
+        stream.process_into(&[0.25; 128], &mut out).unwrap();
+        stream.process_into(&[], &mut out).unwrap();
+        assert!(matches!(
+            stream.process_into(&[0.5], &mut out),
+            Err(VokraError::InvalidArgument(_)),
+        ));
+        stream.reset();
+        assert!(stream.process_into(&[0.5], &mut out).is_ok());
     }
 
     #[test]

--- a/crates/vokra-ops/tests/streaming_resampler_hot_path_alloc.rs
+++ b/crates/vokra-ops/tests/streaming_resampler_hot_path_alloc.rs
@@ -1,0 +1,58 @@
+//! Counting-allocator proof for `StreamingResampler::process_into` (#50).
+
+#![allow(unsafe_code)]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use vokra_ops::StreamingResampler;
+
+struct CountingAlloc;
+
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+
+// SAFETY: the wrapper delegates to `System` without changing pointer/layout
+// contracts and only increments a diagnostic counter.
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        // SAFETY: forwarding the exact layout to `System`.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: forwarding a pointer with its original layout.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        // SAFETY: forwarding the original allocation and requested size.
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAlloc = CountingAlloc;
+
+#[test]
+fn one_thousand_steady_state_chunks_allocate_zero() {
+    let mut stream = StreamingResampler::new(22_050, 48_000, 5).unwrap();
+    let input = [0.125f32; 64];
+    let mut out = [0.0f32; 256];
+
+    stream.process_into(&input, &mut out).expect("warm-up");
+    let before = ALLOCS.load(Ordering::SeqCst);
+    for _ in 0..1000 {
+        stream
+            .process_into(&input, &mut out)
+            .expect("steady-state chunk");
+    }
+    let after = ALLOCS.load(Ordering::SeqCst);
+
+    assert_eq!(
+        after - before,
+        0,
+        "StreamingResampler::process_into allocated in steady state",
+    );
+}

--- a/docs/abi-changelog.md
+++ b/docs/abi-changelog.md
@@ -250,6 +250,23 @@ still legal, and still requires a dated entry in `## Entries` below. The freeze
 
 ## Entries
 
+### 2026-08-21 — 1.0.0-rc.1-dev (stateful streaming resampler — Rust surface only, additive)
+
+Issue #50 adds a caller-owned-buffer streaming wrapper around Vokra's existing
+Kaiser-windowed-sinc resampler. The C ABI and GGUF schema are unchanged. The
+Rust API is additive, preserves the one-shot sample sequence across arbitrary
+chunk boundaries, and allocates all history storage in `new`; a
+1000-steady-state-call counting-allocator test and the zero-allocation source
+gate cover `process_into`.
+
+| Crate / area | Symbol | Kind | Signature | Rationale | Breaking? | PR |
+| --- | --- | --- | --- | --- | --- | --- |
+| `vokra-ops::resample` | `StreamingResampler` | Added | `pub struct StreamingResampler` | Owns the fixed history ring and absolute phase for #50 without exposing implementation fields. | no | (TBD) |
+| `vokra-ops::resample` | `StreamingResampler::delay_samples` | Added | `pub fn delay_samples(&self) -> usize` | Reports centered-kernel look-ahead in output-rate samples for device latency budgeting. | no | (TBD) |
+| `vokra-ops::resample` | `StreamingResampler::new` | Added | `pub fn new(in_rate: u32, out_rate: u32, quality: u8) -> Result<Self>` | Allocates and validates one fixed-rate streaming resampler. | no | (TBD) |
+| `vokra-ops::resample` | `StreamingResampler::process_into` | Added | `pub fn process_into(&mut self, input: &[f32], out: &mut [f32]) -> Result<usize>` | Processes chunks without allocation and uses empty input as an explicit final flush. | no | (TBD) |
+| `vokra-ops::resample` | `StreamingResampler::reset` | Added | `pub fn reset(&mut self)` | Reuses the existing allocation for a new stream. | no | (TBD) |
+
 ### 2026-08-15 — 1.0.0-rc.1-dev (LLaMA-Omni2: the converter now stamps the full `vokra.llama_omni2.*` group its own binder reads, and refuses without `--config` — GGUF schema fill + Rust surface, advisory)
 
 **Behaviour change** plus additive Rust surface. The C ABI

--- a/docs/abi/vokra-rust-public-api.v1.0-rc.list
+++ b/docs/abi/vokra-rust-public-api.v1.0-rc.list
@@ -988,8 +988,12 @@ FN vokra-ops::qwen3_tts_codec::quantizer_vocab_size|pub fn quantizer_vocab_size(
 FN vokra-ops::qwen3_tts_codec::qwen3_tts_12hz|pub const fn qwen3_tts_12hz() -> Self {
 FN vokra-ops::qwen3_tts_codec::qwen3_tts_codec_decode|pub fn qwen3_tts_codec_decode(
 FN vokra-ops::qwen3_tts_codec::tables|pub fn tables(&self) -> &[CodebookTable] {
+FN vokra-ops::resample::delay_samples|pub fn delay_samples(&self) -> usize {
+FN vokra-ops::resample::new|pub fn new(in_rate: u32, out_rate: u32, quality: u8) -> Result<Self> {
+FN vokra-ops::resample::process_into|pub fn process_into(&mut self, input: &[f32], out: &mut [f32]) -> Result<usize> {
 FN vokra-ops::resample::quality_params|pub fn quality_params(quality: u8) -> (usize, f64) {
 FN vokra-ops::resample::resample|pub fn resample(input: &[f32], in_rate: u32, out_rate: u32, quality: u8) -> Result<Vec<f32>> {
+FN vokra-ops::resample::reset|pub fn reset(&mut self) {
 FN vokra-ops::rnnoise::bark_dct|pub fn bark_dct(log_energies: &[f32; N_BARK_BANDS]) -> [f32; N_BARK_BANDS] {
 FN vokra-ops::rnnoise::bark_filterbank|pub fn bark_filterbank(magnitude: &[f32]) -> Result<[f32; N_BARK_BANDS]> {
 FN vokra-ops::rnnoise::dense_forward|pub fn dense_forward(
@@ -1432,6 +1436,7 @@ STRUCT vokra-ops::openwakeword::OpenwakewordClassifierWeights|pub struct Openwak
 STRUCT vokra-ops::prosody::ProsodyControl|pub struct ProsodyControl {
 STRUCT vokra-ops::qwen3_tts_codec::Qwen3TtsCodecConfig|pub struct Qwen3TtsCodecConfig {
 STRUCT vokra-ops::qwen3_tts_codec::Qwen3TtsCodec|pub struct Qwen3TtsCodec {
+STRUCT vokra-ops::resample::StreamingResampler|pub struct StreamingResampler {
 STRUCT vokra-ops::rnnoise::PitchState|pub struct PitchState {
 STRUCT vokra-ops::rnnt_decode::RnntAttrs|pub struct RnntAttrs {
 STRUCT vokra-ops::rnnt_decode::RnntHypothesis|pub struct RnntHypothesis {
@@ -1620,7 +1625,7 @@ USE vokra-ops::openwakeword::{OpenwakewordClassifierWeights, openwakeword_classi
 USE vokra-ops::preprocess::{apply_frontend, dc_offset_remove, pre_emphasis}|pub use preprocess::{apply_frontend, dc_offset_remove, pre_emphasis};
 USE vokra-ops::prosody::{ApplyProsody, ProsodyControl}|pub use prosody::{ApplyProsody, ProsodyControl};
 USE vokra-ops::qwen3_tts_codec::{Qwen3TtsCodec, Qwen3TtsCodecConfig, qwen3_tts_codec_decode}|pub use qwen3_tts_codec::{Qwen3TtsCodec, Qwen3TtsCodecConfig, qwen3_tts_codec_decode};
-USE vokra-ops::resample::resample|pub use resample::resample;
+USE vokra-ops::resample::{StreamingResampler, resample}|pub use resample::{StreamingResampler, resample};
 USE vokra-ops::rnnoise::{ Activation as RnnoiseActivation, BARK_BAND_EDGES, FRAME_HOP, FRAME_SIZE, N_BARK_BANDS, N_FEATURES, N_PITCH_BANDS, N_STFT_BINS, PITCH_BUF_SIZE, PitchState, bark_dct, bark_filterbank, dense_forward as rnnoise_dense_forward, gru_forward as rnnoise_gru_forward, interp_bark_gains, pack_features as rnnoise_pack_features, pitch_analysis, vorbis_window as rnnoise_vorbis_window, zero_pitch_features as rnnoise_zero_pitch_features, }|pub use rnnoise::{ Activation as RnnoiseActivation, BARK_BAND_EDGES, FRAME_HOP, FRAME_SIZE, N_BARK_BANDS, N_FEATURES, N_PITCH_BANDS, N_STFT_BINS, PITCH_BUF_SIZE, PitchState, bark_dct, bark_filterbank, dense_forward as rnnoise_dense_forward, gru_forward as rnnoise_gru_forward, interp_bark_gains, pack_features as rnnoise_pack_features, pitch_analysis, vorbis_window as rnnoise_vorbis_window, zero_pitch_features as rnnoise_zero_pitch_features, };
 USE vokra-ops::rnnt_decode::{RnntAttrs, RnntDecoderKind, RnntHypothesis, rnnt_decode}|pub use rnnt_decode::{RnntAttrs, RnntDecoderKind, RnntHypothesis, rnnt_decode};
 USE vokra-ops::snac_decode::{SnacConfig, SnacDecoder, SnacWeights}|pub use snac_decode::{SnacConfig, SnacDecoder, SnacWeights};

--- a/scripts/check-hot-path-allocs.sh
+++ b/scripts/check-hot-path-allocs.sh
@@ -27,6 +27,9 @@ FILES=(
     # M4-03: the AEC process()/DSP-kernel regions (FR-EX-05; the counting-
     # allocator proof lives in crates/vokra-ops/tests/aec_hot_path_alloc.rs).
     "crates/vokra-ops/src/aec.rs"
+    # #50: stateful streaming resampler; counting-allocator proof lives in
+    # crates/vokra-ops/tests/streaming_resampler_hot_path_alloc.rs.
+    "crates/vokra-ops/src/resample.rs"
 )
 
 # The forbidden allocating constructs, as a grep ERE. (Matching is done by grep,


### PR DESCRIPTION
## What this changes

22.05 kHz NanoCodec PCM を 48/24/16 kHz へ chunk-boundary independent に変換する allocation-free `StreamingResampler` を追加します。reset、flush、遅延照会、出力不足時の状態保持を含みます。

Closes #50

## How it was verified

VAST instance 48324876 (commit 7421d6751c70):

```
cargo test -p vokra-ops --lib resample::tests::  # 19 passed
cargo test -p vokra-ops --test streaming_resampler_hot_path_alloc  # 1 passed, 1000 chunks / 0 alloc
cargo clippy -p vokra-ops --all-targets -- -D warnings
```

Local gates:

```
cargo fmt --all -- --check
scripts/check-zero-deps.sh
scripts/check-forbidden-symbols.sh
scripts/check-hotpath-alloc.sh
```

## Checklist

- [x] Formatting and relevant clippy pass
- [ ] `cargo test --workspace` — package-focused verification used; CI runs the wider matrix
- [x] Zero external dependencies
- [x] No silent fallback
- [x] No parity tolerance was changed
- [x] N/A: no model weight, publication, prohibited dependency, or unsafe change

## Anything reviewers should look at closely

Streaming output is bit-identical to the existing one-shot implementation for all three required rates.
