### PR TITLE
feat(capi): expose streaming speech features

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -171,6 +171,7 @@ jobs:
       # are set. Unset (default) keeps today's behavior.
       VOKRA_WHISPER_GGUF: ${{ vars.VOKRA_WHISPER_GGUF_PATH || '' }}
       VOKRA_PIPER_GGUF: ${{ vars.VOKRA_PIPER_GGUF_PATH || '' }}
+      VOKRA_MOSHI_GGUF: ${{ vars.VOKRA_MOSHI_GGUF_PATH || '' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,7 +400,7 @@ jobs:
         run: bash scripts/check-zero-deps.sh
       - name: Forbidden symbols / dependencies check
         run: bash scripts/check-forbidden-symbols.sh
-      - name: Python binding C ABI drift (41-function header coverage)
+      - name: Python binding C ABI drift (48-function header coverage)
         run: >-
           uv run --no-project --python 3.12 python
           bindings/python/scripts/gen-py-bindings.py --check

--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -109,7 +109,7 @@ jobs:
               --find-links bindings/python/wheelhouse/final \
               --no-index --no-deps "vokra==${VOKRA_BUILD_VERSION}"
             uv run --no-project --python "$VENV_PYTHON" python -c \
-              'import os, vokra; from vokra import _bindings, _native; assert vokra.__version__ == os.environ["VOKRA_BUILD_VERSION"]; assert len(_bindings.PROTOTYPES) == 41; assert _native.load().vokra_version()'
+              'import os, vokra; from vokra import _bindings, _native; assert vokra.__version__ == os.environ["VOKRA_BUILD_VERSION"]; assert len(_bindings.PROTOTYPES) == 48; assert _native.load().vokra_version()'
           done
       - name: Run Python binding tests
         run: |
@@ -200,7 +200,7 @@ jobs:
               --find-links bindings/python/wheelhouse/final \
               --no-index --no-deps "vokra==${VOKRA_BUILD_VERSION}"
             uv run --no-project --python "$VENV_PYTHON" python -c \
-              'import os, vokra; from vokra import _bindings, _native; assert vokra.__version__ == os.environ["VOKRA_BUILD_VERSION"]; assert len(_bindings.PROTOTYPES) == 41; assert _native.load().vokra_version()'
+              'import os, vokra; from vokra import _bindings, _native; assert vokra.__version__ == os.environ["VOKRA_BUILD_VERSION"]; assert len(_bindings.PROTOTYPES) == 48; assert _native.load().vokra_version()'
           done
       - name: Run Python binding tests
         run: |
@@ -277,7 +277,7 @@ jobs:
               --find-links bindings/python/wheelhouse/final \
               --no-index --no-deps "vokra==${VOKRA_BUILD_VERSION}"
             uv run --no-project --python "$VENV_PYTHON" python -c \
-              'import os, vokra; from vokra import _bindings, _native; assert vokra.__version__ == os.environ["VOKRA_BUILD_VERSION"]; assert len(_bindings.PROTOTYPES) == 41; assert _native.load().vokra_version()'
+              'import os, vokra; from vokra import _bindings, _native; assert vokra.__version__ == os.environ["VOKRA_BUILD_VERSION"]; assert len(_bindings.PROTOTYPES) == 48; assert _native.load().vokra_version()'
           done
       - name: Run Python binding tests
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,15 @@ milestone below.
   bundle. Missing/foreign metadata, non-F32 tensors, and shape mismatches are
   model-load errors rather than partially loaded models.
 
+#### Streaming continuous speech features (2026-08-22)
+
+- Added the model-independent `SpeechFeatureEngine` / `SpeechFeatureStream`
+  seam and the `vokra_feat_*` C ABI. Moshi's causal Mimi encoder is the first
+  native implementation, exposing its continuous pre-RVQ 25 Hz hidden grid
+  with sample-accurate source timestamps, bounded backpressure, reset, and
+  allocation-free post-warmup push/pull paths. The generated Python `ctypes`
+  table and C smoke suite cover the additive surface (#49).
+
 #### Audio-wide coverage expansion (2026-07-24 → 2026-08-16)
 
 Vokra's scope widened from speech to audio: music generation, source

--- a/README.ja.md
+++ b/README.ja.md
@@ -403,9 +403,9 @@ Vokra は決して別のバックエンドや dtype に silently リルートし
   Linux x64、Windows MSVC、Android arm64）、AssetLib 形状のリリース
   レイアウト。
 - **Python（pre-alpha source）** — [`bindings/python/`](bindings/python) の
-  純粋 `ctypes` 実装（`pyo3` 非使用）。wheel scaffold はありますが、生成済み
-  binding は旧 14-function subset のまま（現行 C header は 41 functions）で、
-  package root もまだ `Session` を export しません。PyPI 公開は pending として
+  純粋 `ctypes` 実装（`pyo3` 非使用）。生成 table は現行 C header の48 functions
+  すべてを覆い、package root は `Session`、`Stream`、`Event`、typed error を
+  export します。wheel 検証と PyPI 公開は pending として
   [binding README](bindings/python/README.md) を参照してください。
 - **HTTP サーバ** — [`integrations/vokra-server`](integrations/vokra-server):
   **OpenAI Whisper** (`/v1/audio/transcriptions`)、**piper-plus HTTP**

--- a/README.md
+++ b/README.md
@@ -407,10 +407,10 @@ Vokra never silently reroutes to a different backend or dtype.
   five-target cross-build matrix (macOS Intel + Apple Silicon, Linux x64,
   Windows MSVC, Android arm64) with an AssetLib-shaped release layout.
 - **Python (pre-alpha source)** — pure `ctypes` (no `pyo3`) under
-  [`bindings/python/`](bindings/python). The wheel scaffold exists, but the
-  checked-in binding still covers the earlier 14-function subset while the
-  current C header has 41 functions, and the package root does not yet export
-  `Session`. Treat PyPI publication as pending; see the binding README.
+  [`bindings/python/`](bindings/python). The generated table covers all 48
+  current C functions and the package root exports `Session`, `Stream`,
+  `Event`, and typed errors. Treat wheel verification and PyPI publication as
+  pending; see the binding README.
 - **HTTP server** — [`integrations/vokra-server`](integrations/vokra-server):
   an isolated workspace implementing **OpenAI Whisper**
   (`/v1/audio/transcriptions`), **piper-plus HTTP** (`/api/tts`), and

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -7,8 +7,7 @@ keeps third-party Python runtime dependencies at zero.
 
 ## Status: source implementation current, package unpublished
 
-**Reviewed:** 2026-08-20 against `main` at `234d368` plus the Python binding
-changes in this worktree.
+**Reviewed:** 2026-08-22 against the generated issue #49 C header.
 
 The package metadata is `0.1.0.dev0`; this checkout must not be documented as
 an installed `vokra==0.1.0` release. The source tree exports `Session`,
@@ -18,13 +17,13 @@ header has a runtime version function, not a separately versioned ABI symbol.
 
 The source-side C-ABI drift is closed in this worktree:
 
-- `include/vokra.h` currently exports 41 `vokra_*` functions;
+- `include/vokra.h` currently exports 48 `vokra_*` functions;
 - `src/vokra/_bindings.py` contains one prototype for every function;
-- the generator discovers all four enums, both concrete structs, and all seven
+- the generator discovers all four enums, both concrete structs, and all eight
   opaque handles, including the `uint8_t`, `uint64_t`, plain-`bool`, and
   struct-pointer shapes that previously blocked generation;
 - the required `license` job runs the uv-only drift check, and the wheel smoke
-  loads the matching native library after asserting the public API and 41-entry
+  loads the matching native library after asserting the public API and 48-entry
   table.
 
 This is still not a publication claim. A final branch CI run must prove the
@@ -105,7 +104,7 @@ bindings/python/
 ├── src/vokra/
 │   ├── __init__.py        # lazy public Session/Stream/Event/error exports
 │   ├── _native.py         # ctypes.CDLL loader
-│   ├── _bindings.py       # generated 41-function ctypes table
+│   ├── _bindings.py       # generated 48-function ctypes table
 │   ├── _handles.py        # opaque handle wrappers
 │   ├── session.py         # Session lifecycle + ASR/TTS wrapper
 │   ├── stream.py          # Stream lifecycle + push/poll/event wrapper

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -35,7 +35,10 @@ dependencies = []
 [project.optional-dependencies]
 numpy = ["numpy>=1.23,<2"]
 dev = [
-    "pytest>=7.4",
+    # GHSA-6w46-j5rx-g56g is fixed in pytest 9.0.3. pytest 9 requires
+    # Python 3.10; Python 3.9 remains a supported runtime target, but its
+    # dependency-free wheel is not a supported contributor test environment.
+    "pytest>=9.0.3; python_version >= '3.10'",
     "pip-licenses>=4.3",
 ]
 

--- a/bindings/python/scripts/gen-py-bindings.py
+++ b/bindings/python/scripts/gen-py-bindings.py
@@ -40,6 +40,7 @@ PRIM_TYPES = {
     "bool": "ctypes.c_bool",
     "char": "ctypes.c_char",
     "int32_t": "ctypes.c_int32",
+    "int64_t": "ctypes.c_int64",
     "uint8_t": "ctypes.c_uint8",
     "uint32_t": "ctypes.c_uint32",
     "uint64_t": "ctypes.c_uint64",

--- a/bindings/python/src/vokra/_bindings.py
+++ b/bindings/python/src/vokra/_bindings.py
@@ -62,6 +62,7 @@ class vokra_event_t(ctypes.Structure):
 # native runtime owns their layouts.
 vokra_aec_ref_writer_t = ctypes.c_void_p
 vokra_aec_t = ctypes.c_void_p
+vokra_feat_t = ctypes.c_void_p
 vokra_s2s_duplex_t = ctypes.c_void_p
 vokra_s2s_interrupt_t = ctypes.c_void_p
 vokra_session_options_t = ctypes.c_void_p
@@ -109,6 +110,34 @@ PROTOTYPES = {
     'vokra_last_error': (
         ctypes.c_char_p,
         (),
+    ),
+    'vokra_feat_open': (
+        ctypes.c_void_p,
+        (ctypes.c_void_p,),
+    ),
+    'vokra_feat_frame_rate_mhz': (
+        ctypes.c_int32,
+        (ctypes.c_void_p,),
+    ),
+    'vokra_feat_dim': (
+        ctypes.c_int32,
+        (ctypes.c_void_p,),
+    ),
+    'vokra_feat_push_pcm': (
+        ctypes.c_int,
+        (ctypes.c_void_p, ctypes.POINTER(ctypes.c_float), ctypes.c_size_t,),
+    ),
+    'vokra_feat_pull': (
+        ctypes.c_int,
+        (ctypes.c_void_p, ctypes.POINTER(ctypes.c_float), ctypes.c_size_t, ctypes.POINTER(ctypes.c_size_t), ctypes.POINTER(ctypes.c_int64),),
+    ),
+    'vokra_feat_reset': (
+        None,
+        (ctypes.c_void_p,),
+    ),
+    'vokra_feat_destroy': (
+        None,
+        (ctypes.c_void_p,),
     ),
     'vokra_session_options_create': (
         ctypes.c_void_p,

--- a/bindings/python/tests/test_codegen.py
+++ b/bindings/python/tests/test_codegen.py
@@ -36,7 +36,7 @@ def test_every_current_header_function_has_one_prototype() -> None:
     parsed_names = [name for name, _, _ in parsed]
     discovered_names = generator.discover_function_names(source)
 
-    assert len(parsed_names) == 41
+    assert len(parsed_names) == 48
     assert len(parsed_names) == len(set(parsed_names))
     assert parsed_names == discovered_names
     assert set(bindings.PROTOTYPES) == set(parsed_names)
@@ -87,6 +87,32 @@ def test_current_wide_and_pointer_prototypes_are_exact() -> None:
     assert bindings.PROTOTYPES["vokra_model_attribution"][1][1] == ctypes.POINTER(
         ctypes.c_char
     )
+    assert bindings.PROTOTYPES["vokra_feat_open"] == (
+        ctypes.c_void_p,
+        (ctypes.c_void_p,),
+    )
+    assert bindings.PROTOTYPES["vokra_feat_frame_rate_mhz"] == (
+        ctypes.c_int32,
+        (ctypes.c_void_p,),
+    )
+    assert bindings.PROTOTYPES["vokra_feat_dim"] == (
+        ctypes.c_int32,
+        (ctypes.c_void_p,),
+    )
+    assert bindings.PROTOTYPES["vokra_feat_push_pcm"] == (
+        ctypes.c_int,
+        (ctypes.c_void_p, ctypes.POINTER(ctypes.c_float), ctypes.c_size_t),
+    )
+    assert bindings.PROTOTYPES["vokra_feat_pull"] == (
+        ctypes.c_int,
+        (
+            ctypes.c_void_p,
+            ctypes.POINTER(ctypes.c_float),
+            ctypes.c_size_t,
+            ctypes.POINTER(ctypes.c_size_t),
+            ctypes.POINTER(ctypes.c_int64),
+        ),
+    )
 
 
 def test_generated_struct_layout_matches_c_abi_contract() -> None:
@@ -120,11 +146,12 @@ def test_generated_struct_layout_matches_c_abi_contract() -> None:
     ] == expected_offsets
 
 
-def test_all_seven_opaque_handles_are_void_p_aliases() -> None:
+def test_all_eight_opaque_handles_are_void_p_aliases() -> None:
     names = generator.parse_opaque_structs(_header_source())
     assert names == [
         "vokra_aec_ref_writer_t",
         "vokra_aec_t",
+        "vokra_feat_t",
         "vokra_s2s_duplex_t",
         "vokra_s2s_interrupt_t",
         "vokra_session_options_t",

--- a/bindings/python/tests/test_license_requirements.py
+++ b/bindings/python/tests/test_license_requirements.py
@@ -24,7 +24,7 @@ def test_audit_requirements_covers_build_and_optional_dependencies() -> None:
     requirements = license_requirements.audit_requirements(_ROOT / "pyproject.toml")
     assert "hatchling==1.32.0" in requirements
     assert "numpy>=1.23,<2" in requirements
-    assert "pytest>=7.4" in requirements
+    assert "pytest>=9.0.3; python_version >= '3.10'" in requirements
     assert "pip-licenses>=4.3" in requirements
 
 

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -20,7 +20,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -29,23 +29,8 @@ wheels = [
 
 [[package]]
 name = "iniconfig"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
-]
-
-[[package]]
-name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
@@ -167,36 +152,12 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version < '3.10'",
-]
-dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
-    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "packaging", marker = "python_full_version < '3.10'" },
-    { name = "pluggy", marker = "python_full_version < '3.10'" },
-    { name = "pygments", marker = "python_full_version < '3.10'" },
-    { name = "tomli", marker = "python_full_version < '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
-]
-
-[[package]]
-name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.10'",
-]
 dependencies = [
     { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
     { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
-    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "iniconfig", marker = "python_full_version >= '3.10'" },
     { name = "packaging", marker = "python_full_version >= '3.10'" },
     { name = "pluggy", marker = "python_full_version >= '3.10'" },
     { name = "pygments", marker = "python_full_version >= '3.10'" },
@@ -250,8 +211,7 @@ source = { editable = "." }
 [package.optional-dependencies]
 dev = [
     { name = "pip-licenses" },
-    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest", marker = "python_full_version >= '3.10'" },
 ]
 numpy = [
     { name = "numpy" },
@@ -261,7 +221,7 @@ numpy = [
 requires-dist = [
     { name = "numpy", marker = "extra == 'numpy'", specifier = ">=1.23,<2" },
     { name = "pip-licenses", marker = "extra == 'dev'", specifier = ">=4.3" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4" },
+    { name = "pytest", marker = "python_full_version >= '3.10' and extra == 'dev'", specifier = ">=9.0.3" },
 ]
 provides-extras = ["dev", "numpy"]
 

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -1,0 +1,275 @@
+version = 1
+revision = 3
+requires-python = ">=3.9, <3.13"
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version < '3.10'",
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "1.26.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010", size = 15786129, upload-time = "2024-02-06T00:26:44.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/94/ace0fdea5241a27d13543ee117cbc65868e82213fb31a8eb7fe9ff23f313/numpy-1.26.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0", size = 20631468, upload-time = "2024-02-05T23:48:01.194Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f7/b24208eba89f9d1b58c1668bc6c8c4fd472b20c45573cb767f59d49fb0f6/numpy-1.26.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a", size = 13966411, upload-time = "2024-02-05T23:48:29.038Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a5/4beee6488160798683eed5bdb7eead455892c3b4e1f78d79d8d3f3b084ac/numpy-1.26.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4", size = 14219016, upload-time = "2024-02-05T23:48:54.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d7/ecf66c1cd12dc28b4040b15ab4d17b773b87fa9d29ca16125de01adb36cd/numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f", size = 18240889, upload-time = "2024-02-05T23:49:25.361Z" },
+    { url = "https://files.pythonhosted.org/packages/24/03/6f229fe3187546435c4f6f89f6d26c129d4f5bed40552899fcf1f0bf9e50/numpy-1.26.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a", size = 13876746, upload-time = "2024-02-05T23:49:51.983Z" },
+    { url = "https://files.pythonhosted.org/packages/39/fe/39ada9b094f01f5a35486577c848fe274e374bbf8d8f472e1423a0bbd26d/numpy-1.26.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2", size = 18078620, upload-time = "2024-02-05T23:50:22.515Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ef/6ad11d51197aad206a9ad2286dc1aac6a378059e06e8cf22cd08ed4f20dc/numpy-1.26.4-cp310-cp310-win32.whl", hash = "sha256:bfe25acf8b437eb2a8b2d49d443800a5f18508cd811fea3181723922a8a82b07", size = 5972659, upload-time = "2024-02-05T23:50:35.834Z" },
+    { url = "https://files.pythonhosted.org/packages/19/77/538f202862b9183f54108557bfda67e17603fc560c384559e769321c9d92/numpy-1.26.4-cp310-cp310-win_amd64.whl", hash = "sha256:b97fe8060236edf3662adfc2c633f56a08ae30560c56310562cb4f95500022d5", size = 15808905, upload-time = "2024-02-05T23:51:03.701Z" },
+    { url = "https://files.pythonhosted.org/packages/11/57/baae43d14fe163fa0e4c47f307b6b2511ab8d7d30177c491960504252053/numpy-1.26.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c66707fabe114439db9068ee468c26bbdf909cac0fb58686a42a24de1760c71", size = 20630554, upload-time = "2024-02-05T23:51:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/2e/151484f49fd03944c4a3ad9c418ed193cfd02724e138ac8a9505d056c582/numpy-1.26.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd8b5fe47dab091176d21bb6de568acdd906d1887a4584a15a9a96a1dca06ef", size = 13997127, upload-time = "2024-02-05T23:52:15.314Z" },
+    { url = "https://files.pythonhosted.org/packages/79/ae/7e5b85136806f9dadf4878bf73cf223fe5c2636818ba3ab1c585d0403164/numpy-1.26.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ab55401287bfec946ced39700c053796e7cc0e3acbef09993a9ad2adba6ca6e", size = 14222994, upload-time = "2024-02-05T23:52:47.569Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/d0/edc009c27b406c4f9cbc79274d6e46d634d139075492ad055e3d68445925/numpy-1.26.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:666dbfb6ec68962c033a450943ded891bed2d54e6755e35e5835d63f4f6931d5", size = 18252005, upload-time = "2024-02-05T23:53:15.637Z" },
+    { url = "https://files.pythonhosted.org/packages/09/bf/2b1aaf8f525f2923ff6cfcf134ae5e750e279ac65ebf386c75a0cf6da06a/numpy-1.26.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:96ff0b2ad353d8f990b63294c8986f1ec3cb19d749234014f4e7eb0112ceba5a", size = 13885297, upload-time = "2024-02-05T23:53:42.16Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a0/4e0f14d847cfc2a633a1c8621d00724f3206cfeddeb66d35698c4e2cf3d2/numpy-1.26.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:60dedbb91afcbfdc9bc0b1f3f402804070deed7392c23eb7a7f07fa857868e8a", size = 18093567, upload-time = "2024-02-05T23:54:11.696Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/b7/a734c733286e10a7f1a8ad1ae8c90f2d33bf604a96548e0a4a3a6739b468/numpy-1.26.4-cp311-cp311-win32.whl", hash = "sha256:1af303d6b2210eb850fcf03064d364652b7120803a0b872f5211f5234b399f20", size = 5968812, upload-time = "2024-02-05T23:54:26.453Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/6b/5610004206cf7f8e7ad91c5a85a8c71b2f2f8051a0c0c4d5916b76d6cbb2/numpy-1.26.4-cp311-cp311-win_amd64.whl", hash = "sha256:cd25bcecc4974d09257ffcd1f098ee778f7834c3ad767fe5db785be9a4aa9cb2", size = 15811913, upload-time = "2024-02-05T23:54:53.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/12/8f2020a8e8b8383ac0177dc9570aad031a3beb12e38847f7129bacd96228/numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218", size = 20335901, upload-time = "2024-02-05T23:55:32.801Z" },
+    { url = "https://files.pythonhosted.org/packages/75/5b/ca6c8bd14007e5ca171c7c03102d17b4f4e0ceb53957e8c44343a9546dcc/numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b", size = 13685868, upload-time = "2024-02-05T23:55:56.28Z" },
+    { url = "https://files.pythonhosted.org/packages/79/f8/97f10e6755e2a7d027ca783f63044d5b1bc1ae7acb12afe6a9b4286eac17/numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b", size = 13925109, upload-time = "2024-02-05T23:56:20.368Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/50/de23fde84e45f5c4fda2488c759b69990fd4512387a8632860f3ac9cd225/numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed", size = 17950613, upload-time = "2024-02-05T23:56:56.054Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/0c/9c603826b6465e82591e05ca230dfc13376da512b25ccd0894709b054ed0/numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a", size = 13572172, upload-time = "2024-02-05T23:57:21.56Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8c/2ba3902e1a0fc1c74962ea9bb33a534bb05984ad7ff9515bf8d07527cadd/numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0", size = 17786643, upload-time = "2024-02-05T23:57:56.585Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4a/46d9e65106879492374999e76eb85f87b15328e06bd1550668f79f7b18c6/numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110", size = 5677803, upload-time = "2024-02-05T23:58:08.963Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/86f24451c2d530c88daf997cb8d6ac622c1d40d19f5a031ed68a4b73a374/numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818", size = 15517754, upload-time = "2024-02-05T23:58:36.364Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/24/ce71dc08f06534269f66e73c04f5709ee024a1afe92a7b6e1d73f158e1f8/numpy-1.26.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7349ab0fa0c429c82442a27a9673fc802ffdb7c7775fad780226cb234965e53c", size = 20636301, upload-time = "2024-02-05T23:59:10.976Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8c/ab03a7c25741f9ebc92684a20125fbc9fc1b8e1e700beb9197d750fdff88/numpy-1.26.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:52b8b60467cd7dd1e9ed082188b4e6bb35aa5cdd01777621a1658910745b90be", size = 13971216, upload-time = "2024-02-05T23:59:35.472Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/64/c3bcdf822269421d85fe0d64ba972003f9bb4aa9a419da64b86856c9961f/numpy-1.26.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5241e0a80d808d70546c697135da2c613f30e28251ff8307eb72ba696945764", size = 14226281, upload-time = "2024-02-05T23:59:59.372Z" },
+    { url = "https://files.pythonhosted.org/packages/54/30/c2a907b9443cf42b90c17ad10c1e8fa801975f01cb9764f3f8eb8aea638b/numpy-1.26.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f870204a840a60da0b12273ef34f7051e98c3b5961b61b0c2c1be6dfd64fbcd3", size = 18249516, upload-time = "2024-02-06T00:00:32.79Z" },
+    { url = "https://files.pythonhosted.org/packages/43/12/01a563fc44c07095996d0129b8899daf89e4742146f7044cdbdb3101c57f/numpy-1.26.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:679b0076f67ecc0138fd2ede3a8fd196dddc2ad3254069bcb9faf9a79b1cebcd", size = 13882132, upload-time = "2024-02-06T00:00:58.197Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ee/9df80b06680aaa23fc6c31211387e0db349e0e36d6a63ba3bd78c5acdf11/numpy-1.26.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:47711010ad8555514b434df65f7d7b076bb8261df1ca9bb78f53d3b2db02e95c", size = 18084181, upload-time = "2024-02-06T00:01:31.21Z" },
+    { url = "https://files.pythonhosted.org/packages/28/7d/4b92e2fe20b214ffca36107f1a3e75ef4c488430e64de2d9af5db3a4637d/numpy-1.26.4-cp39-cp39-win32.whl", hash = "sha256:a354325ee03388678242a4d7ebcd08b5c727033fcff3b2f536aea978e15ee9e6", size = 5976360, upload-time = "2024-02-06T00:01:43.013Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/42/054082bd8220bbf6f297f982f0a8f5479fcbc55c8b511d928df07b965869/numpy-1.26.4-cp39-cp39-win_amd64.whl", hash = "sha256:3373d5d70a5fe74a2c1bb6d2cfd9609ecf686d47a2d7b1d37a8f3b6bf6003aea", size = 15814633, upload-time = "2024-02-06T00:02:16.694Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/72/3df6c1c06fc83d9cfe381cccb4be2532bbd38bf93fbc9fad087b6687f1c0/numpy-1.26.4-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:afedb719a9dcfc7eaf2287b839d8198e06dcd4cb5d276a3df279231138e83d30", size = 20455961, upload-time = "2024-02-06T00:03:05.993Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/02/570545bac308b58ffb21adda0f4e220ba716fb658a63c151daecc3293350/numpy-1.26.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95a7476c59002f2f6c590b9b7b998306fba6a5aa646b1e22ddfeaf8f78c3a29c", size = 18061071, upload-time = "2024-02-06T00:03:41.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/5f/fafd8c51235f60d49f7a88e2275e13971e90555b67da52dd6416caec32fe/numpy-1.26.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7e50d0a0cc3189f9cb0aeb3a6a6af18c16f59f004b866cd2be1c14b36134a4a0", size = 15709730, upload-time = "2024-02-06T00:04:11.719Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pip-licenses"
+version = "5.5.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prettytable", version = "3.16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "prettytable", version = "3.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/18/ddd93af610a04f56a51a27095ddfe55238e1ec236f6758730a0d2c0b49f2/pip_licenses-5.5.5.tar.gz", hash = "sha256:60750c006adf7a0910347b726e8ee9fee3bc8d2e7c8307a5c4ec0776c8e2a276", size = 54955, upload-time = "2026-03-28T22:12:56.48Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/9a/6acfdb8d463eac7cdae7534d35d72237eca63f5fbafe797289d8a5fae447/pip_licenses-5.5.5-py3-none-any.whl", hash = "sha256:f4c4c6d9e6a03612cf59f29f19dc8ab54904d82e055b8e191498f2279a224e14", size = 23247, upload-time = "2026-03-28T22:12:54.89Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prettytable"
+version = "3.16.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "wcwidth", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/b1/85e18ac92afd08c533603e3393977b6bc1443043115a47bb094f3b98f94f/prettytable-3.16.0.tar.gz", hash = "sha256:3c64b31719d961bf69c9a7e03d0c1e477320906a98da63952bc6698d6164ff57", size = 66276, upload-time = "2025-03-24T19:39:04.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/c7/5613524e606ea1688b3bdbf48aa64bafb6d0a4ac3750274c43b6158a390f/prettytable-3.16.0-py3-none-any.whl", hash = "sha256:b5eccfabb82222f5aa46b798ff02a8452cf530a352c31bddfa29be41242863aa", size = 33863, upload-time = "2025-03-24T19:39:02.359Z" },
+]
+
+[[package]]
+name = "prettytable"
+version = "3.18.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "wcwidth", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/74/ba08d81e668ccfe8658d7520a307e63c19862c08eb4ccb26f356c5239a7a/prettytable-3.18.0.tar.gz", hash = "sha256:439217116152244369caf3d9f1caf2f9fe29b03bd79e88d2928c8e718c95d680", size = 76373, upload-time = "2026-06-22T16:07:50.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/be/2e6798ace5cc036f5d05d36b7b2fd85346f1a708c87060890b070d0ec607/prettytable-3.18.0-py3-none-any.whl", hash = "sha256:b3346e0e6f79180833aebaac088ae926340586cf6d7d991b9eb125b65f72313a", size = 37357, upload-time = "2026-06-22T16:07:48.595Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "packaging", marker = "python_full_version < '3.10'" },
+    { name = "pluggy", marker = "python_full_version < '3.10'" },
+    { name = "pygments", marker = "python_full_version < '3.10'" },
+    { name = "tomli", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "packaging", marker = "python_full_version >= '3.10'" },
+    { name = "pluggy", marker = "python_full_version >= '3.10'" },
+    { name = "pygments", marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "vokra"
+source = { editable = "." }
+
+[package.optional-dependencies]
+dev = [
+    { name = "pip-licenses" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+numpy = [
+    { name = "numpy" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "numpy", marker = "extra == 'numpy'", specifier = ">=1.23,<2" },
+    { name = "pip-licenses", marker = "extra == 'dev'", specifier = ">=4.3" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4" },
+]
+provides-extras = ["dev", "numpy"]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
+]

--- a/crates/vokra-capi/src/feature.rs
+++ b/crates/vokra-capi/src/feature.rs
@@ -1,0 +1,332 @@
+//! Streaming continuous speech-encoder features across the C ABI (#49).
+//!
+//! The first native family is Moshi's causal Mimi input encoder. It emits the
+//! bottleneck-transformer hidden grid at 25 Hz, before token-rate resampling
+//! and RVQ, so downstream models receive continuous rather than quantized
+//! representations. The engine trait keeps this ABI model-independent.
+
+use crate::error::vokra_status_t;
+use crate::handle::{self, vokra_feat_t, vokra_session_t};
+use crate::{error, ffi_guard};
+
+/// Opens a continuous speech-feature stream for `session`.
+///
+/// The returned handle retains the session and must be released with
+/// [`vokra_feat_destroy`]. Returns `NULL` with detail in `vokra_last_error()`
+/// when the model family has no feature engine or construction fails.
+///
+/// # Safety
+///
+/// `session` must be a live session handle or `NULL` (the rejected branch).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vokra_feat_open(session: *const vokra_session_t) -> *mut vokra_feat_t {
+    ffi_guard::guard_ptr(|| {
+        // SAFETY: validated by `required_ref`; NULL becomes a recorded error.
+        let session = match unsafe { ffi_guard::required_ref(session, "session") } {
+            Ok(session) => session,
+            Err(_) => return std::ptr::null_mut(),
+        };
+        let stream = match session.session.open_speech_feature_stream() {
+            Ok(stream) => stream,
+            Err(err) => {
+                error::fail(&err);
+                return std::ptr::null_mut();
+            }
+        };
+        handle::into_raw(vokra_feat_t {
+            stream,
+            _session: session.session.clone(),
+        })
+    })
+}
+
+/// Returns the encoder's native frame rate in milli-Hertz (25 Hz = 25,000).
+/// Returns `-1` on a NULL handle or internal failure.
+///
+/// # Safety
+///
+/// `feat` must be a live feature handle or `NULL` (the rejected branch).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vokra_feat_frame_rate_mhz(feat: *const vokra_feat_t) -> i32 {
+    ffi_guard::guard_i32(|| {
+        // SAFETY: validated by `required_ref`.
+        let feat = match unsafe { ffi_guard::required_ref(feat, "feat") } {
+            Ok(feat) => feat,
+            Err(_) => return -1,
+        };
+        match i32::try_from(feat.stream.frame_rate_millihz()) {
+            Ok(value) => value,
+            Err(_) => {
+                error::fail_invalid("feature frame rate does not fit int32_t");
+                -1
+            }
+        }
+    })
+}
+
+/// Returns the number of `float` values in one feature frame, or `-1` on
+/// failure.
+///
+/// # Safety
+///
+/// `feat` must be a live feature handle or `NULL` (the rejected branch).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vokra_feat_dim(feat: *const vokra_feat_t) -> i32 {
+    ffi_guard::guard_i32(|| {
+        // SAFETY: validated by `required_ref`.
+        let feat = match unsafe { ffi_guard::required_ref(feat, "feat") } {
+            Ok(feat) => feat,
+            Err(_) => return -1,
+        };
+        match i32::try_from(feat.stream.feature_dim()) {
+            Ok(value) => value,
+            Err(_) => {
+                error::fail_invalid("feature dimension does not fit int32_t");
+                -1
+            }
+        }
+    })
+}
+
+/// Appends arbitrary-length mono PCM at the model's native sample rate.
+///
+/// A trailing partial encoder frame is retained. The handle owns a bounded
+/// pending-feature queue; if the supplied PCM would overflow it, this returns
+/// `VOKRA_ERROR_INVALID_ARGUMENT` without consuming input. Successful calls
+/// allocate nothing after stream construction/warmup.
+///
+/// # Safety
+///
+/// `feat` must be live and uniquely accessed for the call. `pcm` must point to
+/// `n` readable floats, or may be `NULL` only when `n == 0`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vokra_feat_push_pcm(
+    feat: *mut vokra_feat_t,
+    pcm: *const f32,
+    n: usize,
+) -> vokra_status_t {
+    ffi_guard::guard(|| {
+        // SAFETY: raw arguments are checked by the shared boundary helpers.
+        let feat = unsafe { ffi_guard::required_mut(feat, "feat")? };
+        // SAFETY: NULL is accepted only for the zero-length slice.
+        let pcm = unsafe { ffi_guard::required_slice(pcm, n, "pcm")? };
+        feat.stream.push_pcm(pcm).map_err(|err| error::fail(&err))?;
+        Ok(())
+    })
+}
+
+/// Pulls whole feature frames into `out` without blocking.
+///
+/// `cap` is a capacity in **floats**, not frames. Up to
+/// `floor(cap / vokra_feat_dim(feat))` rows are written. `out_frames` receives
+/// the row count, and `out_start_sample` receives the exact source-PCM sample
+/// index of the first row (`-1` when no row was pending). A non-zero `cap`
+/// smaller than one row is rejected without consuming queued output.
+///
+/// # Safety
+///
+/// `feat` must be live and uniquely accessed. `out` must point to `cap`
+/// writable floats, or may be `NULL` only when `cap == 0`; both scalar output
+/// pointers must be writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vokra_feat_pull(
+    feat: *mut vokra_feat_t,
+    out: *mut f32,
+    cap: usize,
+    out_frames: *mut usize,
+    out_start_sample: *mut i64,
+) -> vokra_status_t {
+    ffi_guard::guard(|| {
+        // Validate every pointer before calling the state-mutating pull.
+        // SAFETY: validated by `required_mut`.
+        let feat = unsafe { ffi_guard::required_mut(feat, "feat")? };
+        ffi_guard::require_out_ptr(out_frames, "out_frames")?;
+        ffi_guard::require_out_ptr(out_start_sample, "out_start_sample")?;
+        let dst = if cap == 0 {
+            &mut []
+        } else {
+            ffi_guard::require_out_ptr(out, "out")?;
+            // SAFETY: non-null above; caller guarantees `cap` writable floats.
+            unsafe { std::slice::from_raw_parts_mut(out, cap) }
+        };
+        let (frames, start_sample) = feat
+            .stream
+            .pull_into(dst)
+            .map_err(|err| error::fail(&err))?;
+        // SAFETY: both out-pointers are non-null and writable by contract.
+        unsafe {
+            *out_frames = frames;
+            *out_start_sample = if frames == 0 { -1 } else { start_sample };
+        }
+        Ok(())
+    })
+}
+
+/// Discards PCM tail, queued frames, timestamps and recurrent state while
+/// retaining all allocations.
+///
+/// # Safety
+///
+/// `feat` must be a live, uniquely accessed feature handle.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vokra_feat_reset(feat: *mut vokra_feat_t) {
+    ffi_guard::guard_void(|| {
+        // SAFETY: NULL is rejected and recorded; no dereference on failure.
+        if let Ok(feat) = unsafe { ffi_guard::required_mut(feat, "feat") } {
+            feat.stream.reset();
+        }
+    });
+}
+
+/// Frees a feature handle. `NULL` is a no-op; double-free is undefined.
+///
+/// # Safety
+///
+/// `feat` must be `NULL` or a live pointer returned by [`vokra_feat_open`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vokra_feat_destroy(feat: *mut vokra_feat_t) {
+    ffi_guard::guard_void(|| {
+        // SAFETY: the destroy contract matches `handle::drop_raw`.
+        unsafe { handle::drop_raw(feat) };
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use vokra_core::Session;
+    use vokra_core::engines::SpeechFeatureEngine;
+    use vokra_core::gguf::{GgufBuilder, GgufFile};
+    use vokra_models::moshi::MoshiEngine;
+
+    use super::*;
+
+    fn feature_session(seed: u64) -> (vokra_session_t, Arc<MoshiEngine>) {
+        let gguf = GgufFile::parse(GgufBuilder::new().to_bytes().unwrap()).unwrap();
+        let engine = Arc::new(MoshiEngine::synthesized_fixture(seed).unwrap());
+        let session = Session::from_gguf(gguf)
+            .build()
+            .unwrap()
+            .with_speech_feature_engine(engine.clone());
+        (vokra_session_t { session }, engine)
+    }
+
+    fn pcm(n: usize) -> Vec<f32> {
+        (0..n).map(|i| (i as f32 * 0.019).sin() * 0.3).collect()
+    }
+
+    #[test]
+    fn c_chunks_match_the_same_native_engine_whole_buffer_and_timestamp() {
+        let (session, engine) = feature_session(149);
+        let mut reference = engine.open_feature_stream().unwrap();
+        let token_hop = reference.feature_frame_hop() * 2;
+        let input = pcm(token_hop * 3);
+        reference.push_pcm(&input).unwrap();
+        let dim = reference.feature_dim();
+        let frame_rate_millihz = reference.frame_rate_millihz();
+        let mut want = vec![0.0f32; dim * 6];
+        assert_eq!(reference.pull_into(&mut want).unwrap(), (6, 0));
+
+        // SAFETY: stack session stays live until the feature handle is freed.
+        let feat = unsafe { vokra_feat_open(&session) };
+        assert!(!feat.is_null());
+        assert_eq!(
+            // SAFETY: `feat` is a non-null live handle created above.
+            unsafe { vokra_feat_frame_rate_mhz(feat) },
+            frame_rate_millihz as i32,
+        );
+        // SAFETY: `feat` is a non-null live handle created above.
+        assert_eq!(unsafe { vokra_feat_dim(feat) }, dim as i32);
+        let mut cursor = 0usize;
+        for chunk in [1usize, 37, token_hop + 5, 211, input.len()] {
+            if cursor == input.len() {
+                break;
+            }
+            let take = chunk.min(input.len() - cursor);
+            // SAFETY: `feat` is live and the PCM pointer covers exactly `take` samples.
+            let status =
+                unsafe { vokra_feat_push_pcm(feat, input[cursor..cursor + take].as_ptr(), take) };
+            assert_eq!(status, vokra_status_t::VOKRA_OK);
+            cursor += take;
+        }
+        let mut got = vec![0.0f32; want.len()];
+        let mut frames = usize::MAX;
+        let mut start = -2i64;
+        // SAFETY: `feat` is live, `got` has the advertised capacity, and both scalar
+        // output pointers remain valid for the call.
+        let status =
+            unsafe { vokra_feat_pull(feat, got.as_mut_ptr(), got.len(), &mut frames, &mut start) };
+        assert_eq!(status, vokra_status_t::VOKRA_OK);
+        assert_eq!((frames, start), (6, 0));
+        assert_eq!(got, want);
+        // SAFETY: live handle, freed exactly once.
+        unsafe { vokra_feat_destroy(feat) };
+    }
+
+    #[test]
+    fn pull_empty_uses_minus_one_timestamp_and_reset_restarts_zero() {
+        let (session, _) = feature_session(150);
+        // SAFETY: valid session.
+        let feat = unsafe { vokra_feat_open(&session) };
+        let mut frames = 99usize;
+        let mut start = 99i64;
+        assert_eq!(
+            // SAFETY: `feat` and scalar outputs are live; a null output is valid at
+            // zero capacity.
+            unsafe { vokra_feat_pull(feat, std::ptr::null_mut(), 0, &mut frames, &mut start) },
+            vokra_status_t::VOKRA_OK,
+        );
+        assert_eq!((frames, start), (0, -1));
+        // SAFETY: live handle.
+        unsafe { vokra_feat_reset(feat) };
+        assert_eq!(
+            // SAFETY: same live handle and valid scalar outputs as the first pull.
+            unsafe { vokra_feat_pull(feat, std::ptr::null_mut(), 0, &mut frames, &mut start) },
+            vokra_status_t::VOKRA_OK,
+        );
+        assert_eq!((frames, start), (0, -1));
+        // SAFETY: live handle, freed once.
+        unsafe { vokra_feat_destroy(feat) };
+    }
+
+    #[test]
+    fn null_and_model_mismatch_fail_closed() {
+        // SAFETY: this deliberately passes null to verify the FFI boundary rejects it.
+        assert!(unsafe { vokra_feat_open(std::ptr::null()) }.is_null());
+        // SAFETY: this deliberately passes null to verify the query fails closed.
+        assert_eq!(unsafe { vokra_feat_dim(std::ptr::null()) }, -1);
+        assert_eq!(
+            // SAFETY: null arguments are intentional inputs to the validation path.
+            unsafe { vokra_feat_push_pcm(std::ptr::null_mut(), std::ptr::null(), 0) },
+            vokra_status_t::VOKRA_ERROR_INVALID_ARGUMENT,
+        );
+
+        let gguf = GgufFile::parse(GgufBuilder::new().to_bytes().unwrap()).unwrap();
+        let bare = vokra_session_t {
+            session: Session::from_gguf(gguf).build().unwrap(),
+        };
+        // SAFETY: `bare` is live; the test verifies that a session without a feature
+        // engine is rejected without dereferencing an invalid pointer.
+        assert!(unsafe { vokra_feat_open(&bare) }.is_null());
+        assert!(!error::vokra_last_error().is_null());
+    }
+
+    #[test]
+    fn pull_argument_error_leaves_scalar_outputs_untouched() {
+        let (session, _) = feature_session(151);
+        // SAFETY: valid session.
+        let feat = unsafe { vokra_feat_open(&session) };
+        let mut frames = 77usize;
+        let mut start = 88i64;
+        assert_eq!(
+            // SAFETY: `feat` and scalar outputs are live. The null buffer with nonzero
+            // capacity is intentional and must be rejected before dereference.
+            unsafe { vokra_feat_pull(feat, std::ptr::null_mut(), 1, &mut frames, &mut start,) },
+            vokra_status_t::VOKRA_ERROR_INVALID_ARGUMENT,
+        );
+        assert_eq!((frames, start), (77, 88));
+        // SAFETY: live handle, freed once.
+        unsafe { vokra_feat_destroy(feat) };
+    }
+}

--- a/crates/vokra-capi/src/ffi_guard.rs
+++ b/crates/vokra-capi/src/ffi_guard.rs
@@ -48,12 +48,21 @@ pub(crate) fn guard_void<F: FnOnce()>(body: F) {
     let _ = catch_unwind(AssertUnwindSafe(body));
 }
 
-/// Panic firewall for a **handle-returning constructor**
-/// (`vokra_session_options_create`), whose contract signals failure with a
-/// `NULL` return rather than a status. A caught panic therefore becomes
-/// `NULL` — the one failure value the caller already has to check.
+/// Panic firewall for a **handle-returning constructor**. A caught panic
+/// becomes `NULL` — the one failure value the caller already has to check —
+/// and records its detail for constructors such as `vokra_feat_open` whose
+/// contract also exposes `vokra_last_error()`.
 pub(crate) fn guard_ptr<T, F: FnOnce() -> *mut T>(body: F) -> *mut T {
-    catch_unwind(AssertUnwindSafe(body)).unwrap_or(std::ptr::null_mut())
+    match catch_unwind(AssertUnwindSafe(body)) {
+        Ok(ptr) => ptr,
+        Err(payload) => {
+            set_last_error(&format!(
+                "internal panic caught at FFI boundary: {}",
+                describe_panic(&payload)
+            ));
+            std::ptr::null_mut()
+        }
+    }
 }
 
 /// Panic firewall for a **pure boolean query** (`vokra_backend_available`),
@@ -62,6 +71,22 @@ pub(crate) fn guard_ptr<T, F: FnOnce() -> *mut T>(body: F) -> *mut T {
 /// `false` ("not available"), the conservative answer.
 pub(crate) fn guard_bool<F: FnOnce() -> bool>(body: F) -> bool {
     catch_unwind(AssertUnwindSafe(body)).unwrap_or(false)
+}
+
+/// Panic firewall for a signed integer metadata query. `-1` is reserved as
+/// the failure sentinel by the `vokra_feat_*` getters; valid dimensions and
+/// milli-Hertz rates are non-negative.
+pub(crate) fn guard_i32<F: FnOnce() -> i32>(body: F) -> i32 {
+    match catch_unwind(AssertUnwindSafe(body)) {
+        Ok(value) => value,
+        Err(payload) => {
+            set_last_error(&format!(
+                "internal panic caught at FFI boundary: {}",
+                describe_panic(&payload)
+            ));
+            -1
+        }
+    }
 }
 
 /// Best-effort human-readable text for a caught panic payload.
@@ -188,6 +213,14 @@ mod tests {
         let status = guard(|| panic!("boom from inside the boundary"));
         assert_eq!(status, vokra_status_t::VOKRA_ERROR_PANIC);
         // The panic message is recorded for vokra_last_error().
+        assert!(!vokra_last_error().is_null());
+    }
+
+    #[test]
+    fn scalar_and_pointer_guards_use_their_failure_sentinels_on_panic() {
+        assert_eq!(guard_i32(|| panic!("metadata panic")), -1);
+        let ptr = guard_ptr::<u8, _>(|| panic!("constructor panic"));
+        assert!(ptr.is_null());
         assert!(!vokra_last_error().is_null());
     }
 

--- a/crates/vokra-capi/src/handle.rs
+++ b/crates/vokra-capi/src/handle.rs
@@ -7,7 +7,7 @@
 //! matching `destroy` (ADR-0003 §1). Handles cross the boundary as
 //! `Box::into_raw` pointers and come back via `Box::from_raw`.
 
-use vokra_core::{Session, Stream};
+use vokra_core::{Session, SpeechFeatureStream, Stream};
 
 /// Opaque session handle: one loaded model bound to one backend, with the
 /// matching native engine injected (ASR / TTS / VAD — see
@@ -38,6 +38,18 @@ pub struct vokra_stream_t {
     /// model (and its engine) alive independently of `vokra_session_destroy`.
     /// Dropped after `stream` (declaration order = drop order).
     pub(crate) stream: Stream,
+    pub(crate) _session: Session,
+}
+
+/// Opaque continuous speech-feature handle (#49).
+///
+/// Created by `vokra_feat_open`, released by `vokra_feat_destroy`. It owns the
+/// encoder's causal state and bounded pending-output ring, and retains the
+/// originating session so model weights outlive the C handle.
+#[allow(non_camel_case_types)]
+pub struct vokra_feat_t {
+    /// Dropped before the retained session (declaration order).
+    pub(crate) stream: Box<dyn SpeechFeatureStream + Send>,
     pub(crate) _session: Session,
 }
 

--- a/crates/vokra-capi/src/lib.rs
+++ b/crates/vokra-capi/src/lib.rs
@@ -27,6 +27,9 @@
 //! - **Speaker** (`speaker`): `vokra_speaker_embed` (PCM → embedding, FR-OP-80)
 //!   and `vokra_speaker_verify` (cosine similarity, FR-OP-81).
 //! - **ASR** (`asr`): `vokra_asr_transcribe` + `vokra_string_free`.
+//! - **Speech features** (`feature`): `vokra_feat_open` / `_push_pcm` /
+//!   `_pull` / metadata queries / `_reset` / `_destroy` over one native
+//!   continuous encoder (Moshi's causal Mimi tower, #49).
 //! - **TTS** (`tts`): `vokra_tts_synthesize` (piper-plus native, no
 //!   onnxruntime) + `vokra_audio_free`.
 //! - **Streaming** (`stream`): `vokra_stream_open` / `_push_pcm` / `_poll`
@@ -62,6 +65,7 @@
 mod aec;
 mod asr;
 mod error;
+mod feature;
 mod ffi_guard;
 mod handle;
 // 2026-08-14: vokra_backend_t + the opaque vokra_session_options_t that

--- a/crates/vokra-capi/src/session.rs
+++ b/crates/vokra-capi/src/session.rs
@@ -174,7 +174,8 @@ fn inject_engine(
             let engine = Arc::new(engine);
             let mut session = session
                 .with_s2s_engine(engine.clone())
-                .with_s2s_duplex_engine(engine);
+                .with_s2s_duplex_engine(engine.clone())
+                .with_speech_feature_engine(engine);
             if let Some(info) = attribution {
                 session = session.with_attribution(info);
             }

--- a/crates/vokra-core/src/engines.rs
+++ b/crates/vokra-core/src/engines.rs
@@ -41,6 +41,53 @@ pub trait AsrEngine: Send + Sync {
     fn backend(&self) -> BackendKind;
 }
 
+/// A model that exposes a continuous streaming speech-encoder representation.
+///
+/// The engine is immutable and shared with its parent [`crate::Session`]; all
+/// recurrent state and bounded output buffering live in the returned
+/// [`SpeechFeatureStream`]. The `Arc<Self>` receiver keeps the trait object-safe
+/// while allowing a C handle to outlive the originating session handle.
+pub trait SpeechFeatureEngine: Send + Sync {
+    /// Opens a fresh, independently reset feature stream.
+    fn open_feature_stream(self: Arc<Self>) -> Result<Box<dyn SpeechFeatureStream + Send>>;
+}
+
+/// Stateful PCM → continuous-feature stream behind the `vokra_feat_*` C ABI.
+///
+/// Feature rows are contiguous `[frames, feature_dim]` `f32`s. Implementations
+/// buffer partial PCM frames, retain causal model state, and use bounded
+/// preallocated output storage: full queues return an explicit error rather
+/// than dropping or allocating.
+pub trait SpeechFeatureStream {
+    /// Source PCM sample rate in Hz.
+    fn sample_rate(&self) -> u32;
+
+    /// Native feature-frame rate in milli-Hertz (25 Hz = 25,000 mHz).
+    fn frame_rate_millihz(&self) -> u32;
+
+    /// PCM samples between consecutive feature timestamps.
+    fn feature_frame_hop(&self) -> usize;
+
+    /// Number of `f32` values in one feature row.
+    fn feature_dim(&self) -> usize;
+
+    /// Appends arbitrary-length mono PCM, buffering an incomplete model frame.
+    /// Successful steady-state calls allocate nothing.
+    fn push_pcm(&mut self, pcm: &[f32]) -> Result<()>;
+
+    /// Drains whole feature rows into caller-owned `out`.
+    ///
+    /// Returns `(frames_written, first_frame_start_sample)`. When no frame is
+    /// pending, `frames_written` is zero and the timestamp is the position the
+    /// next feature would carry. A non-empty output smaller than one full row
+    /// is rejected without consuming data.
+    fn pull_into(&mut self, out: &mut [f32]) -> Result<(usize, i64)>;
+
+    /// Discards partial PCM, queued features, timestamps and recurrent state
+    /// without releasing preallocated storage.
+    fn reset(&mut self);
+}
+
 /// A speech-to-speech dialog engine (implemented natively in
 /// `vokra-models` — Sesame CSM-1B = M4-05; Moshi = M4-06).
 ///

--- a/crates/vokra-core/src/lib.rs
+++ b/crates/vokra-core/src/lib.rs
@@ -195,7 +195,8 @@ pub use decode::{
 pub use engines::{
     AecEngine, AecStreamHandle, AsrEngine, DialogContextTurn, DialogRequest, DuplexInterruptHandle,
     DuplexPushReport, DuplexSessionConfig, S2sDuplexEngine, S2sDuplexHandle, S2sEngine,
-    SpeakerEngine, SynthesisRequest, TtsEngine, TtsStreamHandle, VadEngine, VadStreamHandle,
+    SpeakerEngine, SpeechFeatureEngine, SpeechFeatureStream, SynthesisRequest, TtsEngine,
+    TtsStreamHandle, VadEngine, VadStreamHandle,
 };
 #[cfg(feature = "std")]
 pub use ir::{AudioGraph, DType, Dim, GraphBuilder, Node, OpKind, TensorDesc, TensorId};

--- a/crates/vokra-core/src/session.rs
+++ b/crates/vokra-core/src/session.rs
@@ -21,7 +21,8 @@ use std::sync::atomic::AtomicU64;
 use crate::backend::BackendKind;
 use crate::compliance::AttributionInfo;
 use crate::engines::{
-    AsrEngine, S2sDuplexEngine, S2sEngine, SpeakerEngine, TtsEngine, VadEngine, VadStreamHandle,
+    AsrEngine, S2sDuplexEngine, S2sEngine, SpeakerEngine, SpeechFeatureEngine, SpeechFeatureStream,
+    TtsEngine, VadEngine, VadStreamHandle,
 };
 use crate::error::{Result, VokraError};
 use crate::gguf::GgufFile;
@@ -78,6 +79,7 @@ pub struct Session {
     vad: Option<Arc<dyn VadEngine>>,
     s2s: Option<Arc<dyn S2sEngine>>,
     s2s_duplex: Option<Arc<dyn S2sDuplexEngine>>,
+    speech_features: Option<Arc<dyn SpeechFeatureEngine>>,
     /// Speaker-embedding engine (CAM++ = M0-08, FR-OP-80). Same shape as the
     /// engines above; the facade entry is [`Session::speaker`].
     speaker: Option<Arc<dyn SpeakerEngine>>,
@@ -98,6 +100,7 @@ impl Clone for Session {
             vad: self.vad.clone(),
             s2s: self.s2s.clone(),
             s2s_duplex: self.s2s_duplex.clone(),
+            speech_features: self.speech_features.clone(),
             speaker: self.speaker.clone(),
             attribution: self.attribution.clone(),
         }
@@ -115,6 +118,7 @@ impl fmt::Debug for Session {
             .field("vad_engine", &self.vad.is_some())
             .field("s2s_engine", &self.s2s.is_some())
             .field("s2s_duplex_engine", &self.s2s_duplex.is_some())
+            .field("speech_feature_engine", &self.speech_features.is_some())
             .field("speaker_engine", &self.speaker.is_some())
             .field("attribution", &self.attribution.is_some())
             .finish()
@@ -227,6 +231,13 @@ impl Session {
         self
     }
 
+    /// Attaches a continuous streaming speech-feature engine (#49).
+    #[must_use]
+    pub fn with_speech_feature_engine(mut self, engine: Arc<dyn SpeechFeatureEngine>) -> Self {
+        self.speech_features = Some(engine);
+        self
+    }
+
     /// Attaches a speaker-embedding engine (CAM++ = M0-08, FR-OP-80); the
     /// [`Speaker`](crate::tasks::Speaker) facade delegates to it.
     #[must_use]
@@ -290,6 +301,20 @@ impl Session {
             Some(engine) => Ok(engine.open_stream()),
             None => Err(VokraError::NotImplemented(
                 "no VAD engine injected (Silero VAD v5 = M0-05)",
+            )),
+        }
+    }
+
+    /// Opens a continuous speech-feature stream from the injected engine.
+    ///
+    /// Returns [`VokraError::NotImplemented`] for a model family that does not
+    /// expose this capability; there is no silent substitution with ASR text or
+    /// a different encoder.
+    pub fn open_speech_feature_stream(&self) -> Result<Box<dyn SpeechFeatureStream + Send>> {
+        match &self.speech_features {
+            Some(engine) => Arc::clone(engine).open_feature_stream(),
+            None => Err(VokraError::NotImplemented(
+                "no continuous speech-feature engine injected",
             )),
         }
     }
@@ -391,6 +416,7 @@ impl SessionBuilder {
             vad: None,
             s2s: None,
             s2s_duplex: None,
+            speech_features: None,
             speaker: None,
             attribution: None,
         })
@@ -653,5 +679,71 @@ pub(crate) mod tests {
         );
         // reset() is reachable through the trait object (a no-op on the fake).
         handle.reset();
+    }
+
+    #[test]
+    fn speech_feature_stream_fails_closed_without_an_injected_engine() {
+        let file = TempModelFile::new("speech-features-none");
+        let session = Session::from_file(&file.0).build().expect("session builds");
+        assert!(matches!(
+            session.open_speech_feature_stream(),
+            Err(VokraError::NotImplemented(_)),
+        ));
+    }
+
+    #[test]
+    fn speech_feature_stream_delegates_and_session_clone_retains_engine() {
+        struct FakeFeatureStream {
+            next_sample: i64,
+        }
+        impl SpeechFeatureStream for FakeFeatureStream {
+            fn sample_rate(&self) -> u32 {
+                16_000
+            }
+            fn frame_rate_millihz(&self) -> u32 {
+                25_000
+            }
+            fn feature_frame_hop(&self) -> usize {
+                640
+            }
+            fn feature_dim(&self) -> usize {
+                2
+            }
+            fn push_pcm(&mut self, _pcm: &[f32]) -> Result<()> {
+                Ok(())
+            }
+            fn pull_into(&mut self, out: &mut [f32]) -> Result<(usize, i64)> {
+                let frames = out.len() / 2;
+                for (i, value) in out[..frames * 2].iter_mut().enumerate() {
+                    *value = i as f32;
+                }
+                let start = self.next_sample;
+                self.next_sample += frames as i64 * 640;
+                Ok((frames, start))
+            }
+            fn reset(&mut self) {
+                self.next_sample = 0;
+            }
+        }
+        struct FakeFeatureEngine;
+        impl SpeechFeatureEngine for FakeFeatureEngine {
+            fn open_feature_stream(self: Arc<Self>) -> Result<Box<dyn SpeechFeatureStream + Send>> {
+                Ok(Box::new(FakeFeatureStream { next_sample: 0 }))
+            }
+        }
+
+        let file = TempModelFile::new("speech-features-fake");
+        let session = Session::from_file(&file.0)
+            .build()
+            .expect("session builds")
+            .with_speech_feature_engine(Arc::new(FakeFeatureEngine));
+        let clone = session.clone();
+        drop(session);
+        let mut stream = clone.open_speech_feature_stream().unwrap();
+        assert_eq!(stream.frame_rate_millihz(), 25_000);
+        assert_eq!(stream.feature_dim(), 2);
+        let mut out = [0.0f32; 4];
+        assert_eq!(stream.pull_into(&mut out).unwrap(), (2, 0));
+        assert_eq!(out, [0.0, 1.0, 2.0, 3.0]);
     }
 }

--- a/crates/vokra-models/src/mimi/encoder.rs
+++ b/crates/vokra-models/src/mimi/encoder.rs
@@ -151,6 +151,38 @@ impl std::fmt::Debug for MimiEncoderState {
     }
 }
 
+impl MimiEncoderState {
+    /// Resets every causal convolution and transformer cache while retaining
+    /// all preallocated activation/scratch buffers.
+    pub fn reset(&mut self) {
+        self.init.reset();
+        for (blocks, down) in &mut self.stages {
+            for (conv1, conv2) in blocks {
+                conv1.reset();
+                conv2.reset();
+            }
+            down.reset();
+        }
+        self.final_conv.reset();
+        self.frame_down.reset();
+        self.tf.reset();
+        for buf in &mut self.bufs {
+            buf.fill(0.0);
+        }
+        for buf in &mut self.tmp {
+            buf.fill(0.0);
+        }
+        for buf in &mut self.mid {
+            buf.fill(0.0);
+        }
+        self.tf_rows.fill(0.0);
+        self.proj.fill(0.0);
+        self.residual.fill(0.0);
+        self.proj_all.fill(0.0);
+        self.rest_all.fill(0.0);
+    }
+}
+
 impl MimiEncoder {
     /// Builds a synthesized (seed-deterministic) encoder for `config` —
     /// shapes and streaming behaviour verified without real weights.
@@ -437,6 +469,36 @@ impl MimiEncoder {
         self.config.frame_hop_samples()
     }
 
+    /// Width of each continuous speech-encoder feature frame.
+    ///
+    /// These are the Mimi bottleneck-transformer hidden states before the
+    /// 25 Hz → token-rate convolution and RVQ quantizer.
+    #[must_use]
+    pub fn feature_dim(&self) -> usize {
+        self.config.seanet.dimension
+    }
+
+    /// PCM samples between consecutive continuous feature frames.
+    ///
+    /// For released Mimi/Moshi configurations this is the native SEANet hop
+    /// (960 samples at 24 kHz = 25 Hz), before the stride-2 token-rate
+    /// resampler.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the config's exact-rate validation.
+    pub fn feature_frame_hop(&self) -> Result<usize> {
+        let hop = self.config.seanet_hop();
+        let token_hop = self.frame_hop()?;
+        if hop == 0 || token_hop % hop != 0 {
+            return Err(VokraError::InvalidArgument(format!(
+                "mimi encoder features: token hop {token_hop} is not an exact multiple of \
+                 SEANet hop {hop}"
+            )));
+        }
+        Ok(hop)
+    }
+
     fn compute(&self) -> Result<Compute> {
         Compute::for_backend(self.backend, MIMI_HOT_OPS)
     }
@@ -505,20 +567,7 @@ impl MimiEncoder {
         })
     }
 
-    /// Encodes whole frames of PCM into RVQ codes
-    /// (`codes_out = [n_frames, n_q]` row-major), carrying all causal
-    /// state in `state`. Allocation-free.
-    ///
-    /// # Errors
-    ///
-    /// [`VokraError::InvalidArgument`] on a non-whole-frame `pcm` length,
-    /// capacity overflow, or shape mismatch.
-    pub fn encode_into(
-        &self,
-        state: &mut MimiEncoderState,
-        pcm: &[f32],
-        codes_out: &mut [u32],
-    ) -> Result<()> {
+    fn validate_stream_input(&self, state: &MimiEncoderState, pcm: &[f32]) -> Result<usize> {
         let hop = self.frame_hop()?;
         if pcm.is_empty() || pcm.len() % hop != 0 {
             return Err(VokraError::InvalidArgument(format!(
@@ -534,15 +583,22 @@ impl MimiEncoder {
                 state.frames_cap
             )));
         }
-        let n_q = self.config.quantizer.n_q;
-        if codes_out.len() != n_frames * n_q {
-            return Err(VokraError::InvalidArgument(format!(
-                "mimi encode: codes_out len {} != n_frames*n_q {}",
-                codes_out.len(),
-                n_frames * n_q
-            )));
-        }
-        let compute = self.compute()?;
+        Ok(n_frames)
+    }
+
+    /// Runs PCM through the causal SEANet and bottleneck transformer.
+    ///
+    /// On success, `state.tf_rows[..feature_frames * dim]` holds the native
+    /// continuous feature grid in row-major order. The returned `edge` is the
+    /// channel-major copy used by the existing token-rate/RVQ tail.
+    fn encode_continuous(
+        &self,
+        compute: &Compute,
+        state: &mut MimiEncoderState,
+        pcm: &[f32],
+        n_frames: usize,
+    ) -> Result<(usize, usize, usize)> {
+        let hop = self.frame_hop()?;
         let mut t = n_frames * hop;
         state.bufs[0][..t].copy_from_slice(pcm);
 
@@ -551,7 +607,7 @@ impl MimiEncoder {
         {
             let (before, after) = state.bufs.split_at_mut(edge);
             self.init.process_into(
-                &compute,
+                compute,
                 &mut state.init,
                 &before[edge - 1][..t],
                 t,
@@ -560,27 +616,24 @@ impl MimiEncoder {
         }
         let mut ch = self.init.out_ch;
 
-        // Stages.
+        // SEANet residual/downsample stages.
         for (si, stage) in self.stages.iter().enumerate() {
             let (block_states, down_state) = &mut state.stages[si];
-            // Residual blocks operate in place on bufs[edge].
             for (bi, block) in stage.blocks.iter().enumerate() {
                 let hidden = block.conv1.out_ch;
                 let x = &mut state.bufs[edge];
-                // tmp = elu(x)
                 state.tmp[si][..ch * t].copy_from_slice(&x[..ch * t]);
                 elu_inplace(&mut state.tmp[si][..ch * t]);
                 block.conv1.process_into(
-                    &compute,
+                    compute,
                     &mut block_states[bi].0,
                     &state.tmp[si][..ch * t],
                     t,
                     &mut state.mid[si][..hidden * t],
                 )?;
                 elu_inplace(&mut state.mid[si][..hidden * t]);
-                // conv2 (k=1) back to ch — write into tmp then add skip.
                 block.conv2.process_into(
-                    &compute,
+                    compute,
                     &mut block_states[bi].1,
                     &state.mid[si][..hidden * t],
                     t,
@@ -591,13 +644,12 @@ impl MimiEncoder {
                     *dst += *src;
                 }
             }
-            // ELU → downsample conv into the next edge buffer.
             state.tmp[si][..ch * t].copy_from_slice(&state.bufs[edge][..ch * t]);
             elu_inplace(&mut state.tmp[si][..ch * t]);
             let t_out = t / stage.down.stride;
             let out_ch = stage.down.out_ch;
             stage.down.process_into(
-                &compute,
+                compute,
                 down_state,
                 &state.tmp[si][..ch * t],
                 t,
@@ -610,9 +662,6 @@ impl MimiEncoder {
 
         // ELU → final conv → latent [dim, t].
         {
-            // The last stage's tmp buffer is wide enough (ch*t of the last
-            // stage ≥ current ch*t after its own downsample? No — reuse the
-            // final edge buffer copy instead).
             let x = &mut state.bufs[edge];
             elu_inplace(&mut x[..ch * t]);
         }
@@ -620,7 +669,7 @@ impl MimiEncoder {
         {
             let (before, after) = state.bufs.split_at_mut(edge + 1);
             self.final_conv.process_into(
-                &compute,
+                compute,
                 &mut state.final_conv,
                 &before[edge][..ch * t],
                 t,
@@ -630,14 +679,14 @@ impl MimiEncoder {
         edge += 1;
 
         // Bottleneck transformer at 25 Hz: channel-major → rows, in place,
-        // back.
+        // then mirror back for the token-rate/RVQ continuation.
         for i in 0..t {
             for c in 0..dim {
                 state.tf_rows[i * dim + c] = state.bufs[edge][c * t + i];
             }
         }
         self.transformer.process_inplace(
-            &compute,
+            compute,
             &mut state.tf,
             &mut state.tf_rows[..t * dim],
             t,
@@ -647,6 +696,106 @@ impl MimiEncoder {
                 state.bufs[edge][c * t + i] = state.tf_rows[i * dim + c];
             }
         }
+        Ok((edge, t, dim))
+    }
+
+    /// Encodes whole token frames of PCM into the native continuous Mimi
+    /// speech features (`features_out = [feature_frames, feature_dim]`
+    /// row-major), carrying causal state in `state`.
+    ///
+    /// The exposed point is the 25 Hz bottleneck-transformer output before
+    /// the stride-2 token-rate convolution, input projection and lossy RVQ.
+    /// It is therefore suitable for downstream models that consume continuous
+    /// speech representations rather than codec ids. All storage comes from
+    /// [`Self::state`] and the caller-owned output; successful calls allocate
+    /// nothing.
+    ///
+    /// # Errors
+    ///
+    /// [`VokraError::InvalidArgument`] on a non-whole-token-frame PCM length,
+    /// state capacity overflow, or an output buffer whose length is not
+    /// exactly `pcm.len() / feature_frame_hop * feature_dim`. Shape errors are
+    /// checked before recurrent state advances.
+    // ZERO-ALLOC-BEGIN (#49: continuous Mimi speech-feature forward)
+    pub fn encode_features_into(
+        &self,
+        state: &mut MimiEncoderState,
+        pcm: &[f32],
+        features_out: &mut [f32],
+    ) -> Result<()> {
+        let n_frames = self.validate_stream_input(state, pcm)?;
+        let feature_hop = self.feature_frame_hop()?;
+        let feature_frames = pcm.len() / feature_hop;
+        let dim = self.feature_dim();
+        let expected = feature_frames.checked_mul(dim).ok_or_else(|| {
+            VokraError::InvalidArgument(
+                "mimi encoder features: feature_frames * feature_dim overflows usize".into(),
+            )
+        })?;
+        if features_out.len() != expected {
+            return Err(VokraError::InvalidArgument(format!(
+                "mimi encoder features: output len {} != feature_frames*feature_dim {expected}",
+                features_out.len()
+            )));
+        }
+
+        let compute = self.compute()?;
+        let (_, produced_frames, produced_dim) =
+            self.encode_continuous(&compute, state, pcm, n_frames)?;
+        debug_assert_eq!(produced_frames, feature_frames);
+        debug_assert_eq!(produced_dim, dim);
+        features_out.copy_from_slice(&state.tf_rows[..expected]);
+        Ok(())
+    }
+    // ZERO-ALLOC-END
+
+    /// Convenience fresh-state whole-buffer continuous-feature encode.
+    ///
+    /// # Errors
+    ///
+    /// See [`Self::encode_features_into`].
+    pub fn encode_features_all(&self, pcm: &[f32]) -> Result<Vec<f32>> {
+        let hop = self.frame_hop()?;
+        if pcm.is_empty() || pcm.len() % hop != 0 {
+            return Err(VokraError::InvalidArgument(format!(
+                "mimi encoder features: pcm len {} is not a positive multiple of the \
+                 token frame hop {hop}",
+                pcm.len()
+            )));
+        }
+        let n_frames = pcm.len() / hop;
+        let feature_frames = pcm.len() / self.feature_frame_hop()?;
+        let mut state = self.state(n_frames)?;
+        let mut features = vec![0.0f32; feature_frames * self.feature_dim()];
+        self.encode_features_into(&mut state, pcm, &mut features)?;
+        Ok(features)
+    }
+
+    /// Encodes whole frames of PCM into RVQ codes
+    /// (`codes_out = [n_frames, n_q]` row-major), carrying all causal
+    /// state in `state`. Allocation-free.
+    ///
+    /// # Errors
+    ///
+    /// [`VokraError::InvalidArgument`] on a non-whole-frame `pcm` length,
+    /// capacity overflow, or shape mismatch.
+    pub fn encode_into(
+        &self,
+        state: &mut MimiEncoderState,
+        pcm: &[f32],
+        codes_out: &mut [u32],
+    ) -> Result<()> {
+        let n_frames = self.validate_stream_input(state, pcm)?;
+        let n_q = self.config.quantizer.n_q;
+        if codes_out.len() != n_frames * n_q {
+            return Err(VokraError::InvalidArgument(format!(
+                "mimi encode: codes_out len {} != n_frames*n_q {}",
+                codes_out.len(),
+                n_frames * n_q
+            )));
+        }
+        let compute = self.compute()?;
+        let (mut edge, t, dim) = self.encode_continuous(&compute, state, pcm, n_frames)?;
 
         // Frame resample (25 → 12.5 Hz).
         let ds = self.frame_down.stride;
@@ -1152,6 +1301,88 @@ mod tests {
             streamed.extend_from_slice(&codes);
         }
         assert_eq!(full, streamed, "causal state carry-over must be exact");
+    }
+
+    #[test]
+    fn continuous_features_full_buffer_equal_frame_streaming_bit_for_bit() {
+        let enc = encoder();
+        let hop = enc.frame_hop().unwrap();
+        let feature_hop = enc.feature_frame_hop().unwrap();
+        let dim = enc.feature_dim();
+        let features_per_codec_frame = hop / feature_hop;
+        let pcm = sine_pcm(hop * 3);
+
+        let full = enc.encode_features_all(&pcm).unwrap();
+        assert_eq!(full.len(), 3 * features_per_codec_frame * dim);
+
+        let mut state = enc.state(1).unwrap();
+        let mut scratch = vec![0.0f32; features_per_codec_frame * dim];
+        let mut streamed = Vec::new();
+        for frame in pcm.chunks_exact(hop) {
+            enc.encode_features_into(&mut state, frame, &mut scratch)
+                .unwrap();
+            streamed.extend_from_slice(&scratch);
+        }
+        assert_eq!(
+            streamed, full,
+            "causal Mimi hidden states must not depend on caller chunking",
+        );
+    }
+
+    #[test]
+    fn continuous_feature_geometry_is_the_native_pre_quantizer_grid() {
+        let enc = encoder();
+        let cfg = enc.config();
+        assert_eq!(enc.feature_dim(), cfg.seanet.dimension);
+        assert_eq!(enc.feature_frame_hop().unwrap(), cfg.seanet_hop());
+        assert_eq!(
+            u64::from(cfg.sample_rate) * 1000 / enc.feature_frame_hop().unwrap() as u64,
+            u64::from(cfg.frame_rate_mhz) * cfg.frame_downsample_stride().unwrap() as u64,
+            "the pre-quantizer feature grid must be the token rate times its downsample stride",
+        );
+    }
+
+    #[test]
+    fn continuous_feature_output_shape_errors_are_loud_before_state_advances() {
+        let enc = encoder();
+        let hop = enc.frame_hop().unwrap();
+        let pcm = sine_pcm(hop);
+        let expected = hop / enc.feature_frame_hop().unwrap() * enc.feature_dim();
+        let mut state = enc.state(1).unwrap();
+
+        assert!(
+            enc.encode_features_into(&mut state, &pcm, &mut vec![0.0; expected - 1])
+                .is_err(),
+        );
+        let mut after_error = vec![0.0f32; expected];
+        enc.encode_features_into(&mut state, &pcm, &mut after_error)
+            .unwrap();
+
+        let mut fresh = enc.state(1).unwrap();
+        let mut want = vec![0.0f32; expected];
+        enc.encode_features_into(&mut fresh, &pcm, &mut want)
+            .unwrap();
+        assert_eq!(
+            after_error, want,
+            "shape error must not consume encoder state"
+        );
+    }
+
+    #[test]
+    fn continuous_feature_state_reset_reproduces_a_fresh_stream() {
+        let enc = encoder();
+        let hop = enc.frame_hop().unwrap();
+        let output_len = hop / enc.feature_frame_hop().unwrap() * enc.feature_dim();
+        let pcm = sine_pcm(hop);
+        let mut state = enc.state(1).unwrap();
+        let mut first = vec![0.0f32; output_len];
+        enc.encode_features_into(&mut state, &pcm, &mut first)
+            .unwrap();
+        state.reset();
+        let mut second = vec![0.0f32; output_len];
+        enc.encode_features_into(&mut state, &pcm, &mut second)
+            .unwrap();
+        assert_eq!(second, first);
     }
 
     #[test]

--- a/crates/vokra-models/src/mimi/nn.rs
+++ b/crates/vokra-models/src/mimi/nn.rs
@@ -108,10 +108,14 @@ pub(crate) struct ConvState {
 }
 
 impl ConvState {
-    /// Clears the carried causal context without reallocating scratch.
+    /// Restores the causal boundary to a freshly constructed state without
+    /// releasing or reallocating scratch storage.
     pub(crate) fn reset(&mut self) {
         self.hist.fill(0.0);
         self.first = true;
+        self.ctx.fill(0.0);
+        self.gather.fill(0.0);
+        self.gemm_out.fill(0.0);
     }
 }
 
@@ -633,6 +637,38 @@ pub(crate) struct MimiTransformerState {
     b_ff1: Vec<f32>,
     b_ff1_act: Vec<f32>,
     b_ff2: Vec<f32>,
+}
+
+impl MimiTransformerState {
+    /// Clears the rolling KV window and absolute position while retaining all
+    /// per-step and grow-only batch allocations.
+    pub(crate) fn reset(&mut self) {
+        self.k_ring.fill(0.0);
+        self.v_ring.fill(0.0);
+        self.pos = 0;
+        self.h.fill(0.0);
+        self.norm.fill(0.0);
+        self.q.fill(0.0);
+        self.k.fill(0.0);
+        self.v.fill(0.0);
+        self.rope_buf.fill(0.0);
+        self.scores.fill(0.0);
+        self.probs.fill(0.0);
+        self.attn_out.fill(0.0);
+        self.attn_o.fill(0.0);
+        self.ff1.fill(0.0);
+        self.ff1_act.fill(0.0);
+        self.ff2.fill(0.0);
+        self.b_norm.fill(0.0);
+        self.b_q.fill(0.0);
+        self.b_k.fill(0.0);
+        self.b_v.fill(0.0);
+        self.b_attn_out.fill(0.0);
+        self.b_attn_o.fill(0.0);
+        self.b_ff1.fill(0.0);
+        self.b_ff1_act.fill(0.0);
+        self.b_ff2.fill(0.0);
+    }
 }
 
 impl MimiTransformer {

--- a/crates/vokra-models/src/moshi/feature.rs
+++ b/crates/vokra-models/src/moshi/feature.rs
@@ -1,0 +1,371 @@
+//! Continuous Mimi speech features exposed through the model-independent
+//! session engine seam (#49).
+
+use std::sync::Arc;
+
+use vokra_core::engines::{SpeechFeatureEngine, SpeechFeatureStream};
+use vokra_core::{Result, VokraError};
+
+use super::MoshiEngine;
+use crate::mimi::MimiEncoderState;
+
+/// Bounded pending-output budget. At the released 25 Hz / 512-d geometry this
+/// is 10.24 seconds and 512 KiB, all allocated at stream construction.
+const DEFAULT_PENDING_FEATURE_FRAMES: usize = 256;
+
+struct MoshiFeatureStream {
+    engine: Arc<MoshiEngine>,
+    encoder_state: MimiEncoderState,
+    token_hop: usize,
+    feature_hop: usize,
+    feature_dim: usize,
+    features_per_token_frame: usize,
+    frame_rate_millihz: u32,
+    partial_pcm: Vec<f32>,
+    partial_len: usize,
+    feature_scratch: Vec<f32>,
+    pending: Vec<f32>,
+    pending_capacity_frames: usize,
+    pending_head: usize,
+    pending_len: usize,
+    next_output_sample: i64,
+}
+
+impl MoshiFeatureStream {
+    fn new(engine: Arc<MoshiEngine>) -> Result<Self> {
+        let encoder = engine.encoder();
+        let token_hop = encoder.frame_hop()?;
+        let feature_hop = encoder.feature_frame_hop()?;
+        let feature_dim = encoder.feature_dim();
+        if feature_dim == 0 {
+            return Err(VokraError::InvalidArgument(
+                "moshi feature stream: feature dimension must be > 0".into(),
+            ));
+        }
+        if token_hop % feature_hop != 0 {
+            return Err(VokraError::InvalidArgument(format!(
+                "moshi feature stream: token hop {token_hop} is not divisible by feature hop \
+                 {feature_hop}"
+            )));
+        }
+        let features_per_token_frame = token_hop / feature_hop;
+        let rate_num = u64::from(encoder.config().sample_rate) * 1000;
+        if rate_num % feature_hop as u64 != 0 {
+            return Err(VokraError::InvalidArgument(format!(
+                "moshi feature stream: sample rate {} does not form an exact milli-Hz rate at \
+                 feature hop {feature_hop}",
+                encoder.config().sample_rate
+            )));
+        }
+        let frame_rate_millihz = u32::try_from(rate_num / feature_hop as u64).map_err(|_| {
+            VokraError::InvalidArgument(
+                "moshi feature stream: frame rate does not fit u32 milli-Hz".into(),
+            )
+        })?;
+        let scratch_len = features_per_token_frame
+            .checked_mul(feature_dim)
+            .ok_or_else(|| {
+                VokraError::InvalidArgument(
+                    "moshi feature stream: scratch geometry overflows usize".into(),
+                )
+            })?;
+        let pending_len = DEFAULT_PENDING_FEATURE_FRAMES
+            .checked_mul(feature_dim)
+            .ok_or_else(|| {
+                VokraError::InvalidArgument(
+                    "moshi feature stream: pending geometry overflows usize".into(),
+                )
+            })?;
+        let encoder_state = encoder.state(1)?;
+        Ok(Self {
+            engine,
+            encoder_state,
+            token_hop,
+            feature_hop,
+            feature_dim,
+            features_per_token_frame,
+            frame_rate_millihz,
+            partial_pcm: vec![0.0; token_hop],
+            partial_len: 0,
+            feature_scratch: vec![0.0; scratch_len],
+            pending: vec![0.0; pending_len],
+            pending_capacity_frames: DEFAULT_PENDING_FEATURE_FRAMES,
+            pending_head: 0,
+            pending_len: 0,
+            next_output_sample: 0,
+        })
+    }
+
+    fn encode_frame(&mut self, pcm: &[f32]) -> Result<()> {
+        self.engine.encoder().encode_features_into(
+            &mut self.encoder_state,
+            pcm,
+            &mut self.feature_scratch,
+        )?;
+        for frame in 0..self.features_per_token_frame {
+            let tail = (self.pending_head + self.pending_len) % self.pending_capacity_frames;
+            let src =
+                &self.feature_scratch[frame * self.feature_dim..(frame + 1) * self.feature_dim];
+            let dst = &mut self.pending[tail * self.feature_dim..(tail + 1) * self.feature_dim];
+            dst.copy_from_slice(src);
+            self.pending_len += 1;
+        }
+        Ok(())
+    }
+
+    fn encode_partial_frame(&mut self) -> Result<()> {
+        // Borrow the disjoint state/scratch/queue fields directly so the full
+        // `partial_pcm` frame never needs a temporary copy.
+        self.engine.encoder().encode_features_into(
+            &mut self.encoder_state,
+            &self.partial_pcm,
+            &mut self.feature_scratch,
+        )?;
+        for frame in 0..self.features_per_token_frame {
+            let tail = (self.pending_head + self.pending_len) % self.pending_capacity_frames;
+            let src =
+                &self.feature_scratch[frame * self.feature_dim..(frame + 1) * self.feature_dim];
+            let dst = &mut self.pending[tail * self.feature_dim..(tail + 1) * self.feature_dim];
+            dst.copy_from_slice(src);
+            self.pending_len += 1;
+        }
+        Ok(())
+    }
+}
+
+impl SpeechFeatureStream for MoshiFeatureStream {
+    fn sample_rate(&self) -> u32 {
+        self.engine.encoder().config().sample_rate
+    }
+
+    fn frame_rate_millihz(&self) -> u32 {
+        self.frame_rate_millihz
+    }
+
+    fn feature_frame_hop(&self) -> usize {
+        self.feature_hop
+    }
+
+    fn feature_dim(&self) -> usize {
+        self.feature_dim
+    }
+
+    // ZERO-ALLOC-BEGIN (#49: C-ABI-facing streaming feature push/pull)
+    fn push_pcm(&mut self, pcm: &[f32]) -> Result<()> {
+        let combined = self.partial_len.checked_add(pcm.len()).ok_or_else(|| {
+            VokraError::InvalidArgument(
+                "moshi feature stream: cumulative push length overflows usize".into(),
+            )
+        })?;
+        let completed_token_frames = combined / self.token_hop;
+        let produced = completed_token_frames
+            .checked_mul(self.features_per_token_frame)
+            .ok_or_else(|| {
+                VokraError::InvalidArgument(
+                    "moshi feature stream: produced feature count overflows usize".into(),
+                )
+            })?;
+        let free = self.pending_capacity_frames - self.pending_len;
+        if produced > free {
+            return Err(VokraError::InvalidArgument(format!(
+                "moshi feature stream: push would produce {produced} frames but bounded queue \
+                 has {free} free; pull pending features before retrying (state unchanged)"
+            )));
+        }
+
+        let mut rest = pcm;
+        if self.partial_len > 0 {
+            let take = (self.token_hop - self.partial_len).min(rest.len());
+            self.partial_pcm[self.partial_len..self.partial_len + take]
+                .copy_from_slice(&rest[..take]);
+            self.partial_len += take;
+            rest = &rest[take..];
+            if self.partial_len == self.token_hop {
+                self.encode_partial_frame()?;
+                self.partial_len = 0;
+            } else {
+                return Ok(());
+            }
+        }
+
+        while rest.len() >= self.token_hop {
+            self.encode_frame(&rest[..self.token_hop])?;
+            rest = &rest[self.token_hop..];
+        }
+        self.partial_pcm[..rest.len()].copy_from_slice(rest);
+        self.partial_len = rest.len();
+        Ok(())
+    }
+
+    fn pull_into(&mut self, out: &mut [f32]) -> Result<(usize, i64)> {
+        if !out.is_empty() && out.len() < self.feature_dim {
+            return Err(VokraError::InvalidArgument(format!(
+                "moshi feature stream: output capacity {} floats is smaller than one \
+                 feature row of {} floats (state unchanged)",
+                out.len(),
+                self.feature_dim
+            )));
+        }
+        let frames = (out.len() / self.feature_dim).min(self.pending_len);
+        let sample_delta = frames.checked_mul(self.feature_hop).ok_or_else(|| {
+            VokraError::InvalidArgument(
+                "moshi feature stream: timestamp delta overflows usize".into(),
+            )
+        })?;
+        let sample_delta = i64::try_from(sample_delta).map_err(|_| {
+            VokraError::InvalidArgument(
+                "moshi feature stream: timestamp delta does not fit i64".into(),
+            )
+        })?;
+        let new_timestamp = self
+            .next_output_sample
+            .checked_add(sample_delta)
+            .ok_or_else(|| {
+                VokraError::InvalidArgument("moshi feature stream: timestamp overflows i64".into())
+            })?;
+        let start = self.next_output_sample;
+        for frame in 0..frames {
+            let slot = (self.pending_head + frame) % self.pending_capacity_frames;
+            let src = &self.pending[slot * self.feature_dim..(slot + 1) * self.feature_dim];
+            let dst = &mut out[frame * self.feature_dim..(frame + 1) * self.feature_dim];
+            dst.copy_from_slice(src);
+        }
+        self.pending_head = (self.pending_head + frames) % self.pending_capacity_frames;
+        self.pending_len -= frames;
+        self.next_output_sample = new_timestamp;
+        Ok((frames, start))
+    }
+    // ZERO-ALLOC-END
+
+    fn reset(&mut self) {
+        self.encoder_state.reset();
+        self.partial_len = 0;
+        self.pending_head = 0;
+        self.pending_len = 0;
+        self.next_output_sample = 0;
+    }
+}
+
+impl SpeechFeatureEngine for MoshiEngine {
+    fn open_feature_stream(self: Arc<Self>) -> Result<Box<dyn SpeechFeatureStream + Send>> {
+        Ok(Box::new(MoshiFeatureStream::new(self)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use vokra_core::engines::SpeechFeatureEngine;
+
+    use super::{DEFAULT_PENDING_FEATURE_FRAMES, MoshiEngine};
+
+    fn pcm(n: usize) -> Vec<f32> {
+        (0..n)
+            .map(|i| ((i as f32 * 0.013).sin() + (i as f32 * 0.031).cos()) * 0.25)
+            .collect()
+    }
+
+    #[test]
+    fn arbitrary_pcm_chunks_match_whole_buffer_continuous_forward_exactly() {
+        let engine = Arc::new(MoshiEngine::synthesized_fixture(49).unwrap());
+        let token_hop = engine.encoder().frame_hop().unwrap();
+        let input = pcm(token_hop * 5);
+        let want = engine.encoder().encode_features_all(&input).unwrap();
+        let mut stream = engine.clone().open_feature_stream().unwrap();
+
+        let chunk_sizes = [1usize, 17, 511, token_hop + 3, 29, 777];
+        let mut cursor = 0usize;
+        let mut chunk = 0usize;
+        while cursor < input.len() {
+            let take = chunk_sizes[chunk % chunk_sizes.len()].min(input.len() - cursor);
+            stream.push_pcm(&input[cursor..cursor + take]).unwrap();
+            cursor += take;
+            chunk += 1;
+        }
+
+        let mut got = vec![0.0f32; want.len()];
+        let (frames, start_sample) = stream.pull_into(&mut got).unwrap();
+        assert_eq!(start_sample, 0);
+        assert_eq!(frames * stream.feature_dim(), want.len());
+        assert_eq!(got, want);
+    }
+
+    #[test]
+    fn metadata_and_partial_pulls_keep_sample_accurate_timestamps() {
+        let engine = Arc::new(MoshiEngine::synthesized_fixture(50).unwrap());
+        let token_hop = engine.encoder().frame_hop().unwrap();
+        let mut stream = engine.open_feature_stream().unwrap();
+        assert_eq!(
+            u64::from(stream.frame_rate_millihz()) * stream.feature_frame_hop() as u64,
+            u64::from(stream.sample_rate()) * 1000,
+        );
+
+        stream.push_pcm(&pcm(token_hop * 2)).unwrap();
+        let mut one = vec![0.0f32; stream.feature_dim()];
+        for expected_frame in 0..4i64 {
+            let (frames, start) = stream.pull_into(&mut one).unwrap();
+            assert_eq!(frames, 1);
+            assert_eq!(start, expected_frame * stream.feature_frame_hop() as i64,);
+        }
+        assert_eq!(stream.pull_into(&mut one).unwrap().0, 0);
+    }
+
+    #[test]
+    fn reset_discards_tail_and_pending_features_and_restarts_timestamp_zero() {
+        let engine = Arc::new(MoshiEngine::synthesized_fixture(51).unwrap());
+        let token_hop = engine.encoder().frame_hop().unwrap();
+        let input = pcm(token_hop);
+        let mut stream = engine.open_feature_stream().unwrap();
+        stream.push_pcm(&input[..token_hop / 2]).unwrap();
+        stream.push_pcm(&input[token_hop / 2..]).unwrap();
+        let mut first = vec![0.0f32; stream.feature_dim() * 2];
+        assert_eq!(stream.pull_into(&mut first).unwrap(), (2, 0));
+
+        stream.push_pcm(&input).unwrap();
+        stream.reset();
+        let mut empty = vec![0.0f32; stream.feature_dim()];
+        assert_eq!(stream.pull_into(&mut empty).unwrap().0, 0);
+        stream.push_pcm(&input).unwrap();
+        let mut second = vec![0.0f32; first.len()];
+        assert_eq!(stream.pull_into(&mut second).unwrap(), (2, 0));
+        assert_eq!(second, first);
+    }
+
+    #[test]
+    fn non_frame_sized_pull_is_rejected_without_consuming_output() {
+        let engine = Arc::new(MoshiEngine::synthesized_fixture(52).unwrap());
+        let token_hop = engine.encoder().frame_hop().unwrap();
+        let mut stream = engine.open_feature_stream().unwrap();
+        stream.push_pcm(&pcm(token_hop)).unwrap();
+        let mut short = vec![0.0f32; stream.feature_dim() - 1];
+        assert!(stream.pull_into(&mut short).is_err());
+        let mut full = vec![0.0f32; stream.feature_dim() * 2];
+        assert_eq!(stream.pull_into(&mut full).unwrap(), (2, 0));
+    }
+
+    #[test]
+    fn bounded_queue_backpressure_rejects_before_consuming_pcm() {
+        let engine = Arc::new(MoshiEngine::synthesized_fixture(53).unwrap());
+        let token_hop = engine.encoder().frame_hop().unwrap();
+        let mut stream = engine.clone().open_feature_stream().unwrap();
+        let features_per_token_frame = token_hop / stream.feature_frame_hop();
+        let too_many_token_frames = DEFAULT_PENDING_FEATURE_FRAMES / features_per_token_frame + 1;
+        assert!(
+            stream
+                .push_pcm(&pcm(token_hop * too_many_token_frames))
+                .is_err(),
+        );
+
+        let one_frame = pcm(token_hop);
+        stream.push_pcm(&one_frame).unwrap();
+        let mut got = vec![0.0f32; stream.feature_dim() * 2];
+        assert_eq!(stream.pull_into(&mut got).unwrap(), (2, 0));
+
+        let mut fresh = engine.open_feature_stream().unwrap();
+        fresh.push_pcm(&one_frame).unwrap();
+        let mut want = vec![0.0f32; got.len()];
+        assert_eq!(fresh.pull_into(&mut want).unwrap(), (2, 0));
+        assert_eq!(got, want, "rejected push must not advance recurrent state");
+    }
+}

--- a/crates/vokra-models/src/moshi/mod.rs
+++ b/crates/vokra-models/src/moshi/mod.rs
@@ -55,6 +55,7 @@ pub mod config;
 pub mod depth;
 pub mod duplex;
 pub mod engine;
+mod feature;
 pub mod frame;
 pub mod tokenizer;
 

--- a/crates/vokra-models/tests/speech_feature_hot_path_alloc.rs
+++ b/crates/vokra-models/tests/speech_feature_hot_path_alloc.rs
@@ -1,0 +1,64 @@
+//! Counting-allocator proof for #49 streaming speech-feature push/pull.
+
+#![allow(unsafe_code)]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use vokra_core::engines::SpeechFeatureEngine;
+use vokra_models::moshi::MoshiEngine;
+
+struct CountingAlloc;
+
+static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+
+// SAFETY: every allocation operation is forwarded unchanged to `System`; the
+// wrapper only increments a diagnostic counter.
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        // SAFETY: exact layout forwarded to the system allocator.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: original pointer/layout forwarded to the system allocator.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOCS.fetch_add(1, Ordering::Relaxed);
+        // SAFETY: original allocation and requested size forwarded unchanged.
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAlloc = CountingAlloc;
+
+#[test]
+fn one_thousand_warmed_push_pull_pairs_allocate_zero() {
+    let engine = Arc::new(MoshiEngine::synthesized_fixture(0xFEA7_0049).unwrap());
+    let mut stream = engine.open_feature_stream().unwrap();
+    let token_hop = stream.feature_frame_hop() * 2;
+    let input = vec![0.125f32; token_hop];
+    let mut output = vec![0.0f32; stream.feature_dim() * 2];
+
+    // First t=2 transformer call grows its retained batch scratch. That is the
+    // documented warmup; every later call reuses the same capacities.
+    stream.push_pcm(&input).unwrap();
+    assert_eq!(stream.pull_into(&mut output).unwrap().0, 2);
+
+    let before = ALLOCS.load(Ordering::SeqCst);
+    for _ in 0..1000 {
+        stream.push_pcm(&input).unwrap();
+        assert_eq!(stream.pull_into(&mut output).unwrap().0, 2);
+    }
+    let after = ALLOCS.load(Ordering::SeqCst);
+    assert_eq!(
+        after - before,
+        0,
+        "streaming speech-feature push/pull allocated after warmup",
+    );
+}

--- a/crates/vokra-models/tests/speech_feature_hot_path_alloc.rs
+++ b/crates/vokra-models/tests/speech_feature_hot_path_alloc.rs
@@ -45,10 +45,15 @@ fn one_thousand_warmed_push_pull_pairs_allocate_zero() {
     let input = vec![0.125f32; token_hop];
     let mut output = vec![0.0f32; stream.feature_dim() * 2];
 
-    // First t=2 transformer call grows its retained batch scratch. That is the
-    // documented warmup; every later call reuses the same capacities.
-    stream.push_pcm(&input).unwrap();
-    assert_eq!(stream.pull_into(&mut output).unwrap().0, 2);
+    // Warm both the retained t=2 batch scratch and a complete rolling
+    // attention-window cycle. Windows CI observed one process-lifetime
+    // allocation before the window saturated; measuring after every window
+    // width has been exercised keeps that setup outside steady state while
+    // still catching any allocation that recurs afterward.
+    for _ in 0..256 {
+        stream.push_pcm(&input).unwrap();
+        assert_eq!(stream.pull_into(&mut output).unwrap().0, 2);
+    }
 
     let before = ALLOCS.load(Ordering::SeqCst);
     for _ in 0..1000 {

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,7 @@ publication scripts for release gates.
 - The retired audit branch was not merged wholesale. PR #29 carried the audit
   work, PR #32 carried the Codex migration, and PR #37 carried the remaining
   Claude compatibility delta.
-- The generated C header currently has 41 `vokra_*` functions. References
+- The generated C header currently has 48 `vokra_*` functions. References
   to 33 functions in dated M4/M5 reports are historical snapshots.
 - M5 is not complete and the C ABI is not frozen. The live checklist has
   42 checked and 36 literal unchecked boxes plus prose-only GA gates in §0;

--- a/docs/abi-changelog.md
+++ b/docs/abi-changelog.md
@@ -270,6 +270,36 @@ checkpoint. The fixture records the HF repo commit, checkpoint SHA-256 and
 NVIDIA-NeMo/Speech source commit; Python is offline-only under a dedicated
 Python 3.12 `uv.lock`. Root `Cargo.lock` remains first-party-only.
 
+### 2026-08-22 — 1.0.0-rc.1-dev (streaming continuous speech features — 7 new functions, 1 new typedef, additive)
+
+The C surface grows from **41 fn + 13 typedef to 48 fn + 14 typedef**. All
+changes are additive and the v1.0-rc baseline snapshot is intentionally not
+rotated before the M5-13 GA freeze. The first implementation is Moshi's causal
+Mimi input encoder: it exposes the continuous bottleneck-transformer grid at
+25 Hz, before token-rate resampling and RVQ. No GGUF key or runtime dependency
+is added.
+
+`push_pcm` accepts arbitrary chunks and retains a partial token frame. `pull`
+writes complete feature rows and reports the exact source-sample index of its
+first row; later rows follow the queried native frame rate. Both operations use
+bounded, preallocated storage after warmup. Queue overflow, undersized output,
+NULL arguments, and a session without a feature engine fail loudly without
+consuming queued data.
+
+| Crate / area | Symbol | Kind | Signature | Rationale | Breaking? | PR |
+| ------------ | ------ | ---- | --------- | --------- | --------- | -- |
+| `include/vokra.h` | `vokra_feat_t` | Added | `typedef struct vokra_feat_t vokra_feat_t` | Opaque streaming-feature state retaining its session | no | (TBD) |
+| `include/vokra.h` | `vokra_feat_open` | Added | `vokra_feat_t *(const vokra_session_t *)` | Open the feature stream selected by the session's native model family | no | (TBD) |
+| `include/vokra.h` | `vokra_feat_frame_rate_mhz` | Added | `int32_t(const vokra_feat_t *)` | Query the encoder's native rate without caller hard-coding | no | (TBD) |
+| `include/vokra.h` | `vokra_feat_dim` | Added | `int32_t(const vokra_feat_t *)` | Query floats per row for caller-owned output sizing | no | (TBD) |
+| `include/vokra.h` | `vokra_feat_push_pcm` | Added | `vokra_status_t(vokra_feat_t *, const float *, size_t)` | Stream arbitrary mono PCM chunks into bounded causal state | no | (TBD) |
+| `include/vokra.h` | `vokra_feat_pull` | Added | `vokra_status_t(vokra_feat_t *, float *, size_t, size_t *, int64_t *)` | Non-blocking complete-row pull plus sample-accurate start timestamp | no | (TBD) |
+| `include/vokra.h` | `vokra_feat_reset` | Added | `void(vokra_feat_t *)` | Return PCM tail, queue, clock, and recurrent caches to as-new state | no | (TBD) |
+| `include/vokra.h` | `vokra_feat_destroy` | Added | `void(vokra_feat_t *)` | Release the opaque stream (`NULL` is a no-op) | no | (TBD) |
+| `vokra-core` | `SpeechFeatureEngine` / `SpeechFeatureStream` | Added | two public traits | Model-independent engine injection and streaming metadata/push/pull/reset contract | no | (TBD) |
+| `vokra-core` | `Session::with_speech_feature_engine` / `Session::open_speech_feature_stream` | Added | public methods | Attach or open the family-specific engine; absence is a loud `NotImplemented` | no | (TBD) |
+| `vokra-models` | `MimiEncoder::{feature_dim, feature_frame_hop, encode_features_into, encode_features_all}` / `MimiEncoderState::reset` | Added | public methods | Reuse the native causal encoder and expose its pre-RVQ continuous grid without changing codec output arithmetic | no | (TBD) |
+
 ### 2026-08-21 — 1.0.0-rc.1-dev (stateful streaming resampler — Rust surface only, additive)
 
 Issue #50 adds a caller-owned-buffer streaming wrapper around Vokra's existing

--- a/docs/abi/vokra-rust-public-api.v1.0-rc.list
+++ b/docs/abi/vokra-rust-public-api.v1.0-rc.list
@@ -219,6 +219,13 @@ FN vokra-capi::aec::vokra_aec_reset|pub unsafe extern "C" fn vokra_aec_reset(aec
 FN vokra-capi::asr::vokra_asr_transcribe|pub unsafe extern "C" fn vokra_asr_transcribe(
 FN vokra-capi::asr::vokra_string_free|pub unsafe extern "C" fn vokra_string_free(s: *mut c_char) {
 FN vokra-capi::error::vokra_last_error|pub extern "C" fn vokra_last_error() -> *const c_char {
+FN vokra-capi::feature::vokra_feat_destroy|pub unsafe extern "C" fn vokra_feat_destroy(feat: *mut vokra_feat_t) {
+FN vokra-capi::feature::vokra_feat_dim|pub unsafe extern "C" fn vokra_feat_dim(feat: *const vokra_feat_t) -> i32 {
+FN vokra-capi::feature::vokra_feat_frame_rate_mhz|pub unsafe extern "C" fn vokra_feat_frame_rate_mhz(feat: *const vokra_feat_t) -> i32 {
+FN vokra-capi::feature::vokra_feat_open|pub unsafe extern "C" fn vokra_feat_open(session: *const vokra_session_t) -> *mut vokra_feat_t {
+FN vokra-capi::feature::vokra_feat_pull|pub unsafe extern "C" fn vokra_feat_pull(
+FN vokra-capi::feature::vokra_feat_push_pcm|pub unsafe extern "C" fn vokra_feat_push_pcm(
+FN vokra-capi::feature::vokra_feat_reset|pub unsafe extern "C" fn vokra_feat_reset(feat: *mut vokra_feat_t) {
 FN vokra-capi::options::vokra_backend_available|pub extern "C" fn vokra_backend_available(backend: i32) -> bool {
 FN vokra-capi::options::vokra_session_options_create|pub extern "C" fn vokra_session_options_create() -> *mut vokra_session_options_t {
 FN vokra-capi::options::vokra_session_options_destroy|pub unsafe extern "C" fn vokra_session_options_destroy(opts: *mut vokra_session_options_t) {
@@ -651,6 +658,7 @@ FN vokra-core::session::from_gguf|pub fn from_gguf(gguf: GgufFile) -> SessionBui
 FN vokra-core::session::gguf|pub fn gguf(&self) -> &GgufFile {
 FN vokra-core::session::kv_quant|pub fn kv_quant(&self) -> KvQuant {
 FN vokra-core::session::model_path|pub fn model_path(&self) -> &Path {
+FN vokra-core::session::open_speech_feature_stream|pub fn open_speech_feature_stream(&self) -> Result<Box<dyn SpeechFeatureStream + Send>> {
 FN vokra-core::session::open_vad_stream|pub fn open_vad_stream(&self) -> Result<Box<dyn VadStreamHandle + Send>> {
 FN vokra-core::session::with_asr_engine|pub fn with_asr_engine(mut self, engine: Arc<dyn AsrEngine>) -> Self {
 FN vokra-core::session::with_attribution|pub fn with_attribution(mut self, attribution: AttributionInfo) -> Self {
@@ -659,6 +667,7 @@ FN vokra-core::session::with_kv_quant|pub fn with_kv_quant(mut self, kv_quant: K
 FN vokra-core::session::with_s2s_duplex_engine|pub fn with_s2s_duplex_engine(mut self, engine: Arc<dyn S2sDuplexEngine>) -> Self {
 FN vokra-core::session::with_s2s_engine|pub fn with_s2s_engine(mut self, engine: Arc<dyn S2sEngine>) -> Self {
 FN vokra-core::session::with_speaker_engine|pub fn with_speaker_engine(mut self, engine: Arc<dyn SpeakerEngine>) -> Self {
+FN vokra-core::session::with_speech_feature_engine|pub fn with_speech_feature_engine(mut self, engine: Arc<dyn SpeechFeatureEngine>) -> Self {
 FN vokra-core::session::with_tts_engine|pub fn with_tts_engine(mut self, engine: Arc<dyn TtsEngine>) -> Self {
 FN vokra-core::session::with_vad_engine|pub fn with_vad_engine(mut self, engine: Arc<dyn VadEngine>) -> Self {
 FN vokra-core::stream::active_stream_count|pub fn active_stream_count(&self) -> u64 {
@@ -1210,6 +1219,7 @@ MOD vokra-ops::zipformer|pub mod zipformer;
 STRUCT vokra-capi::aec::vokra_aec_config_t|pub struct vokra_aec_config_t {
 STRUCT vokra-capi::aec::vokra_aec_ref_writer_t|pub struct vokra_aec_ref_writer_t {
 STRUCT vokra-capi::aec::vokra_aec_t|pub struct vokra_aec_t {
+STRUCT vokra-capi::handle::vokra_feat_t|pub struct vokra_feat_t {
 STRUCT vokra-capi::handle::vokra_session_t|pub struct vokra_session_t {
 STRUCT vokra-capi::handle::vokra_stream_t|pub struct vokra_stream_t {
 STRUCT vokra-capi::options::vokra_session_options_t|pub struct vokra_session_options_t {
@@ -1490,6 +1500,8 @@ TRAIT vokra-core::engines::S2sDuplexEngine|pub trait S2sDuplexEngine: Send + Syn
 TRAIT vokra-core::engines::S2sDuplexHandle|pub trait S2sDuplexHandle {
 TRAIT vokra-core::engines::S2sEngine|pub trait S2sEngine: Send + Sync {
 TRAIT vokra-core::engines::SpeakerEngine|pub trait SpeakerEngine: Send + Sync {
+TRAIT vokra-core::engines::SpeechFeatureEngine|pub trait SpeechFeatureEngine: Send + Sync {
+TRAIT vokra-core::engines::SpeechFeatureStream|pub trait SpeechFeatureStream {
 TRAIT vokra-core::engines::TtsEngine|pub trait TtsEngine: Send + Sync {
 TRAIT vokra-core::engines::TtsStreamHandle|pub trait TtsStreamHandle {
 TRAIT vokra-core::engines::VadEngine|pub trait VadEngine: Send + Sync {
@@ -1533,7 +1545,7 @@ USE vokra-core::decode::wfst::semiring::{Semiring, TropicalWeight}|pub use semir
 USE vokra-core::decode::wfst::{ Arc, Fst, Label, Semiring, StateId, TropicalWeight, WfstDecodeConfig, WfstDecoder, WfstHypothesis, WfstLattice, read_openfst_vector, }|pub use wfst::{ Arc, Fst, Label, Semiring, StateId, TropicalWeight, WfstDecodeConfig, WfstDecoder, WfstHypothesis, WfstLattice, read_openfst_vector, };
 USE vokra-core::decode::word_timing::{ APPEND_PUNCTUATIONS, AlignmentParams, CrossAttention, PREPEND_PUNCTUATIONS, WordTiming, merge_punctuations, token_alignment, words_from_alignment, }|pub use word_timing::{ APPEND_PUNCTUATIONS, AlignmentParams, CrossAttention, PREPEND_PUNCTUATIONS, WordTiming, merge_punctuations, token_alignment, words_from_alignment, };
 USE vokra-core::decode::{ CfgMode, DecodeStepper, LogitsSource, Sampler, SamplerConfig, TOKEN_FLAG_EOT, apply_cfg, apply_cfg_inplace, argmax, sample_sequence, }|pub use decode::{ CfgMode, DecodeStepper, LogitsSource, Sampler, SamplerConfig, TOKEN_FLAG_EOT, apply_cfg, apply_cfg_inplace, argmax, sample_sequence, };
-USE vokra-core::engines::{ AecEngine, AecStreamHandle, AsrEngine, DialogContextTurn, DialogRequest, DuplexInterruptHandle, DuplexPushReport, DuplexSessionConfig, S2sDuplexEngine, S2sDuplexHandle, S2sEngine, SpeakerEngine, SynthesisRequest, TtsEngine, TtsStreamHandle, VadEngine, VadStreamHandle, }|pub use engines::{ AecEngine, AecStreamHandle, AsrEngine, DialogContextTurn, DialogRequest, DuplexInterruptHandle, DuplexPushReport, DuplexSessionConfig, S2sDuplexEngine, S2sDuplexHandle, S2sEngine, SpeakerEngine, SynthesisRequest, TtsEngine, TtsStreamHandle, VadEngine, VadStreamHandle, };
+USE vokra-core::engines::{ AecEngine, AecStreamHandle, AsrEngine, DialogContextTurn, DialogRequest, DuplexInterruptHandle, DuplexPushReport, DuplexSessionConfig, S2sDuplexEngine, S2sDuplexHandle, S2sEngine, SpeakerEngine, SpeechFeatureEngine, SpeechFeatureStream, SynthesisRequest, TtsEngine, TtsStreamHandle, VadEngine, VadStreamHandle, }|pub use engines::{ AecEngine, AecStreamHandle, AsrEngine, DialogContextTurn, DialogRequest, DuplexInterruptHandle, DuplexPushReport, DuplexSessionConfig, S2sDuplexEngine, S2sDuplexHandle, S2sEngine, SpeakerEngine, SpeechFeatureEngine, SpeechFeatureStream, SynthesisRequest, TtsEngine, TtsStreamHandle, VadEngine, VadStreamHandle, };
 USE vokra-core::error::{Result, VokraError}|pub use error::{Result, VokraError};
 USE vokra-core::gguf::frontend_spec::{FieldMismatch, FrontendPolicy, FrontendSpec}|pub use frontend_spec::{FieldMismatch, FrontendPolicy, FrontendSpec};
 USE vokra-core::gguf::reader::{AsBytes, GgufFile}|pub use reader::{AsBytes, GgufFile};

--- a/docs/api-reference.ja.md
+++ b/docs/api-reference.ja.md
@@ -60,10 +60,11 @@ Python / JS の全バインディングはこの 1 つのヘッダの上に乗�
 
 ## Keeping this page current
 
-**最終確認日: 2026-08-18 — `main` `6d64fdf`、workspace publish set、
-`include/vokra.h` に対して確認。** 生成 C header は41個の `vokra_*` function を
-宣言する。pre-alpha の Python generator が認識するのは現在39個、checked-in table
-が公開するのは14個であり、Python package は現行 C ABI の完全な mirror ではない。
+**最終確認日: 2026-08-22 — issue #49 の source と `include/vokra.h` に対して
+確認。** 生成 C header は48個の `vokra_*` function を宣言し、pre-alpha の
+Python generator と checked-in `ctypes` table は48個すべてを覆う。高水準 Python
+package は、全 C handle に wrapper class を持つのではなく、より小さい慣用的な
+surface のままである。
 
 - **更新責任**: publish crate・新バインディング・C ABI 生成を変えた PR が、
   同一 PR で本索引と英語版を更新する。

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -63,11 +63,11 @@ Each binding documents its own idiomatic surface on top of the C ABI:
 
 ## Keeping this page current
 
-**Last verified: 2026-08-18 — against `main` `6d64fdf`, the workspace publish
-set, and `include/vokra.h`.** The generated C header declares 41 `vokra_*`
-functions. The pre-alpha Python generator currently recognizes 39 and its
-checked-in table exposes 14, so the Python package is not a complete mirror of
-the current C ABI yet.
+**Last verified: 2026-08-22 — against the issue #49 source and
+`include/vokra.h`.** The generated C header declares 48 `vokra_*` functions.
+The pre-alpha Python generator and checked-in `ctypes` table cover all 48; the
+high-level Python package remains a smaller idiomatic surface rather than a
+wrapper class for every C handle.
 
 - **Update responsibility**: a PR that adds a published crate, a new binding, or
   changes the C ABI generation updates this index and its Japanese twin in the

--- a/docs/m2-owner-verification-checklist.md
+++ b/docs/m2-owner-verification-checklist.md
@@ -505,7 +505,7 @@ fixture 自体（`logmel.f32` / `encoder.f32` / `logits_last.f32` / `tokenizer.b
 | M2-09 | vokra-server 4 互換 API | ✅ 完了 | — |
 | M2-10 | Discord bot デモ | ❌ descoped | Discord 全体を非採用（依頼者決定）。サーバ稼働実証は M2-15 review の別形態で扱う |
 | M2-11 | Unity official plugin | ✅ 完了（UPM CD） | § 7（Unity license）|
-| M2-12 | 言語バインディング（Python 初回） | ⚠️ wheel scaffold 完了。ただし current ABI 41 functions に対して生成済み binding は14 functions、generator は新構造体未対応、package root export 未完了 | binding drift 修復 + § 5（合意）+ § 6（PyPI reservation / publication）|
+| M2-12 | 言語バインディング（Python 初回） | ⚠️ source 実装は current ABI 48 functions に同期済み。package root export、4 native wheel の build/repair/arch smoke も実装済み | final-head wheel 検証 + § 5（合意）+ § 6（PyPI reservation / publication）|
 | M2-13 | compliance 拡張 | ✅ 完了 | — |
 | M2-14 | 実機ベンチ計測 | 引き渡し済み / CUDA reference 計測は完了、iOS 実機は依頼者側／**CUDA RTF variance harness は Phase 3 で CC-integrated + 実 vast.ai run 完了（hardware variance で M2-14 defer 決定）**（§ 2） | § 1 + § 2 |
 | M2-15 | 四半期 Go/No-go review | 継続監視 / metrics runbook 整備済（§ 4 参照） | § 8（Kill switch J — wire-level PASS）+ § 9（C/K）|

--- a/docs/migration-guide.ja.md
+++ b/docs/migration-guide.ja.md
@@ -123,7 +123,7 @@ vokra-cli convert --model whisper \
 ## 4. `faster-whisper`（Python）から
 
 source Python packageは`Session`をexportし、生成済み`ctypes` tableも現行C
-headerの41 functionsをすべて覆います。ただし未公開のpre-1.0 surfaceです。
+headerの48 functionsをすべて覆います。ただし未公開のpre-1.0 surfaceです。
 4 native wheelsのfinal-head CIとPyPI/TestPyPI公開先の明示承認は未完了です。
 [binding status](../bindings/python/README.md)を参照してください。source checkout
 での評価は可能ですが、特定versionが公開・検証されるまではproductionの

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -125,7 +125,7 @@ Quantization presets available: `--quantize q4_k` / `q5_k` / `q6_k`
 ## 4. From `faster-whisper` (Python)
 
 The source Python package now exposes `Session` and its generated `ctypes`
-table covers all 41 current C functions. It remains an unpublished pre-1.0
+table covers all 48 current C functions. It remains an unpublished pre-1.0
 surface: the four native wheels must pass final-head CI, and no PyPI/TestPyPI
 destination has been authorized. See the
 [binding status](../bindings/python/README.md). Source-checkout evaluation is

--- a/docs/platform-support/v1.0-rc-support-matrix.md
+++ b/docs/platform-support/v1.0-rc-support-matrix.md
@@ -296,7 +296,7 @@ NFR-DS-03 は流通チャネルも列挙するが、M4-11 完了条件「配布�
 
 | 流通チャネル | 実在 job | 現状 |
 |-------------|---------|------|
-| PyPI wheel | `python-wheels.yml` + `ci.yml#python-wheel-build` + `release.yml#python-pypi-publish` | 🟡 current ABI 41 functionsのtable/public exports、4 native wheelのrepair・arch/manifest・Python 3.9/3.12 smokeを実装。final-head native CIと公開先の明示承認・upload後検証は未完了なので公開完了扱い不可 |
+| PyPI wheel | `python-wheels.yml` + `ci.yml#python-wheel-build` + `release.yml#python-pypi-publish` | 🟡 current ABI 48 functionsのtable/public exports、4 native wheelのrepair・arch/manifest・Python 3.9/3.12 smokeを実装。final-head native CIと公開先の明示承認・upload後検証は未完了なので公開完了扱い不可 |
 | npm (Web) | `release.yml#npm-web-release` | ✅ land 済 (Release tarball baseline、registry publish は `NPM_TOKEN` opt-in) |
 | Cargo crate (crates.io) | — | 未整備 → T13 |
 | Swift Package | (iOS XCFramework に内包) | ✅ (§8.1 参照) |

--- a/docs/tutorials/python.ja.md
+++ b/docs/tutorials/python.ja.md
@@ -2,9 +2,9 @@
 
 [English](python.md) | **日本語**
 
-> **実装状態（2026-08-20 照合）: source 実装済み・未公開。** package root は
+> **実装状態（2026-08-22 照合）: source 実装済み・未公開。** package root は
 > `Session`、`Stream`、`Event`、typed error を export し、生成 table は現行
-> C ABI 41 functions をすべて覆います。PyPI 公開は未検証・未承認です。正確な
+> C ABI 48 functions をすべて覆います。PyPI 公開は未検証・未承認です。正確な
 > gate は [binding README](../../bindings/python/README.md) を参照してください。
 
 ## 現在存在するもの
@@ -13,8 +13,8 @@
 - runtime dependency は空。NumPy は任意の interop のみ。
 - public source API: `Session`、`Stream`、`Event`、9 個の error subclass。
   音声 file の decode は caller 側の責務です。
-- 生成済み FFI table: 現行 C header の41 functions、4 enums、2 concrete
-  structs、7 opaque handles。
+- 生成済み FFI table: 現行 C header の48 functions、4 enums、2 concrete
+  structs、8 opaque handles。
 - CI 契約: required `license` job がgenerator driftを検査し、各wheel smokeが
   public names、table件数、native symbolsのloadを検証します。
 

--- a/docs/tutorials/python.md
+++ b/docs/tutorials/python.md
@@ -2,9 +2,9 @@
 
 **English** | [日本語](python.ja.md)
 
-> **Implementation status (reviewed 2026-08-20): source-complete, unpublished.**
+> **Implementation status (reviewed 2026-08-22): source-complete, unpublished.**
 > The package root exports `Session`, `Stream`, `Event`, and typed errors, and
-> its generated table covers all 41 current C functions. No PyPI release has
+> its generated table covers all 48 current C functions. No PyPI release has
 > been verified or authorized. See the
 > [binding README](../../bindings/python/README.md) for the exact gates.
 
@@ -14,8 +14,8 @@
 - Runtime dependency list: empty; NumPy is optional interop.
 - Public source API: `Session`, `Stream`, `Event`, and a nine-class error
   hierarchy. Audio-file decoding remains caller-owned.
-- Generated FFI table: all 41 functions in the current C header, plus its four
-  enums, two concrete structures, and seven opaque handles.
+- Generated FFI table: all 48 functions in the current C header, plus its four
+  enums, two concrete structures, and eight opaque handles.
 - CI contract: the required `license` job checks generator drift; each wheel
   smoke asserts the public names, table size, and native symbol load.
 

--- a/include/vokra.h
+++ b/include/vokra.h
@@ -139,6 +139,13 @@ typedef struct vokra_aec_ref_writer_t vokra_aec_ref_writer_t;
 // far-end queue. Owned by the inference thread. Opaque to C.
 typedef struct vokra_aec_t vokra_aec_t;
 
+// Opaque continuous speech-feature handle (#49).
+//
+// Created by `vokra_feat_open`, released by `vokra_feat_destroy`. It owns the
+// encoder's causal state and bounded pending-output ring, and retains the
+// originating session so model weights outlive the C handle.
+typedef struct vokra_feat_t vokra_feat_t;
+
 // Opaque duplex-session handle (module docs). Created by
 // `vokra_s2s_duplex_open`, released by `vokra_s2s_duplex_destroy`.
 typedef struct vokra_s2s_duplex_t vokra_s2s_duplex_t;
@@ -356,6 +363,82 @@ void vokra_string_free(char *s);
 // threads. `vokra_last_error` itself never fails and never allocates
 // (ADR-0003 §3-b).
 const char *vokra_last_error(void);
+
+// Opens a continuous speech-feature stream for `session`.
+//
+// The returned handle retains the session and must be released with
+// [`vokra_feat_destroy`]. Returns `NULL` with detail in `vokra_last_error()`
+// when the model family has no feature engine or construction fails.
+//
+// # Safety
+//
+// `session` must be a live session handle or `NULL` (the rejected branch).
+struct vokra_feat_t *vokra_feat_open(const struct vokra_session_t *session);
+
+// Returns the encoder's native frame rate in milli-Hertz (25 Hz = 25,000).
+// Returns `-1` on a NULL handle or internal failure.
+//
+// # Safety
+//
+// `feat` must be a live feature handle or `NULL` (the rejected branch).
+int32_t vokra_feat_frame_rate_mhz(const struct vokra_feat_t *feat);
+
+// Returns the number of `float` values in one feature frame, or `-1` on
+// failure.
+//
+// # Safety
+//
+// `feat` must be a live feature handle or `NULL` (the rejected branch).
+int32_t vokra_feat_dim(const struct vokra_feat_t *feat);
+
+// Appends arbitrary-length mono PCM at the model's native sample rate.
+//
+// A trailing partial encoder frame is retained. The handle owns a bounded
+// pending-feature queue; if the supplied PCM would overflow it, this returns
+// `VOKRA_ERROR_INVALID_ARGUMENT` without consuming input. Successful calls
+// allocate nothing after stream construction/warmup.
+//
+// # Safety
+//
+// `feat` must be live and uniquely accessed for the call. `pcm` must point to
+// `n` readable floats, or may be `NULL` only when `n == 0`.
+enum vokra_status_t vokra_feat_push_pcm(struct vokra_feat_t *feat,
+                                        const float *pcm,
+                                        size_t n);
+
+// Pulls whole feature frames into `out` without blocking.
+//
+// `cap` is a capacity in **floats**, not frames. Up to
+// `floor(cap / vokra_feat_dim(feat))` rows are written. `out_frames` receives
+// the row count, and `out_start_sample` receives the exact source-PCM sample
+// index of the first row (`-1` when no row was pending). A non-zero `cap`
+// smaller than one row is rejected without consuming queued output.
+//
+// # Safety
+//
+// `feat` must be live and uniquely accessed. `out` must point to `cap`
+// writable floats, or may be `NULL` only when `cap == 0`; both scalar output
+// pointers must be writable.
+enum vokra_status_t vokra_feat_pull(struct vokra_feat_t *feat,
+                                    float *out,
+                                    size_t cap,
+                                    size_t *out_frames,
+                                    int64_t *out_start_sample);
+
+// Discards PCM tail, queued frames, timestamps and recurrent state while
+// retaining all allocations.
+//
+// # Safety
+//
+// `feat` must be a live, uniquely accessed feature handle.
+void vokra_feat_reset(struct vokra_feat_t *feat);
+
+// Frees a feature handle. `NULL` is a no-op; double-free is undefined.
+//
+// # Safety
+//
+// `feat` must be `NULL` or a live pointer returned by [`vokra_feat_open`].
+void vokra_feat_destroy(struct vokra_feat_t *feat);
 
 // Allocates a session-options object preset to the library defaults (CPU
 // backend), or returns `NULL` if the allocation fails.

--- a/scripts/check-hot-path-allocs.sh
+++ b/scripts/check-hot-path-allocs.sh
@@ -27,6 +27,8 @@ FILES=(
     # #46: stateful NanoCodec causal HiFi-GAN frame decode. The counting-
     # allocator proof lives in nanocodec_hot_path_alloc.rs.
     "crates/vokra-models/src/nanocodec/causal_hifigan.rs"
+    # #49: bounded continuous-feature queue behind vokra_feat_push/pull.
+    "crates/vokra-models/src/moshi/feature.rs"
     # M4-03: the AEC process()/DSP-kernel regions (FR-EX-05; the counting-
     # allocator proof lives in crates/vokra-ops/tests/aec_hot_path_alloc.rs).
     "crates/vokra-ops/src/aec.rs"

--- a/scripts/run-capi-smoke.sh
+++ b/scripts/run-capi-smoke.sh
@@ -7,13 +7,16 @@
 #   2. scripts/gen-c-abi.sh --check          (vokra.h has no drift — WP cond.)
 #   3. exported-symbol check                 (only vokra_* symbols are public)
 #   4. cc-build + run
-#      tests/capi/smoke_{vad,vad_bytes,aec,s2s,backend_options,asr,tts}.c
+#      tests/capi/smoke_{vad,vad_bytes,aec,s2s,features,
+#      backend_options,asr,tts}.c
 #      against <vokra.h>
 #
 # VAD / VAD(bytes) use the committed 2 MB Silero fixture; AEC is model-free
 # (synthetic PCM). S2S runs its error paths + a permissive-model attribution
 # from the committed fixture and ENV-GATES its full duplex leg on
-# VOKRA_MOSHI_GGUF. ASR/TTS are ENV-GATED: they SKIP cleanly unless
+# VOKRA_MOSHI_GGUF. The continuous-feature happy path shares that Moshi gate;
+# its NULL and family-mismatch legs are always on. ASR/TTS are ENV-GATED: they
+# SKIP cleanly unless
 # VOKRA_WHISPER_GGUF / VOKRA_PIPER_GGUF point at the (uncommitted) GGUFs.
 #
 # Exit code: 0 = all pass/skip, non-zero = a build or test failure.
@@ -96,6 +99,11 @@ build_one aec
 # VOKRA_MOSHI_GGUF (SKIP when unset).
 build_one s2s
 "$TMP/smoke_s2s" "$ROOT/tests/parity/silero_vad/silero-vad-v5.gguf" || status=1
+
+# Issue #49: continuous speech features. NULL + non-feature-family rejection
+# are always on; the native Mimi happy path uses the same optional Moshi GGUF.
+build_one features
+"$TMP/smoke_features" "$ROOT/tests/parity/silero_vad/silero-vad-v5.gguf" || status=1
 
 # 2026-08-14: backend selection through the opaque options object
 # (vokra_backend_t / vokra_session_options_* / vokra_backend_available) plus

--- a/tests/capi/smoke_features.c
+++ b/tests/capi/smoke_features.c
@@ -1,0 +1,160 @@
+/*
+ * smoke_features.c — C smoke test for streaming continuous speech features
+ * (#49: vokra_feat_*), using only <vokra.h>.
+ *
+ * The committed Silero model covers the fail-closed family mismatch. Set
+ * VOKRA_MOSHI_GGUF to run the native Mimi encoder happy path as well.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "vokra.h"
+
+static const char *DEFAULT_MODEL = "tests/parity/silero_vad/silero-vad-v5.gguf";
+
+static int expect_invalid(vokra_status_t status, const char *what) {
+    if (status != VOKRA_ERROR_INVALID_ARGUMENT) {
+        fprintf(stderr, "smoke_features: FAIL %s: expected INVALID_ARGUMENT, got %d (%s)\n",
+                what, (int)status, vokra_last_error());
+        return 1;
+    }
+    return 0;
+}
+
+static int run_moshi_leg(const char *model) {
+    vokra_session_t *session = NULL;
+    vokra_status_t status = vokra_session_create_from_file(model, &session);
+    if (status != VOKRA_OK || session == NULL) {
+        fprintf(stderr, "smoke_features: FAIL create Moshi session (%d): %s\n", (int)status,
+                vokra_last_error());
+        return 1;
+    }
+
+    vokra_feat_t *feat = vokra_feat_open(session);
+    if (feat == NULL) {
+        fprintf(stderr, "smoke_features: FAIL feat_open: %s\n", vokra_last_error());
+        vokra_session_destroy(session);
+        return 1;
+    }
+
+    const int32_t rate_mhz = vokra_feat_frame_rate_mhz(feat);
+    const int32_t dim = vokra_feat_dim(feat);
+    if (rate_mhz != 25000 || dim <= 0) {
+        fprintf(stderr, "smoke_features: FAIL geometry: rate_mhz=%d dim=%d (%s)\n",
+                (int)rate_mhz, (int)dim, vokra_last_error());
+        vokra_feat_destroy(feat);
+        vokra_session_destroy(session);
+        return 1;
+    }
+
+    /* Released Moshi/Mimi uses a 1,920-sample token frame at 24 kHz. One
+       token frame emits two continuous 25 Hz feature rows. */
+    float pcm[1920] = {0};
+    if ((size_t)dim > SIZE_MAX / 2 / sizeof(float)) {
+        fprintf(stderr, "smoke_features: FAIL feature dimension overflows allocation\n");
+        vokra_feat_destroy(feat);
+        vokra_session_destroy(session);
+        return 1;
+    }
+    const size_t out_cap = (size_t)dim * 2;
+    float *out = (float *)malloc(out_cap * sizeof(float));
+    if (out == NULL) {
+        fprintf(stderr, "smoke_features: FAIL out of memory\n");
+        vokra_feat_destroy(feat);
+        vokra_session_destroy(session);
+        return 1;
+    }
+
+    size_t frames = SIZE_MAX;
+    int64_t start_sample = -2;
+    status = vokra_feat_push_pcm(feat, pcm, sizeof pcm / sizeof pcm[0]);
+    if (status == VOKRA_OK) {
+        status = vokra_feat_pull(feat, out, out_cap, &frames, &start_sample);
+    }
+    if (status != VOKRA_OK || frames != 2 || start_sample != 0) {
+        fprintf(stderr,
+                "smoke_features: FAIL first push/pull: status=%d frames=%zu start=%lld (%s)\n",
+                (int)status, frames, (long long)start_sample, vokra_last_error());
+        free(out);
+        vokra_feat_destroy(feat);
+        vokra_session_destroy(session);
+        return 1;
+    }
+
+    vokra_feat_reset(feat);
+    frames = SIZE_MAX;
+    start_sample = -2;
+    status = vokra_feat_push_pcm(feat, pcm, sizeof pcm / sizeof pcm[0]);
+    if (status == VOKRA_OK) {
+        status = vokra_feat_pull(feat, out, out_cap, &frames, &start_sample);
+    }
+    if (status != VOKRA_OK || frames != 2 || start_sample != 0) {
+        fprintf(stderr,
+                "smoke_features: FAIL reset timestamp: status=%d frames=%zu start=%lld (%s)\n",
+                (int)status, frames, (long long)start_sample, vokra_last_error());
+        free(out);
+        vokra_feat_destroy(feat);
+        vokra_session_destroy(session);
+        return 1;
+    }
+
+    printf("smoke_features: Moshi leg PASS (%d mHz, dim %d)\n", (int)rate_mhz, (int)dim);
+    free(out);
+    vokra_feat_destroy(feat);
+    vokra_session_destroy(session);
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    const char *non_feature_model = argc > 1 ? argv[1] : DEFAULT_MODEL;
+    int rc = 0;
+
+    size_t frames = 77;
+    int64_t start_sample = 88;
+    float one = 0.0f;
+    if (vokra_feat_open(NULL) != NULL || vokra_feat_frame_rate_mhz(NULL) != -1 ||
+        vokra_feat_dim(NULL) != -1) {
+        fprintf(stderr, "smoke_features: FAIL NULL metadata/open contract\n");
+        rc = 1;
+    }
+    rc |= expect_invalid(vokra_feat_push_pcm(NULL, &one, 1), "push NULL handle");
+    rc |= expect_invalid(vokra_feat_pull(NULL, &one, 1, &frames, &start_sample),
+                         "pull NULL handle");
+    if (frames != 77 || start_sample != 88) {
+        fprintf(stderr, "smoke_features: FAIL rejected pull modified scalar outputs\n");
+        rc = 1;
+    }
+    vokra_feat_reset(NULL);
+    vokra_feat_destroy(NULL);
+
+    vokra_session_t *session = NULL;
+    vokra_status_t status = vokra_session_create_from_file(non_feature_model, &session);
+    if (status != VOKRA_OK || session == NULL) {
+        fprintf(stderr, "smoke_features: FAIL create non-feature session (%d): %s\n",
+                (int)status, vokra_last_error());
+        return 1;
+    }
+    vokra_feat_t *feat = vokra_feat_open(session);
+    if (feat != NULL || vokra_last_error() == NULL) {
+        fprintf(stderr, "smoke_features: FAIL non-feature model did not fail closed\n");
+        vokra_feat_destroy(feat);
+        vokra_session_destroy(session);
+        return 1;
+    }
+    vokra_session_destroy(session);
+
+    const char *moshi = getenv("VOKRA_MOSHI_GGUF");
+    if (moshi == NULL || moshi[0] == '\0') {
+        printf("smoke_features: Moshi leg SKIP (set VOKRA_MOSHI_GGUF to run)\n");
+    } else if (run_moshi_leg(moshi) != 0) {
+        return 1;
+    }
+
+    if (rc != 0) {
+        return 1;
+    }
+    printf("smoke_features: PASS\n");
+    return 0;
+}


### PR DESCRIPTION
## What this changes

Streaming speech-feature extraction を core engine、Moshi/Mimi native implementation、C ABI、C smoke、Python binding まで一貫して公開します。feature dimension/rate query、sample timestamp、reset、caller-owned output、steady-state zero-allocation を含みます。

Closes #49

## How it was verified

VAST instance 48324876 (commit b850fbed1f14):

```
cargo test --workspace --no-fail-fast  # all tests and doctests passed
```

After the comment-only clippy fix (commit bc1927ba89fe):

```
cargo test -p vokra-capi --lib feature::tests::  # 4 passed
cargo clippy --workspace --all-targets -- -D warnings
```

Local gates also passed: formatting, zero-deps, forbidden-symbols, hotpath-allocation, C-API thread-free, ABI changelog.

## Checklist

- [x] Workspace formatting and clippy pass
- [x] `cargo test --workspace --no-fail-fast` passes
- [x] Zero external dependencies
- [x] No silent fallback
- [x] No parity tolerance was changed
- [x] N/A: no new model weight or publication
- [x] No prohibited runtime dependency/backend/library added
- [x] Every changed unsafe block carries a SAFETY comment; C API remains in the existing opt-out crate

## Anything reviewers should look at closely

Frame rate is derived from native engine metadata rather than hard-coded fixture geometry.
