### PR TITLE
feat(convert): add NanoCodec decoder conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,19 @@ milestone below.
 
 ### Added
 
+#### NVIDIA NanoCodec decoder conversion (2026-08-22)
+
+- Added the pinned `.nemo` preparation sidecar and the dependency-free
+  `vokra-cli convert --model nanocodec` path. The converter derives the full
+  decoder topology from the restored checkpoint, accepts decoder tensors only,
+  folds weight normalization, expands grouped transposed convolutions, and
+  stamps immutable provenance plus the NVIDIA Open Model License attribution.
+- Audited the three NVIDIA-published 22.05 kHz profiles independently. The
+  unavailable issue-listed 0.8 kbps alias has no invented revision or fixture
+  and remains fail-closed. The 1.89 kbps checkpoint's declared 1024-sample
+  frame hop matches the `[8,8,4,2,2]` generator product; sidecar and converter
+  validate both independently.
+
 #### Audio-wide coverage expansion (2026-07-24 → 2026-08-16)
 
 Vokra's scope widened from speech to audio: music generation, source

--- a/crates/vokra-cli/src/convert.rs
+++ b/crates/vokra-cli/src/convert.rs
@@ -17,10 +17,10 @@ use vokra_convert::{
     convert_cosyvoice3_file, convert_crepe_file, convert_dac_file, convert_deberta_v2_file,
     convert_deberta_v3_file, convert_file, convert_file_quantized, convert_file_with_policy,
     convert_file_with_slug, convert_irodori_file, convert_kokoro_file,
-    convert_llama_omni2_file_with_config, convert_openwakeword_op_file_with_config,
-    convert_piper_plus_file, convert_qwen3_tts_file, convert_sbv2_file, convert_silero_file,
-    convert_styletts2_file, convert_vibevoice_file, convert_vits_ja_file,
-    convert_voxcpm2_file_with_tokenizer, convert_voxtral_file_quantized,
+    convert_llama_omni2_file_with_config, convert_nanocodec_file,
+    convert_openwakeword_op_file_with_config, convert_piper_plus_file, convert_qwen3_tts_file,
+    convert_sbv2_file, convert_silero_file, convert_styletts2_file, convert_vibevoice_file,
+    convert_vits_ja_file, convert_voxcpm2_file_with_tokenizer, convert_voxtral_file_quantized,
     convert_voxtral_file_streaming, convert_voxtral_file_streaming_with_adapter_config,
     convert_voxtral_file_with_adapter_config_quantized, parse_voxtral_hf_config,
 };
@@ -44,6 +44,7 @@ USAGE:
     vokra-cli convert --model vibevoice --input <model.safetensors> --output <out.gguf>
     vokra-cli convert --model irodori --input <model.safetensors> --output <out.gguf>
     vokra-cli convert --model dac --input <prepared.safetensors> --config <config.json> --output <out.gguf>
+    vokra-cli convert --model nanocodec --input <prepared.safetensors> --config <config.json> --output <out.gguf>
     vokra-cli convert --model voxtral --input <ckpt.safetensors | model.safetensors.index.json> \
                       [--config <config.json>] [--adapter-config <adapter.json>] \
                       [--tokenizer <tekken-vocab.bin>] --output <out.gguf>
@@ -74,7 +75,7 @@ USAGE:
 
 OPTIONS:
     --model <kind>            whisper (alias: whisper-base) | silero-vad | piper-plus |
-                              campplus | kokoro | cosyvoice2 | cosyvoice3 | voxtral | mimi | dac |
+                              campplus | kokoro | cosyvoice2 | cosyvoice3 | voxtral | mimi | nanocodec | dac |
                               csm | moshi | denoise | dia | zonos | kyutai-stt |
                               parakeet-tdt | parakeet-ctc | canary | canary-qwen | omniasr-ctc |
                               distil-whisper | kotoba-whisper |
@@ -499,7 +500,7 @@ fn parse_args(args: &[String]) -> Result<Parsed, String> {
                     format!(
                         "unknown model `{v}` \
                          (whisper [alias: whisper-base] | silero-vad | piper-plus | \
-                         campplus | kokoro | cosyvoice2 | cosyvoice3 | voxtral | mimi | dac | \
+                         campplus | kokoro | cosyvoice2 | cosyvoice3 | voxtral | mimi | nanocodec | dac | \
                          csm | moshi | denoise | dia | zonos | kyutai-stt | \
                          parakeet-tdt | parakeet-ctc | canary | canary-qwen | omniasr-ctc | \
                          distil-whisper | kotoba-whisper | \
@@ -873,6 +874,22 @@ pub(crate) fn main(args: &[String]) -> Result<ExitCode, String> {
                 None => {
                     return Err("--model dac requires --config <config.json> (from \
                                 tools/parity/dac_prepare_checkpoint.py)"
+                        .to_owned());
+                }
+            }
+        }
+        ModelKind::NanoCodec => {
+            if p.quant.is_some() {
+                return Err("--quantize is only supported for whisper".to_owned());
+            }
+            if p.policy.is_some() {
+                return Err("--policy-preset is only supported for whisper".to_owned());
+            }
+            match &p.config {
+                Some(config) => convert_nanocodec_file(&p.input, config, &p.output),
+                None => {
+                    return Err("--model nanocodec requires --config <config.json> (from \
+                         tools/parity/nanocodec/prepare_checkpoint.py)"
                         .to_owned());
                 }
             }
@@ -1768,6 +1785,7 @@ mod tests {
             ("cosyvoice3", ModelKind::CosyVoice3),
             ("voxtral", ModelKind::Voxtral),
             ("mimi", ModelKind::Mimi),
+            ("nanocodec", ModelKind::NanoCodec),
             ("dac", ModelKind::Dac),
             ("csm", ModelKind::Csm),
             ("moshi", ModelKind::Moshi),

--- a/crates/vokra-convert/src/lib.rs
+++ b/crates/vokra-convert/src/lib.rs
@@ -136,6 +136,12 @@ pub enum ModelKind {
     /// `vokra.mimi.{n_codebooks,codebook_size,d_model}` from the checkpoint
     /// shapes (ADR M4-04 §D-f/§D-k).
     Mimi,
+    /// NVIDIA NeMo NanoCodec 22.05 kHz decoder-only checkpoint.  The upstream
+    /// `.nemo` archive is restored by the uv-managed
+    /// `tools/parity/nanocodec/prepare_checkpoint.py` sidecar, which emits
+    /// canonical F32 decoder tensors and checkpoint-derived JSON.  Convert
+    /// with [`convert_nanocodec_file`]; the Rust path never parses pickle.
+    NanoCodec,
     /// Standalone DAC (Descript Audio Codec) checkpoint (M4-04 T11): a
     /// **prepared** safetensors (from `tools/parity/dac_prepare_checkpoint.py`
     /// — the upstream release is a `.pth`) plus a JSON config side-car.
@@ -3965,6 +3971,13 @@ impl ModelKind {
             | "fun-cosyvoice3-0_5b-2512" => Some(Self::CosyVoice3),
             "voxtral" => Some(Self::Voxtral),
             "mimi" => Some(Self::Mimi),
+            "nanocodec"
+            | "nemo-nano-codec-22khz-0.6kbps-12.5fps"
+            | "nemo-nano-codec-22khz-1.78kbps-12.5fps"
+            | "nemo-nano-codec-22khz-1.89kbps-21.5fps"
+            | "nvidia/nemo-nano-codec-22khz-0.6kbps-12.5fps"
+            | "nvidia/nemo-nano-codec-22khz-1.78kbps-12.5fps"
+            | "nvidia/nemo-nano-codec-22khz-1.89kbps-21.5fps" => Some(Self::NanoCodec),
             "dac" | "dac-24khz" | "dac-16khz" | "dac-44khz" | "dac-44_1khz"
             | "descript/dac_24khz" | "descript/dac_16khz" | "descript/dac_44khz" => {
                 Some(Self::Dac)
@@ -5873,6 +5886,7 @@ impl ModelKind {
             Self::CosyVoice3 => "cosyvoice3",
             Self::Voxtral => "voxtral",
             Self::Mimi => "mimi",
+            Self::NanoCodec => "nanocodec",
             Self::Dac => "dac",
             Self::Csm => "csm",
             Self::Moshi => "moshi",
@@ -7149,6 +7163,14 @@ pub fn convert_file_licensed(
                 },
             )];
             (builder, notes)
+        }
+        ModelKind::NanoCodec => {
+            return Err(ConvertError::Usage(
+                "nanocodec needs a --config side-car from the pinned \
+                 tools/parity/nanocodec/prepare_checkpoint.py; use \
+                 convert_nanocodec_file"
+                    .to_owned(),
+            ));
         }
         ModelKind::Dac => {
             return Err(ConvertError::Usage(
@@ -12254,6 +12276,50 @@ pub fn convert_dac_file(
     })
 }
 
+/// Convert a prepared NVIDIA NeMo NanoCodec decoder checkpoint and its
+/// checkpoint-derived JSON side-car into a Vokra GGUF.
+///
+/// The source `.nemo` archive must first pass through the pinned uv-managed
+/// `tools/parity/nanocodec/prepare_checkpoint.py` bridge.  That bridge is the
+/// only code which imports NeMo/torch or opens pickle.  This function accepts
+/// dependency-free safetensors + JSON, verifies a total decoder tensor
+/// manifest and every shape, then stamps the NVIDIA Open Model License
+/// attribution required by the checkpoint's official model card.
+pub fn convert_nanocodec_file(
+    input: &Path,
+    config: &Path,
+    output: &Path,
+) -> Result<ConvertSummary, ConvertError> {
+    let bytes = std::fs::read(input)?;
+    let config_bytes = std::fs::read(config)?;
+    let cfg = models::nanocodec::NanoCodecConfig::parse(&config_bytes)?;
+    let (builder, report) = models::nanocodec::convert(bytes, &cfg)?;
+
+    let notes = vec![format!(
+        "nanocodec: {} decoder tensors written from {}@{}; {} codebook groups, embed_dim {}, sample_rate {}, frame_hop {} matches generator stride product",
+        report.written,
+        cfg.source_model_id,
+        cfg.source_revision,
+        cfg.n_codebooks,
+        cfg.embed_dim,
+        cfg.sample_rate,
+        cfg.frame_hop,
+    )];
+
+    let tensor_count = builder.tensor_count();
+    let metadata_count = builder.metadata_count();
+    let out_bytes = builder.to_bytes()?;
+    std::fs::write(output, &out_bytes)?;
+
+    Ok(ConvertSummary {
+        model: ModelKind::NanoCodec,
+        tensor_count,
+        metadata_count,
+        output_bytes: out_bytes.len() as u64,
+        notes,
+    })
+}
+
 /// Convert a prepared SaruLab UTMOS22-strong checkpoint into a Vokra GGUF
 /// (M5-15 T14).
 ///
@@ -14771,6 +14837,7 @@ mod modelkind_alias_and_roundtrip_tests {
             CosyVoice3,
             Voxtral,
             Mimi,
+            NanoCodec,
             Dac,
             Csm,
             Moshi,
@@ -15179,6 +15246,18 @@ mod modelkind_alias_and_roundtrip_tests {
             ),
             // Phase 1-4 / 1-5 aliases still present
             (ModelKind::Dia, &["dia", "dia-1.6b", "dia-1_6b"]),
+            (
+                ModelKind::NanoCodec,
+                &[
+                    "nanocodec",
+                    "nemo-nano-codec-22khz-0.6kbps-12.5fps",
+                    "nemo-nano-codec-22khz-1.78kbps-12.5fps",
+                    "nemo-nano-codec-22khz-1.89kbps-21.5fps",
+                    "nvidia/nemo-nano-codec-22khz-0.6kbps-12.5fps",
+                    "nvidia/nemo-nano-codec-22khz-1.78kbps-12.5fps",
+                    "nvidia/nemo-nano-codec-22khz-1.89kbps-21.5fps",
+                ],
+            ),
             (
                 ModelKind::Zonos,
                 &[
@@ -16033,6 +16112,9 @@ mod modelkind_alias_and_roundtrip_tests {
             "voxcpm3",                  // future major bump not aliased today
             "vits-en",                  // vits-* only covers the JA arm here
             "whisper-base.en",          // registry-only alias, not CLI arg
+            // Named by issue #47, but no NVIDIA repository existed in the
+            // 2026-08-22 audit. Do not pre-authorize provenance or licensing.
+            "nemo-nano-codec-22khz-0.8kbps-12.5fps",
             // SBV2 v2 plan Task 8 (2026-07-27) regression pin: the
             // nonexistent copy-paste alias that used to silently resolve
             // to Some(DebertaV3). MUST return None so a future re-add of

--- a/crates/vokra-convert/src/main.rs
+++ b/crates/vokra-convert/src/main.rs
@@ -1,7 +1,7 @@
 //! `vokra-convert` command-line entry point (M0-03, FR-TL-01).
 //!
 //! ```text
-//! vokra-convert --model <whisper|silero-vad|piper-plus|campplus|kokoro|cosyvoice2|voxtral|mimi|dac|csm|moshi|denoise|dia|zonos|kyutai-stt>
+//! vokra-convert --model <whisper|silero-vad|piper-plus|campplus|kokoro|cosyvoice2|voxtral|mimi|nanocodec|dac|csm|moshi|denoise|dia|zonos|kyutai-stt>
 //!               --input <ckpt> [--config <side-car>] --output <out.gguf>
 //! ```
 //!
@@ -20,8 +20,8 @@ use std::process::ExitCode;
 use vokra_convert::{
     ConvertError, ConvertSummary, ModelKind, convert_beat_this_with_config,
     convert_cosyvoice2_file, convert_cosyvoice3_file, convert_csm_file, convert_dac_file,
-    convert_file_licensed, convert_file_quantized, convert_moshi_file, convert_piper_plus_file,
-    convert_sbv2_file, convert_utmos_file,
+    convert_file_licensed, convert_file_quantized, convert_moshi_file, convert_nanocodec_file,
+    convert_piper_plus_file, convert_sbv2_file, convert_utmos_file,
 };
 use vokra_core::gguf::{FrontendSpec, GgmlType};
 
@@ -32,6 +32,7 @@ USAGE:
     vokra-convert --model <whisper|silero-vad|fsmn-vad|campplus|kokoro|voxtral|mimi|denoise|dia|zonos|kyutai-stt|parakeet-tdt|parakeet-ctc|canary|canary-qwen|omniasr-ctc|distil-whisper|kotoba-whisper|vits-ja|styletts2> --input <checkpoint> --output <out.gguf>
     vokra-convert --model piper-plus --input <voice.onnx> --config <config.json> --output <out.gguf>
     vokra-convert --model dac --input <prepared.safetensors> --config <config.json> --output <out.gguf>
+    vokra-convert --model nanocodec --input <prepared.safetensors> --config <config.json> --output <out.gguf>
     vokra-convert --model utmos --input <prepared.safetensors> --config <config.json> --output <out.gguf>
     vokra-convert --model <cosyvoice2|csm|moshi> --input <ckpt.safetensors> [--config <side-car>] --output <out.gguf>
 
@@ -46,7 +47,9 @@ OPTIONS:
                        LLM safetensors), voxtral (Mistral Voxtral safetensors;
                        shape-only here — the config-aware / adapter path is
                        `vokra-cli convert`), mimi (Kyutai Mimi codec
-                       safetensors), dac (prepared DAC safetensors +
+                       safetensors), nanocodec (prepared NVIDIA NeMo
+                       NanoCodec decoder safetensors + checkpoint-derived
+                       config.json), dac (prepared DAC safetensors +
                        config.json), csm (Sesame CSM-1B safetensors),
                        moshi (Kyutai Moshi safetensors), dia (nari-labs
                        Dia-1.6B safetensors — SoTA plan Phase 1-4),
@@ -205,6 +208,22 @@ fn main() -> ExitCode {
                     eprintln!(
                         "error: --model dac requires --config <config.json> (from \
                          tools/parity/dac_prepare_checkpoint.py)\n\n{USAGE}"
+                    );
+                    return ExitCode::from(2);
+                }
+            }
+        }
+        ModelKind::NanoCodec => {
+            if quant.is_some() {
+                eprintln!("error: --quantize is only supported for whisper\n\n{USAGE}");
+                return ExitCode::from(2);
+            }
+            match &config {
+                Some(config) => convert_nanocodec_file(&input, config, &output),
+                None => {
+                    eprintln!(
+                        "error: --model nanocodec requires --config <config.json> (from \
+                         tools/parity/nanocodec/prepare_checkpoint.py)\n\n{USAGE}"
                     );
                     return ExitCode::from(2);
                 }
@@ -684,6 +703,31 @@ fn verify(model: ModelKind, output: &PathBuf) -> Result<(), ExitCode> {
                 .and_then(|v| v.as_u64())
                 .unwrap_or(0);
             println!("; arch={arch} n_codebooks={n_cb} codebook_size={cb_size} d_model={d_model}");
+        }
+        ModelKind::NanoCodec => {
+            let arch = file
+                .get("vokra.model.arch")
+                .and_then(|v| v.as_str())
+                .unwrap_or("<none>");
+            let n_cb = file
+                .get("vokra.nanocodec.n_codebooks")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let embed_dim = file
+                .get("vokra.nanocodec.embed_dim")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let sr = file
+                .get("vokra.nanocodec.sample_rate")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let hop = file
+                .get("vokra.nanocodec.frame_hop")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            println!(
+                "; arch={arch} n_codebooks={n_cb} embed_dim={embed_dim} sample_rate={sr} frame_hop={hop}"
+            );
         }
         ModelKind::Csm => {
             let arch = file
@@ -3306,6 +3350,7 @@ mod tests {
             ("cosyvoice2", ModelKind::CosyVoice2),
             ("voxtral", ModelKind::Voxtral),
             ("mimi", ModelKind::Mimi),
+            ("nanocodec", ModelKind::NanoCodec),
             ("dac", ModelKind::Dac),
             ("csm", ModelKind::Csm),
             ("moshi", ModelKind::Moshi),

--- a/crates/vokra-convert/src/models/mod.rs
+++ b/crates/vokra-convert/src/models/mod.rs
@@ -104,6 +104,12 @@ pub(crate) mod crepe;
 pub(crate) mod cosyvoice3;
 pub(crate) mod csm;
 pub(crate) mod dac;
+// NVIDIA NeMo NanoCodec 22.05 kHz decoder-only conversion.  The upstream
+// `.nemo` tar contains a torch-pickle checkpoint, so an uv-managed Python
+// sidecar first emits canonical F32 decoder tensors plus checkpoint-derived
+// JSON.  Rust consumes only safetensors + JSON; pickle/NeMo never enters the
+// zero-dependency runtime or converter dependency graph.
+pub(crate) mod nanocodec;
 // SBV2 v2 plan Task 11 (2026-07-26): DeBERTa v2 (`ku-nlp/deberta-v2-large-
 // japanese-char-wwm`, cc-by-sa-4.0) and v3 (`microsoft/deberta-v3-large`,
 // mit) safetensors → GGUF, category `bert`. BF16 pass-through mirror of

--- a/crates/vokra-convert/src/models/nanocodec.rs
+++ b/crates/vokra-convert/src/models/nanocodec.rs
@@ -1,0 +1,948 @@
+//! NVIDIA NeMo NanoCodec 22.05 kHz decoder-only checkpoint conversion.
+//!
+//! The source `.nemo` archive contains a torch-pickle checkpoint.  The
+//! uv-managed `tools/parity/nanocodec/prepare_checkpoint.py` sidecar restores
+//! that archive through the pinned official NeMo implementation and emits a
+//! canonical F32 safetensors file plus checkpoint-derived JSON.  This module
+//! consumes only those dependency-free interchange formats.
+
+use std::collections::HashSet;
+
+use vokra_core::LicenseClass;
+use vokra_core::gguf::{
+    GgmlType, GgufArray, GgufBuilder, GgufMetadataValue, GgufValueType, chunks,
+};
+
+use crate::ConvertError;
+use crate::json::{self, JsonValue};
+use crate::safetensors::SafetensorsFile;
+
+pub(crate) const ARCH: &str = "nanocodec";
+const NAME: &str = "NVIDIA NeMo NanoCodec 22.05 kHz";
+const FORMAT_VERSION: u64 = 1;
+const NVIDIA_OML: &str = "nvidia-open-model-license";
+const NVIDIA_NOTICE: &str = "Licensed by NVIDIA Corporation under the NVIDIA Open Model License";
+const PROFILE_06: &str = "nvidia/nemo-nano-codec-22khz-0.6kbps-12.5fps";
+const PROFILE_178: &str = "nvidia/nemo-nano-codec-22khz-1.78kbps-12.5fps";
+const PROFILE_189: &str = "nvidia/nemo-nano-codec-22khz-1.89kbps-21.5fps";
+const REVISION_06: &str = "5c8e22ed763c14d81337fbe6ca74062f3d10f7e5";
+const REVISION_178: &str = "c4ab84a92c8d36a8b5a79eaea807cfaf7f03ed86";
+const REVISION_189: &str = "fc00890b604aa2de298d2641ffc6c5f6caf8c4d7";
+const NEMO_SPEECH_COMMIT: &str = "4fcff72febec9395fdbd4bfa0747bfda2ecd3cef";
+const NEMO_SOURCE_URL: &str = "https://github.com/NVIDIA-NeMo/Speech.git";
+
+fn audited_revision(model_id: &str) -> Option<&'static str> {
+    match model_id {
+        PROFILE_06 => Some(REVISION_06),
+        PROFILE_178 => Some(REVISION_178),
+        PROFILE_189 => Some(REVISION_189),
+        #[cfg(test)]
+        "nvidia/nemo-nano-codec-22khz-test-fixture" => Some(REVISION_06),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NanoCodecConfig {
+    pub(crate) source_model_id: String,
+    pub(crate) source_revision: String,
+    pub(crate) checkpoint_sha256: String,
+    pub(crate) nemo_speech_commit: String,
+    pub(crate) nemo_source_url: String,
+    pub(crate) sample_rate: u32,
+    pub(crate) frame_hop: u32,
+    pub(crate) generator_hop: u32,
+    pub(crate) n_codebooks: usize,
+    pub(crate) levels_per_group: Vec<u32>,
+    pub(crate) embed_dim: usize,
+    pub(crate) base_channels: usize,
+    pub(crate) upsample_rates: Vec<u32>,
+    pub(crate) input_kernel_size: usize,
+    pub(crate) output_kernel_size: usize,
+    pub(crate) resblock_kernel_sizes: Vec<u32>,
+    pub(crate) resblock_dilations: Vec<u32>,
+}
+
+impl NanoCodecConfig {
+    pub(crate) fn parse(bytes: &[u8]) -> Result<Self, ConvertError> {
+        let root = json::parse(bytes).map_err(|e| ConvertError::Parse(e.to_string()))?;
+        let req_u64 = |key: &str| -> Result<u64, ConvertError> {
+            root.get(key).and_then(JsonValue::as_u64).ok_or_else(|| {
+                parse_error(format!(
+                    "required non-negative integer field `{key}` missing"
+                ))
+            })
+        };
+        let req_usize = |key: &str| -> Result<usize, ConvertError> {
+            usize::try_from(req_u64(key)?).map_err(|_| {
+                parse_error(format!("field `{key}` does not fit this platform's usize"))
+            })
+        };
+        let req_u32 = |key: &str| -> Result<u32, ConvertError> {
+            u32::try_from(req_u64(key)?)
+                .map_err(|_| parse_error(format!("field `{key}` exceeds u32")))
+        };
+        let req_string = |key: &str| -> Result<String, ConvertError> {
+            let value = root
+                .get(key)
+                .and_then(JsonValue::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| parse_error(format!("required non-empty string `{key}` missing")))?;
+            Ok(value.to_owned())
+        };
+        let req_u32_array = |key: &str| -> Result<Vec<u32>, ConvertError> {
+            let values = root
+                .get(key)
+                .and_then(JsonValue::as_array)
+                .filter(|values| !values.is_empty())
+                .ok_or_else(|| {
+                    parse_error(format!("required non-empty integer array `{key}` missing"))
+                })?;
+            values
+                .iter()
+                .enumerate()
+                .map(|(index, value)| {
+                    let value = value.as_u64().ok_or_else(|| {
+                        parse_error(format!("`{key}[{index}]` must be a non-negative integer"))
+                    })?;
+                    let value = u32::try_from(value)
+                        .map_err(|_| parse_error(format!("`{key}[{index}]` exceeds u32")))?;
+                    if value == 0 {
+                        return Err(parse_error(format!("`{key}[{index}]` must be > 0")));
+                    }
+                    Ok(value)
+                })
+                .collect()
+        };
+        let req_bool = |key: &str| -> Result<bool, ConvertError> {
+            match root.get(key) {
+                Some(JsonValue::Bool(value)) => Ok(*value),
+                _ => Err(parse_error(format!(
+                    "required boolean field `{key}` missing"
+                ))),
+            }
+        };
+
+        let version = req_u64("format_version")?;
+        if version != FORMAT_VERSION {
+            return Err(parse_error(format!(
+                "unsupported format_version {version}; expected {FORMAT_VERSION}"
+            )));
+        }
+        let source_model_id = req_string("source_model_id")?;
+        let expected_revision = audited_revision(&source_model_id).ok_or_else(|| {
+            parse_error(format!(
+                "source_model_id `{source_model_id}` is not one of the three audited NVIDIA 22 kHz NanoCodec repositories"
+            ))
+        })?;
+        let source_revision = req_string("source_revision")?;
+        if !is_lower_hex(&source_revision, 40) {
+            return Err(parse_error(
+                "source_revision must be a full 40-character lowercase hexadecimal commit"
+                    .to_owned(),
+            ));
+        }
+        if source_revision != expected_revision {
+            return Err(parse_error(format!(
+                "source_revision `{source_revision}` does not match audited revision `{expected_revision}` for `{source_model_id}`"
+            )));
+        }
+        let checkpoint_sha256 = req_string("checkpoint_sha256")?;
+        if !is_lower_hex(&checkpoint_sha256, 64) {
+            return Err(parse_error(
+                "checkpoint_sha256 must be 64 lowercase hexadecimal characters".to_owned(),
+            ));
+        }
+        let nemo_speech_commit = req_string("nemo_speech_commit")?;
+        if nemo_speech_commit != NEMO_SPEECH_COMMIT {
+            return Err(parse_error(format!(
+                "nemo_speech_commit `{nemo_speech_commit}` does not match pinned `{NEMO_SPEECH_COMMIT}`"
+            )));
+        }
+        let nemo_source_url = req_string("nemo_source_url")?;
+        if nemo_source_url != NEMO_SOURCE_URL {
+            return Err(parse_error(format!(
+                "nemo_source_url `{nemo_source_url}` is not the official pinned source `{NEMO_SOURCE_URL}`"
+            )));
+        }
+        require_string(&root, "target_class", "CausalHiFiGANDecoder")?;
+        require_string(&root, "activation", "HalfSnake")?;
+        require_string(&root, "output_activation", "ClampActivation")?;
+        require_string(&root, "pad_mode", "zeros")?;
+        if !req_bool("grouped_upsample")? {
+            return Err(parse_error(
+                "grouped_upsample must be true for the checked NanoCodec transform".to_owned(),
+            ));
+        }
+
+        let config = Self {
+            source_model_id,
+            source_revision,
+            checkpoint_sha256,
+            nemo_speech_commit,
+            nemo_source_url,
+            sample_rate: req_u32("sample_rate")?,
+            frame_hop: req_u32("frame_hop")?,
+            generator_hop: req_u32("generator_hop")?,
+            n_codebooks: req_usize("n_codebooks")?,
+            levels_per_group: req_u32_array("levels_per_group")?,
+            embed_dim: req_usize("embed_dim")?,
+            base_channels: req_usize("base_channels")?,
+            upsample_rates: req_u32_array("upsample_rates")?,
+            input_kernel_size: req_usize("input_kernel_size")?,
+            output_kernel_size: req_usize("output_kernel_size")?,
+            resblock_kernel_sizes: req_u32_array("resblock_kernel_sizes")?,
+            resblock_dilations: req_u32_array("resblock_dilations")?,
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    fn validate(&self) -> Result<(), ConvertError> {
+        if self.sample_rate == 0
+            || self.frame_hop == 0
+            || self.generator_hop == 0
+            || self.n_codebooks == 0
+            || self.embed_dim == 0
+            || self.base_channels == 0
+            || self.input_kernel_size == 0
+            || self.output_kernel_size == 0
+        {
+            return Err(parse_error(
+                "sample rate, frame hop, dimensions, and kernels must be > 0".to_owned(),
+            ));
+        }
+        if self.levels_per_group.iter().any(|&level| level < 2) {
+            return Err(parse_error(
+                "levels_per_group entries must each be >= 2".to_owned(),
+            ));
+        }
+        let expected_embed = self
+            .n_codebooks
+            .checked_mul(self.levels_per_group.len())
+            .ok_or_else(|| parse_error("embed_dim product overflow".to_owned()))?;
+        if self.embed_dim != expected_embed {
+            return Err(parse_error(format!(
+                "embed_dim {} != n_codebooks {} * levels_per_group length {}",
+                self.embed_dim,
+                self.n_codebooks,
+                self.levels_per_group.len()
+            )));
+        }
+        for (field, value) in [
+            ("n_codebooks", self.n_codebooks),
+            ("embed_dim", self.embed_dim),
+            ("base_channels", self.base_channels),
+            ("input_kernel_size", self.input_kernel_size),
+            ("output_kernel_size", self.output_kernel_size),
+        ] {
+            if u32::try_from(value).is_err() {
+                return Err(parse_error(format!("field `{field}` exceeds u32")));
+            }
+        }
+        let mut channels = self.base_channels;
+        let mut computed_generator_hop = 1_u32;
+        for (stage, &rate) in self.upsample_rates.iter().enumerate() {
+            if channels < 2 || channels % 2 != 0 {
+                return Err(parse_error(format!(
+                    "stage {stage} input channels {channels} cannot be halved"
+                )));
+            }
+            let _ = usize::try_from(rate)
+                .ok()
+                .and_then(|rate| rate.checked_mul(2))
+                .ok_or_else(|| parse_error(format!("stage {stage} upsample kernel overflow")))?;
+            computed_generator_hop = computed_generator_hop
+                .checked_mul(rate)
+                .ok_or_else(|| parse_error("upsample-rate product exceeds u32".to_owned()))?;
+            channels /= 2;
+        }
+        if self.generator_hop != computed_generator_hop {
+            return Err(parse_error(format!(
+                "generator_hop {} != upsample-rate product {}",
+                self.generator_hop, computed_generator_hop
+            )));
+        }
+        if channels == 0 {
+            return Err(parse_error(
+                "post-activation channel count must be > 0".to_owned(),
+            ));
+        }
+        self.validate_audited_profile()?;
+        Ok(())
+    }
+
+    fn validate_audited_profile(&self) -> Result<(), ConvertError> {
+        #[cfg(test)]
+        if self.source_model_id == "nvidia/nemo-nano-codec-22khz-test-fixture" {
+            return Ok(());
+        }
+
+        let (n_codebooks, levels, embed_dim, frame_hop, upsample_rates) =
+            match self.source_model_id.as_str() {
+                PROFILE_06 => (4, &[9, 8, 8, 7][..], 16, 1764, &[7, 7, 6, 3, 2][..]),
+                PROFILE_178 => (13, &[8, 7, 6, 6][..], 52, 1764, &[7, 7, 6, 3, 2][..]),
+                PROFILE_189 => (8, &[8, 7, 6, 6][..], 32, 1024, &[8, 8, 4, 2, 2][..]),
+                _ => {
+                    return Err(parse_error(format!(
+                        "source_model_id `{}` is not an audited profile",
+                        self.source_model_id
+                    )));
+                }
+            };
+        if self.sample_rate != 22_050
+            || self.base_channels != 864
+            || self.n_codebooks != n_codebooks
+            || self.levels_per_group != levels
+            || self.embed_dim != embed_dim
+            || self.frame_hop != frame_hop
+            || self.upsample_rates != upsample_rates
+        {
+            return Err(parse_error(format!(
+                "checkpoint geometry does not match audited profile `{}`: sample_rate={}, base_channels={}, n_codebooks={}, levels_per_group={:?}, embed_dim={}, frame_hop={}, upsample_rates={:?}",
+                self.source_model_id,
+                self.sample_rate,
+                self.base_channels,
+                self.n_codebooks,
+                self.levels_per_group,
+                self.embed_dim,
+                self.frame_hop,
+                self.upsample_rates
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct NanoCodecReport {
+    pub(crate) written: usize,
+}
+
+pub(crate) fn convert(
+    bytes: Vec<u8>,
+    config: &NanoCodecConfig,
+) -> Result<(GgufBuilder, NanoCodecReport), ConvertError> {
+    config.validate()?;
+    let st = SafetensorsFile::parse(bytes)?;
+    let expected = expected_tensors(config)?;
+    let expected_names = expected
+        .iter()
+        .map(|(name, _)| name.as_str())
+        .collect::<HashSet<_>>();
+
+    for tensor in st.tensors() {
+        if !expected_names.contains(tensor.name.as_str()) {
+            return Err(parse_error(format!(
+                "unexpected prepared tensor `{}`; NanoCodec conversion is decoder-only and total",
+                tensor.name
+            )));
+        }
+    }
+    for (name, shape) in &expected {
+        let tensor = st
+            .tensors()
+            .iter()
+            .find(|tensor| tensor.name == *name)
+            .ok_or_else(|| parse_error(format!("required tensor `{name}` missing")))?;
+        if tensor.dtype != GgmlType::F32 {
+            return Err(parse_error(format!(
+                "prepared tensor `{name}` must be F32, got {:?}",
+                tensor.dtype
+            )));
+        }
+        if tensor.shape != *shape {
+            return Err(parse_error(format!(
+                "prepared tensor `{name}` shape {:?} != checkpoint-derived {shape:?}",
+                tensor.shape
+            )));
+        }
+    }
+    if st.tensors().len() != expected.len() {
+        return Err(parse_error(format!(
+            "prepared tensor count {} != decoder manifest {}",
+            st.tensors().len(),
+            expected.len()
+        )));
+    }
+
+    let generator_hop = config.generator_hop;
+
+    let mut builder = GgufBuilder::new();
+    builder.add_string(chunks::KEY_MODEL_ARCH, ARCH);
+    builder.add_string(chunks::KEY_MODEL_NAME, NAME);
+    builder.add_u32("vokra.nanocodec.n_codebooks", config.n_codebooks as u32);
+    add_u32_array(
+        &mut builder,
+        "vokra.nanocodec.levels_per_group",
+        &config.levels_per_group,
+    );
+    builder.add_u32("vokra.nanocodec.embed_dim", config.embed_dim as u32);
+    builder.add_u32("vokra.nanocodec.sample_rate", config.sample_rate);
+    builder.add_u32("vokra.nanocodec.frame_hop", config.frame_hop);
+    builder.add_u32("vokra.nanocodec.generator_hop", generator_hop);
+    builder.add_u32("vokra.nanocodec.base_channels", config.base_channels as u32);
+    add_u32_array(
+        &mut builder,
+        "vokra.nanocodec.upsample_rates",
+        &config.upsample_rates,
+    );
+    builder.add_u32(
+        "vokra.nanocodec.input_kernel_size",
+        config.input_kernel_size as u32,
+    );
+    builder.add_u32(
+        "vokra.nanocodec.output_kernel_size",
+        config.output_kernel_size as u32,
+    );
+    add_u32_array(
+        &mut builder,
+        "vokra.nanocodec.resblock_kernel_sizes",
+        &config.resblock_kernel_sizes,
+    );
+    add_u32_array(
+        &mut builder,
+        "vokra.nanocodec.resblock_dilations",
+        &config.resblock_dilations,
+    );
+    builder.add_string("vokra.nanocodec.activation", "HalfSnake");
+    builder.add_string("vokra.nanocodec.output_activation", "ClampActivation");
+    builder.add_string("vokra.nanocodec.pad_mode", "zeros");
+    builder.add_bool("vokra.nanocodec.grouped_upsample_expanded", true);
+    builder.add_string(
+        "vokra.nanocodec.nemo_speech_commit",
+        &config.nemo_speech_commit,
+    );
+    builder.add_string("vokra.nanocodec.nemo_source_url", &config.nemo_source_url);
+    builder.add_string("vokra.provenance.upstream_hf", &config.source_model_id);
+    builder.add_string(
+        "vokra.provenance.upstream_revision",
+        &config.source_revision,
+    );
+    builder.add_string(
+        "vokra.provenance.checkpoint_sha256",
+        &config.checkpoint_sha256,
+    );
+    let source = format!(
+        "https://huggingface.co/{}/tree/{} (prepared from .nemo by the pinned official NeMo sidecar)",
+        config.source_model_id, config.source_revision
+    );
+    vokra_core::stamp_provenance(
+        &mut builder,
+        LicenseClass::AttributionRequired,
+        NVIDIA_OML,
+        Some(&config.source_model_id),
+        Some(&source),
+    );
+    vokra_core::stamp_attribution(&mut builder, NVIDIA_NOTICE);
+
+    for tensor in st.tensors() {
+        builder.add_tensor(
+            &tensor.name,
+            tensor.dtype,
+            tensor.shape.clone(),
+            st.tensor_bytes(tensor).to_vec(),
+        )?;
+    }
+
+    Ok((
+        builder,
+        NanoCodecReport {
+            written: st.tensors().len(),
+        },
+    ))
+}
+
+fn parse_error(message: String) -> ConvertError {
+    ConvertError::Parse(format!("nanocodec config: {message}"))
+}
+
+fn require_string(root: &JsonValue, key: &str, expected: &str) -> Result<(), ConvertError> {
+    let actual = root
+        .get(key)
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| parse_error(format!("required string field `{key}` missing")))?;
+    if actual != expected {
+        return Err(parse_error(format!(
+            "`{key}` must be `{expected}`, got `{actual}`"
+        )));
+    }
+    Ok(())
+}
+
+fn is_lower_hex(value: &str, len: usize) -> bool {
+    value.len() == len
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn add_u32_array(builder: &mut GgufBuilder, key: &str, values: &[u32]) {
+    builder.add_metadata(
+        key,
+        GgufMetadataValue::Array(GgufArray {
+            element_type: GgufValueType::U32,
+            values: values.iter().copied().map(GgufMetadataValue::U32).collect(),
+        }),
+    );
+}
+
+fn expected_tensors(config: &NanoCodecConfig) -> Result<Vec<(String, Vec<u64>)>, ConvertError> {
+    let shape = |dims: &[usize]| -> Result<Vec<u64>, ConvertError> {
+        dims.iter()
+            .map(|&dim| {
+                u64::try_from(dim)
+                    .map_err(|_| parse_error("tensor dimension does not fit u64".to_owned()))
+            })
+            .collect()
+    };
+    let mut expected = Vec::new();
+    let mut push = |name: String, dims: &[usize]| -> Result<(), ConvertError> {
+        expected.push((name, shape(dims)?));
+        Ok(())
+    };
+
+    push(
+        "nanocodec.pre_conv.weight".to_owned(),
+        &[
+            config.base_channels,
+            config.embed_dim,
+            config.input_kernel_size,
+        ],
+    )?;
+    push(
+        "nanocodec.pre_conv.bias".to_owned(),
+        &[config.base_channels],
+    )?;
+    let mut in_channels = config.base_channels;
+    for (stage, &rate) in config.upsample_rates.iter().enumerate() {
+        let rate = usize::try_from(rate)
+            .map_err(|_| parse_error(format!("stage {stage} rate does not fit usize")))?;
+        let out_channels = in_channels / 2;
+        let stage_prefix = format!("nanocodec.stage.{stage}");
+        push(
+            format!("{stage_prefix}.activation.alpha"),
+            &[in_channels / 2],
+        )?;
+        push(
+            format!("{stage_prefix}.activation.alpha_inv"),
+            &[in_channels / 2],
+        )?;
+        push(
+            format!("{stage_prefix}.upsample.weight"),
+            &[in_channels, out_channels, 2 * rate],
+        )?;
+        push(format!("{stage_prefix}.upsample.bias"), &[out_channels])?;
+        for (branch, &kernel) in config.resblock_kernel_sizes.iter().enumerate() {
+            let kernel = usize::try_from(kernel).map_err(|_| {
+                parse_error(format!(
+                    "residual branch {branch} kernel does not fit usize"
+                ))
+            })?;
+            for block in 0..config.resblock_dilations.len() {
+                let block_prefix = format!("{stage_prefix}.branch.{branch}.block.{block}");
+                for activation in ["input_activation", "skip_activation"] {
+                    push(
+                        format!("{block_prefix}.{activation}.alpha"),
+                        &[out_channels / 2],
+                    )?;
+                    push(
+                        format!("{block_prefix}.{activation}.alpha_inv"),
+                        &[out_channels / 2],
+                    )?;
+                }
+                for conv in ["input_conv", "skip_conv"] {
+                    push(
+                        format!("{block_prefix}.{conv}.weight"),
+                        &[out_channels, out_channels, kernel],
+                    )?;
+                    push(format!("{block_prefix}.{conv}.bias"), &[out_channels])?;
+                }
+            }
+        }
+        in_channels = out_channels;
+    }
+    push(
+        "nanocodec.post_activation.alpha".to_owned(),
+        &[in_channels / 2],
+    )?;
+    push(
+        "nanocodec.post_activation.alpha_inv".to_owned(),
+        &[in_channels / 2],
+    )?;
+    push(
+        "nanocodec.post_conv.weight".to_owned(),
+        &[1, in_channels, config.output_kernel_size],
+    )?;
+    push("nanocodec.post_conv.bias".to_owned(), &[1])?;
+    Ok(expected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vokra_core::gguf::{GgufFile, GgufMetadataValue};
+
+    const SHA256: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    fn config_json(
+        model_id: &str,
+        n_codebooks: usize,
+        levels: &[u32],
+        embed_dim: usize,
+        frame_hop: u32,
+        upsample_rates: &[u32],
+    ) -> Vec<u8> {
+        let generator_hop = upsample_rates.iter().product::<u32>();
+        let levels = levels
+            .iter()
+            .map(u32::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
+        let upsample_rates = upsample_rates
+            .iter()
+            .map(u32::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
+        let base_channels = if upsample_rates.matches(',').count() >= 4 {
+            864
+        } else {
+            8
+        };
+        let revision = audited_revision(model_id).unwrap_or(REVISION_06);
+        format!(
+            r#"{{
+              "format_version":1,
+              "source_model_id":"{model_id}",
+              "source_revision":"{revision}",
+              "checkpoint_sha256":"{SHA256}",
+              "nemo_speech_commit":"4fcff72febec9395fdbd4bfa0747bfda2ecd3cef",
+              "nemo_source_url":"https://github.com/NVIDIA-NeMo/Speech.git",
+              "target_class":"CausalHiFiGANDecoder",
+              "sample_rate":22050,
+              "frame_hop":{frame_hop},
+              "generator_hop":{generator_hop},
+              "n_codebooks":{n_codebooks},
+              "levels_per_group":[{levels}],
+              "embed_dim":{embed_dim},
+              "base_channels":{base_channels},
+              "upsample_rates":[{upsample_rates}],
+              "input_kernel_size":3,
+              "output_kernel_size":3,
+              "resblock_kernel_sizes":[3,5],
+              "resblock_dilations":[1,2],
+              "activation":"HalfSnake",
+              "output_activation":"ClampActivation",
+              "pad_mode":"zeros",
+              "grouped_upsample":true
+            }}"#
+        )
+        .into_bytes()
+    }
+
+    fn tiny_config() -> NanoCodecConfig {
+        NanoCodecConfig::parse(&config_json(
+            "nvidia/nemo-nano-codec-22khz-test-fixture",
+            2,
+            &[3, 2],
+            4,
+            4,
+            &[2, 2],
+        ))
+        .expect("tiny config")
+    }
+
+    fn build_safetensors(entries: &[(String, Vec<usize>, Vec<f32>)]) -> Vec<u8> {
+        let mut header = String::from("{");
+        let mut data = Vec::<u8>::new();
+        for (i, (name, shape, values)) in entries.iter().enumerate() {
+            let start = data.len();
+            for value in values {
+                data.extend_from_slice(&value.to_le_bytes());
+            }
+            let end = data.len();
+            if i > 0 {
+                header.push(',');
+            }
+            let shape = shape
+                .iter()
+                .map(usize::to_string)
+                .collect::<Vec<_>>()
+                .join(",");
+            header.push_str(&format!(
+                r#""{name}":{{"dtype":"F32","shape":[{shape}],"data_offsets":[{start},{end}]}}"#
+            ));
+        }
+        header.push('}');
+        let mut out = Vec::new();
+        out.extend_from_slice(&(header.len() as u64).to_le_bytes());
+        out.extend_from_slice(header.as_bytes());
+        out.extend_from_slice(&data);
+        out
+    }
+
+    fn tensor(
+        name: impl Into<String>,
+        shape: &[usize],
+        seed: &mut f32,
+    ) -> (String, Vec<usize>, Vec<f32>) {
+        let len = shape.iter().product();
+        let values = (0..len)
+            .map(|_| {
+                *seed += 0.01;
+                *seed
+            })
+            .collect();
+        (name.into(), shape.to_vec(), values)
+    }
+
+    fn synthetic_decoder(config: &NanoCodecConfig) -> Vec<u8> {
+        let mut seed = 0.0;
+        let mut entries = vec![
+            tensor(
+                "nanocodec.pre_conv.weight",
+                &[
+                    config.base_channels,
+                    config.embed_dim,
+                    config.input_kernel_size,
+                ],
+                &mut seed,
+            ),
+            tensor(
+                "nanocodec.pre_conv.bias",
+                &[config.base_channels],
+                &mut seed,
+            ),
+        ];
+        let mut in_channels = config.base_channels;
+        for (stage, &rate) in config.upsample_rates.iter().enumerate() {
+            let out_channels = in_channels / 2;
+            entries.push(tensor(
+                format!("nanocodec.stage.{stage}.activation.alpha"),
+                &[in_channels / 2],
+                &mut seed,
+            ));
+            entries.push(tensor(
+                format!("nanocodec.stage.{stage}.activation.alpha_inv"),
+                &[in_channels / 2],
+                &mut seed,
+            ));
+            entries.push(tensor(
+                format!("nanocodec.stage.{stage}.upsample.weight"),
+                &[in_channels, out_channels, 2 * rate as usize],
+                &mut seed,
+            ));
+            entries.push(tensor(
+                format!("nanocodec.stage.{stage}.upsample.bias"),
+                &[out_channels],
+                &mut seed,
+            ));
+            for (branch, &kernel) in config.resblock_kernel_sizes.iter().enumerate() {
+                for block in 0..config.resblock_dilations.len() {
+                    let prefix = format!("nanocodec.stage.{stage}.branch.{branch}.block.{block}");
+                    for activation in ["input_activation", "skip_activation"] {
+                        entries.push(tensor(
+                            format!("{prefix}.{activation}.alpha"),
+                            &[out_channels / 2],
+                            &mut seed,
+                        ));
+                        entries.push(tensor(
+                            format!("{prefix}.{activation}.alpha_inv"),
+                            &[out_channels / 2],
+                            &mut seed,
+                        ));
+                    }
+                    for conv in ["input_conv", "skip_conv"] {
+                        entries.push(tensor(
+                            format!("{prefix}.{conv}.weight"),
+                            &[out_channels, out_channels, kernel as usize],
+                            &mut seed,
+                        ));
+                        entries.push(tensor(
+                            format!("{prefix}.{conv}.bias"),
+                            &[out_channels],
+                            &mut seed,
+                        ));
+                    }
+                }
+            }
+            in_channels = out_channels;
+        }
+        entries.push(tensor(
+            "nanocodec.post_activation.alpha",
+            &[in_channels / 2],
+            &mut seed,
+        ));
+        entries.push(tensor(
+            "nanocodec.post_activation.alpha_inv",
+            &[in_channels / 2],
+            &mut seed,
+        ));
+        entries.push(tensor(
+            "nanocodec.post_conv.weight",
+            &[1, in_channels, config.output_kernel_size],
+            &mut seed,
+        ));
+        entries.push(tensor("nanocodec.post_conv.bias", &[1], &mut seed));
+        build_safetensors(&entries)
+    }
+
+    #[test]
+    fn parses_checkpoint_derived_axes_for_every_published_profile() {
+        let profiles = [
+            (
+                PROFILE_06,
+                4,
+                vec![9, 8, 8, 7],
+                16,
+                1764,
+                vec![7, 7, 6, 3, 2],
+            ),
+            (
+                PROFILE_178,
+                13,
+                vec![8, 7, 6, 6],
+                52,
+                1764,
+                vec![7, 7, 6, 3, 2],
+            ),
+            (
+                PROFILE_189,
+                8,
+                vec![8, 7, 6, 6],
+                32,
+                1024,
+                vec![8, 8, 4, 2, 2],
+            ),
+        ];
+        for (model_id, n_codebooks, levels, embed_dim, frame_hop, rates) in profiles {
+            let cfg = NanoCodecConfig::parse(&config_json(
+                model_id,
+                n_codebooks,
+                &levels,
+                embed_dim,
+                frame_hop,
+                &rates,
+            ))
+            .unwrap_or_else(|e| panic!("{model_id}: {e}"));
+            assert_eq!(cfg.n_codebooks, n_codebooks);
+            assert_eq!(cfg.levels_per_group, levels);
+            assert_eq!(cfg.embed_dim, embed_dim);
+            assert_eq!(cfg.frame_hop, frame_hop);
+            assert_eq!(cfg.upsample_rates, rates);
+        }
+    }
+
+    #[test]
+    fn config_rejects_missing_provenance_and_non_checkpoint_topology() {
+        let mut missing_sha = config_json(PROFILE_06, 2, &[3, 2], 4, 4, &[2, 2]);
+        missing_sha = String::from_utf8(missing_sha)
+            .unwrap()
+            .replace(SHA256, "")
+            .into_bytes();
+        assert!(NanoCodecConfig::parse(&missing_sha).is_err());
+
+        let wrong_class = String::from_utf8(config_json(PROFILE_06, 2, &[3, 2], 4, 4, &[2, 2]))
+            .unwrap()
+            .replace("CausalHiFiGANDecoder", "HiFiGANDecoder")
+            .into_bytes();
+        assert!(NanoCodecConfig::parse(&wrong_class).is_err());
+
+        let unpublished = config_json(
+            "nvidia/nemo-nano-codec-22khz-0.8kbps-12.5fps",
+            4,
+            &[9, 8, 8, 7],
+            16,
+            1764,
+            &[7, 7, 6, 3, 2],
+        );
+        assert!(
+            NanoCodecConfig::parse(&unpublished).is_err(),
+            "the issue-listed but unpublished 0.8 kbps repository must stay fail-closed",
+        );
+
+        let mislabeled_profile =
+            config_json(PROFILE_06, 13, &[8, 7, 6, 6], 52, 1764, &[7, 7, 6, 3, 2]);
+        let error = NanoCodecConfig::parse(&mislabeled_profile).unwrap_err();
+        assert!(error.to_string().contains("audited profile"), "{error}");
+
+        let wrong_nemo_source = String::from_utf8(config_json(
+            PROFILE_06,
+            4,
+            &[9, 8, 8, 7],
+            16,
+            1764,
+            &[7, 7, 6, 3, 2],
+        ))
+        .unwrap()
+        .replace(
+            "4fcff72febec9395fdbd4bfa0747bfda2ecd3cef",
+            "0000000000000000000000000000000000000000",
+        )
+        .into_bytes();
+        let error = NanoCodecConfig::parse(&wrong_nemo_source).unwrap_err();
+        assert!(error.to_string().contains("nemo_speech_commit"), "{error}");
+
+        let wrong_generator_hop = String::from_utf8(config_json(
+            PROFILE_189,
+            8,
+            &[8, 7, 6, 6],
+            32,
+            1024,
+            &[8, 8, 4, 2, 2],
+        ))
+        .unwrap()
+        .replace("\"generator_hop\":1024", "\"generator_hop\":2048")
+        .into_bytes();
+        let error = NanoCodecConfig::parse(&wrong_generator_hop).unwrap_err();
+        assert!(error.to_string().contains("generator_hop"), "{error}");
+    }
+
+    #[test]
+    fn conversion_is_total_and_emits_decoder_contract() {
+        let cfg = tiny_config();
+        let (builder, report) = convert(synthetic_decoder(&cfg), &cfg).expect("convert");
+        let file = GgufFile::parse(builder.to_bytes().expect("serialize")).expect("GGUF");
+        assert_eq!(report.written, file.tensors().len());
+        assert!(matches!(
+            file.get("vokra.nanocodec.n_codebooks"),
+            Some(GgufMetadataValue::U32(2))
+        ));
+        assert!(matches!(
+            file.get("vokra.nanocodec.frame_hop"),
+            Some(GgufMetadataValue::U32(4))
+        ));
+        assert!(matches!(
+            file.get("vokra.nanocodec.nemo_speech_commit"),
+            Some(GgufMetadataValue::String(value))
+                if value == "4fcff72febec9395fdbd4bfa0747bfda2ecd3cef"
+        ));
+        assert!(matches!(
+            file.get("vokra.provenance.attribution"),
+            Some(GgufMetadataValue::String(text))
+                if text == "Licensed by NVIDIA Corporation under the NVIDIA Open Model License"
+        ));
+        assert!(file.tensor_info("nanocodec.pre_conv.weight").is_some());
+        assert!(
+            file.tensor_info("nanocodec.stage.1.upsample.weight")
+                .is_some()
+        );
+        assert!(file.tensor_info("nanocodec.post_conv.weight").is_some());
+    }
+
+    #[test]
+    fn conversion_rejects_extra_or_misshapen_prepared_tensors() {
+        let cfg = tiny_config();
+        // The synthetic builder cannot append after serialization, so build a
+        // single unknown tensor to pin total-consumption failure.
+        let extra = build_safetensors(&[tensor("encoder.forbidden", &[1], &mut 0.0)]);
+        let err = convert(extra, &cfg).unwrap_err();
+        assert!(
+            err.to_string().contains("required tensor") || err.to_string().contains("unexpected")
+        );
+
+        let wrong = build_safetensors(&[tensor("nanocodec.pre_conv.weight", &[1, 1, 1], &mut 0.0)]);
+        assert!(convert(wrong, &cfg).is_err());
+    }
+}

--- a/docs/abi-changelog.md
+++ b/docs/abi-changelog.md
@@ -287,6 +287,21 @@ gate cover `process_into`.
 | `vokra-ops::resample` | `StreamingResampler::process_into` | Added | `pub fn process_into(&mut self, input: &[f32], out: &mut [f32]) -> Result<usize>` | Processes chunks without allocation and uses empty input as an explicit final flush. | no | (TBD) |
 | `vokra-ops::resample` | `StreamingResampler::reset` | Added | `pub fn reset(&mut self)` | Reuses the existing allocation for a new stream. | no | (TBD) |
 
+### 2026-08-22 — 1.0.0-rc.1-dev (NanoCodec decoder converter — additive GGUF schema)
+
+Additive on-disk GGUF metadata only. The C ABI, `vokra-core` public surface,
+and `vokra-ops` public surface are unchanged. The new converter writes the
+checkpoint-derived NanoCodec decoder contract under a dedicated prefix; it
+does not reuse or change the existing `vokra.wavtokenizer.*` or
+`vokra.xcodec2.*` FSQ schemas.
+
+| Chunk prefix | Keys | Kind | Status | Rationale | Introducing issue |
+| --- | --- | --- | --- | --- | --- |
+| `vokra.nanocodec.*` | `n_codebooks`, `embed_dim`, `sample_rate`, `frame_hop`, `generator_hop`, `base_channels`, `input_kernel_size`, `output_kernel_size`; `levels_per_group`, `upsample_rates`, `resblock_kernel_sizes`, `resblock_dilations`; `activation`, `output_activation`, `pad_mode`, `nemo_speech_commit`, `nemo_source_url`; `grouped_upsample_expanded` | `u32`; `u32-array`; `string`; `bool` | persisted | Complete checkpoint-derived decoder topology plus the verified official NeMo source identity for the pinned NanoCodec transform. `frame_hop` and `generator_hop` remain separate provenance fields, and conversion rejects disagreement; the published 1.89 kbps checkpoint records 1024 for both. | #47 (2026-08-22) |
+
+The converter also reuses the existing `vokra.provenance.*` namespace for the
+immutable source revision and checkpoint SHA-256. Those are not new prefixes.
+
 ### 2026-08-15 — 1.0.0-rc.1-dev (LLaMA-Omni2: the converter now stamps the full `vokra.llama_omni2.*` group its own binder reads, and refuses without `--config` — GGUF schema fill + Rust surface, advisory)
 
 **Behaviour change** plus additive Rust surface. The C ABI

--- a/docs/nanocodec-conversion.md
+++ b/docs/nanocodec-conversion.md
@@ -1,0 +1,72 @@
+# NanoCodec conversion contract
+
+NanoCodec conversion is intentionally split at the `.nemo` pickle boundary:
+
+1. `tools/parity/nanocodec/prepare_checkpoint.py` runs in the pinned Python
+   3.12/NeMo environment, verifies the imported distribution's PEP 610 source
+   as the official `NVIDIA-NeMo/Speech` repository at commit
+   `4fcff72febec9395fdbd4bfa0747bfda2ecd3cef`, and emits decoder-only F32
+   safetensors plus JSON.
+2. `vokra-cli convert --model nanocodec` consumes only those two
+   dependency-free files, verifies the complete tensor manifest and shapes,
+   and writes GGUF.
+
+```sh
+uv run --project tools/parity/nanocodec \
+  python tools/parity/nanocodec/prepare_checkpoint.py \
+  --checkpoint /path/to/model.nemo \
+  --model-id nvidia/nemo-nano-codec-22khz-0.6kbps-12.5fps \
+  --revision 5c8e22ed763c14d81337fbe6ca74062f3d10f7e5 \
+  --output /tmp/nanocodec.decoder.safetensors \
+  --config-output /tmp/nanocodec.decoder.json
+
+vokra-cli convert --model nanocodec \
+  --input /tmp/nanocodec.decoder.safetensors \
+  --config /tmp/nanocodec.decoder.json \
+  --output /tmp/nanocodec.gguf
+```
+
+Every public metadata field is read from the restored checkpoint: number of
+FSQ groups, levels per group, embedding width, sample rate, frame hop, decoder
+channels/kernels/dilations, and upsample rates. Weight normalization is folded
+by reading PyTorch's effective parametrized weight. Grouped transposed
+convolutions are expanded to dense `[in, out, kernel]` tensors with explicit
+zeros, matching the pinned official NeMo-Speech.cpp transform.
+
+The sidecar and Rust converter independently require the model ID/revision and
+the audited sample-rate, group/level, embedding, base-channel, frame-hop, and
+upsample-rate tuple to agree. This prevents a valid checkpoint from one profile
+being mislabeled as another. The 0.6 kbps checkpoint additionally has the
+audited file SHA-256
+`bd5883099d0c74ceda760b6b7a1600b86da4d8a02531c9c282679951dcb08870`;
+the sidecar checks it before opening the `.nemo` pickle.
+
+## Audited checkpoint inventory (2026-08-22)
+
+The official NVIDIA Hugging Face namespace exposes these three repositories:
+
+| Repository | Immutable revision | FSQ groups | FSQ levels | Embed dim | Frame hop | Upsample rates |
+|---|---|---:|---|---:|---:|---|
+| `nvidia/nemo-nano-codec-22khz-0.6kbps-12.5fps` | `5c8e22ed763c14d81337fbe6ca74062f3d10f7e5` | 4 | `[9,8,8,7]` | 16 | 1764 | `[7,7,6,3,2]` |
+| `nvidia/nemo-nano-codec-22khz-1.78kbps-12.5fps` | `c4ab84a92c8d36a8b5a79eaea807cfaf7f03ed86` | 13 | `[8,7,6,6]` | 52 | 1764 | `[7,7,6,3,2]` |
+| `nvidia/nemo-nano-codec-22khz-1.89kbps-21.5fps` | `fc00890b604aa2de298d2641ffc6c5f6caf8c4d7` | 8 | `[8,7,6,6]` | 32 | 1024 | `[8,8,4,2,2]` |
+
+Issue #47 also names
+`nvidia/nemo-nano-codec-22khz-0.8kbps-12.5fps`. That repository was not
+published in the NVIDIA namespace at audit time, and NVIDIA's NanoCodec search
+returned only the three repositories above. That id is deliberately rejected
+by both the sidecar and converter, and is absent from the license registry and
+publish sign-off map. A future official release needs its own immutable
+revision, license audit, fixture, and parity result before the exact alias can
+be added.
+
+The 1.89 kbps checkpoint declares `frame_hop = 1024`; its decoder rates
+`[8,8,4,2,2]` also multiply to 1024. The sidecar records both values and the
+Rust converter requires them to agree, so topology drift fails closed before a
+GGUF is written.
+
+All three weights use the NVIDIA Open Model License Agreement (June 14, 2024).
+The converter stamps `AttributionRequired` and the agreement's exact NOTICE
+sentence. Model publication remains blocked until the separate license audit
+owner sign-off succeeds; conversion and a green parity run do not authorize an
+upload.

--- a/scripts/publish/signoff_match.py
+++ b/scripts/publish/signoff_match.py
@@ -1158,6 +1158,9 @@ CONVERTER_TO_SIGNOFF_ROWS: dict[str, list[str]] = {
     "csm": ["Sesame CSM-1B"],
     "moshi": ["Moshi (Helium + Mimi)"],
     "mimi": ["Mimi codec (Kyutai)"],
+    # The matching §3.1 row is deliberately blank until the owner records a
+    # decision, so converter coverage remains fail-closed for publication.
+    "nanocodec": ["NVIDIA NanoCodec (NeMo, 22 kHz)"],
     "dac": ["DAC 24khz (Descript)"],
     "denoise": ["DeepFilterNet3"],
     "utmos": ["UTMOS22-strong (SaruLab)"],

--- a/tools/parity/nanocodec/README.md
+++ b/tools/parity/nanocodec/README.md
@@ -1,4 +1,4 @@
-# NanoCodec Group-FSQ parity environment
+# NanoCodec checkpoint preparation and Group-FSQ parity
 
 This isolated Python 3.12 uv project exists only to regenerate the committed
 Group-FSQ oracle fixture for issue #45. It is not part of the Rust runtime and
@@ -28,3 +28,28 @@ The checkpoint must be the file at HF repo commit
 `5c8e22ed763c14d81337fbe6ca74062f3d10f7e5`, SHA-256
 `bd5883099d0c74ceda760b6b7a1600b86da4d8a02531c9c282679951dcb08870`.
 The checkpoint remains a temporary local/VAST input and is never committed.
+
+## Checkpoint preparation
+
+This directory is the only trusted Python/pickle boundary for NVIDIA NeMo
+NanoCodec conversion. The project is locked to Python 3.12, the official
+`NVIDIA-NeMo/Speech` commit recorded in `pyproject.toml`, and the explicit PEFT
+import dependency required by that pinned NeMo TTS package.
+
+Prepare one of the three audited public checkpoints:
+
+```sh
+uv sync --project tools/parity/nanocodec --locked
+uv run --project tools/parity/nanocodec \
+  python tools/parity/nanocodec/prepare_checkpoint.py \
+  --checkpoint /path/to/model.nemo \
+  --model-id nvidia/nemo-nano-codec-22khz-0.6kbps-12.5fps \
+  --revision 5c8e22ed763c14d81337fbe6ca74062f3d10f7e5 \
+  --output /tmp/nanocodec.decoder.safetensors \
+  --config-output /tmp/nanocodec.decoder.json
+```
+
+The script verifies the installed NeMo PEP 610 source, immutable model
+revision, audited geometry, and the 0.6 kbps checkpoint SHA-256 before opening
+the `.nemo` pickle. The emitted safetensors and JSON are then consumed by the
+dependency-free Rust converter. No model is uploaded by this workflow.

--- a/tools/parity/nanocodec/prepare_checkpoint.py
+++ b/tools/parity/nanocodec/prepare_checkpoint.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""Prepare a decoder-only NVIDIA NeMo NanoCodec checkpoint for Vokra.
+
+The upstream ``.nemo`` archive contains a torch-pickle checkpoint.  This
+uv-managed, offline sidecar is the sole pickle/NeMo boundary: it restores the
+model with the pinned official NeMo package, reads topology from the restored
+objects, materializes weight normalization, expands grouped ConvTranspose1d
+weights to dense PyTorch layout, and emits:
+
+* canonical F32 decoder tensors in safetensors; and
+* JSON containing only checkpoint-derived geometry and immutable provenance.
+
+The Rust converter consumes those two files without Python, torch, pickle,
+ONNX, protobuf, or any third-party runtime dependency.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import math
+import os
+import re
+from pathlib import Path
+from typing import NoReturn
+
+import torch
+from nemo.collections.tts.models.audio_codec import AudioCodecModel
+from safetensors.torch import save_file
+
+
+NEMO_SPEECH_COMMIT = "4fcff72febec9395fdbd4bfa0747bfda2ecd3cef"
+FORMAT_VERSION = 1
+AUDITED_REVISIONS = {
+    "nvidia/nemo-nano-codec-22khz-0.6kbps-12.5fps": "5c8e22ed763c14d81337fbe6ca74062f3d10f7e5",
+    "nvidia/nemo-nano-codec-22khz-1.78kbps-12.5fps": "c4ab84a92c8d36a8b5a79eaea807cfaf7f03ed86",
+    "nvidia/nemo-nano-codec-22khz-1.89kbps-21.5fps": "fc00890b604aa2de298d2641ffc6c5f6caf8c4d7",
+}
+AUDITED_CHECKPOINT_SHA256 = {
+    "nvidia/nemo-nano-codec-22khz-0.6kbps-12.5fps": "bd5883099d0c74ceda760b6b7a1600b86da4d8a02531c9c282679951dcb08870",
+}
+AUDITED_GEOMETRY = {
+    "nvidia/nemo-nano-codec-22khz-0.6kbps-12.5fps": {
+        "sample_rate": 22_050,
+        "frame_hop": 1764,
+        "generator_hop": 1764,
+        "n_codebooks": 4,
+        "levels_per_group": [9, 8, 8, 7],
+        "embed_dim": 16,
+        "base_channels": 864,
+        "upsample_rates": [7, 7, 6, 3, 2],
+    },
+    "nvidia/nemo-nano-codec-22khz-1.78kbps-12.5fps": {
+        "sample_rate": 22_050,
+        "frame_hop": 1764,
+        "generator_hop": 1764,
+        "n_codebooks": 13,
+        "levels_per_group": [8, 7, 6, 6],
+        "embed_dim": 52,
+        "base_channels": 864,
+        "upsample_rates": [7, 7, 6, 3, 2],
+    },
+    "nvidia/nemo-nano-codec-22khz-1.89kbps-21.5fps": {
+        "sample_rate": 22_050,
+        "frame_hop": 1024,
+        "generator_hop": 1024,
+        "n_codebooks": 8,
+        "levels_per_group": [8, 7, 6, 6],
+        "embed_dim": 32,
+        "base_channels": 864,
+        "upsample_rates": [8, 8, 4, 2, 2],
+    },
+}
+FULL_REVISION = re.compile(r"[0-9a-f]{40}")
+
+
+def fail(message: str) -> NoReturn:
+    raise RuntimeError(f"nanocodec prepare: {message}")
+
+
+def checkpoint_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_nemo_source() -> str:
+    distribution = importlib.metadata.distribution("nemo_toolkit")
+    direct_url_text = distribution.read_text("direct_url.json")
+    if direct_url_text is None:
+        fail(
+            "nemo_toolkit has no PEP 610 direct_url.json; refusing an unverified source install"
+        )
+    direct_url = json.loads(direct_url_text)
+    source_url = str(direct_url.get("url", ""))
+    vcs_info = direct_url.get("vcs_info")
+    commit = vcs_info.get("commit_id") if isinstance(vcs_info, dict) else None
+    if source_url != "https://github.com/NVIDIA-NeMo/Speech.git":
+        fail(f"nemo_toolkit source is not official NVIDIA-NeMo/Speech: {source_url!r}")
+    if commit != NEMO_SPEECH_COMMIT:
+        fail(f"nemo_toolkit commit {commit!r} != pinned {NEMO_SPEECH_COMMIT}")
+    return source_url
+
+
+def validate_audited_geometry(model_id: str, geometry: dict) -> None:
+    expected = AUDITED_GEOMETRY[model_id]
+    mismatches = [
+        f"{key}={geometry.get(key)!r} (expected {value!r})"
+        for key, value in expected.items()
+        if geometry.get(key) != value
+    ]
+    if mismatches:
+        fail(
+            f"checkpoint geometry does not match audited profile {model_id}: "
+            + "; ".join(mismatches)
+        )
+
+
+def f32(tensor: torch.Tensor, *, name: str) -> torch.Tensor:
+    if not isinstance(tensor, torch.Tensor):
+        fail(f"{name} is not a torch.Tensor")
+    result = tensor.detach().cpu().to(torch.float32).contiguous()
+    if not torch.isfinite(result).all().item():
+        fail(f"{name} contains a non-finite value")
+    return result
+
+
+def add_tensor(
+    tensors: dict[str, torch.Tensor], name: str, tensor: torch.Tensor
+) -> None:
+    if name in tensors:
+        fail(f"duplicate canonical tensor {name}")
+    tensors[name] = f32(tensor, name=name)
+
+
+def add_conv(
+    tensors: dict[str, torch.Tensor], prefix: str, module: object
+) -> None:
+    conv = getattr(module, "conv", None)
+    if conv is None or conv.__class__.__name__ != "ParametrizedConv1d":
+        fail(
+            f"{prefix} expected weight-normalized ParametrizedConv1d, got "
+            f"{type(conv).__module__}.{type(conv).__name__}"
+        )
+    if conv.bias is None:
+        fail(f"{prefix} convolution has no bias")
+    # ``conv.weight`` is the official torch parametrization's effective
+    # weight.  Reading it folds weight norm without mirroring its internals.
+    add_tensor(tensors, f"{prefix}.weight", conv.weight)
+    add_tensor(tensors, f"{prefix}.bias", conv.bias)
+
+
+def half_snake(module: object, *, context: str) -> tuple[torch.Tensor, torch.Tensor]:
+    activation = getattr(module, "activation", None)
+    if activation is None or activation.__class__.__name__ != "HalfSnake":
+        fail(
+            f"{context} expected HalfSnake, got "
+            f"{type(activation).__module__}.{type(activation).__name__}"
+        )
+    snake = getattr(activation, "snake_act", None)
+    alpha = getattr(snake, "alpha", None)
+    if alpha is None:
+        fail(f"{context} HalfSnake has no snake_act.alpha")
+    alpha = f32(alpha, name=f"{context}.alpha").reshape(-1)
+    alpha_inv = 1.0 / (alpha + 1.0e-9)
+    if not torch.isfinite(alpha_inv).all().item():
+        fail(f"{context} produces non-finite 1/(alpha+1e-9)")
+    return alpha, alpha_inv.contiguous()
+
+
+def add_half_snake(
+    tensors: dict[str, torch.Tensor], prefix: str, module: object
+) -> None:
+    alpha, alpha_inv = half_snake(module, context=prefix)
+    add_tensor(tensors, f"{prefix}.alpha", alpha)
+    add_tensor(tensors, f"{prefix}.alpha_inv", alpha_inv)
+
+
+def dense_grouped_conv_transpose(module: object, *, context: str) -> torch.Tensor:
+    conv = getattr(module, "conv", None)
+    if conv is None or conv.__class__.__name__ != "ParametrizedConvTranspose1d":
+        fail(
+            f"{context} expected weight-normalized ParametrizedConvTranspose1d, got "
+            f"{type(conv).__module__}.{type(conv).__name__}"
+        )
+    weight = f32(conv.weight, name=f"{context}.weight")
+    in_channels = int(conv.in_channels)
+    out_channels = int(conv.out_channels)
+    groups = int(conv.groups)
+    if groups != out_channels:
+        fail(f"{context} groups {groups} != out_channels {out_channels}")
+    if in_channels % groups != 0 or tuple(weight.shape[1:2]) != (1,):
+        fail(
+            f"{context} unexpected grouped shape {tuple(weight.shape)} for "
+            f"in={in_channels}, out={out_channels}, groups={groups}"
+        )
+    kernel = int(weight.shape[2])
+    inputs_per_group = in_channels // groups
+    dense = torch.zeros((in_channels, out_channels, kernel), dtype=torch.float32)
+    for input_channel in range(in_channels):
+        output_channel = input_channel // inputs_per_group
+        dense[input_channel, output_channel, :] = weight[input_channel, 0, :]
+    return dense.contiguous()
+
+
+def checked_uniform(values: list[list[int]], *, context: str) -> list[int]:
+    if not values:
+        fail(f"{context} is empty")
+    first = values[0]
+    for index, value in enumerate(values[1:], start=1):
+        if value != first:
+            fail(f"{context}[{index}] {value} disagrees with {first}")
+    return first
+
+
+def quantizer_geometry(model: AudioCodecModel) -> tuple[int, list[int], int]:
+    quantizer = getattr(model, "vector_quantizer", None)
+    if quantizer is None or quantizer.__class__.__name__ != "GroupFiniteScalarQuantizer":
+        fail(
+            "expected vector_quantizer GroupFiniteScalarQuantizer, got "
+            f"{type(quantizer).__module__}.{type(quantizer).__name__}"
+        )
+    fsqs = list(getattr(quantizer, "fsqs", ()))
+    n_codebooks = int(getattr(quantizer, "num_codebooks"))
+    if n_codebooks <= 0 or len(fsqs) != n_codebooks:
+        fail(
+            f"quantizer num_codebooks {n_codebooks} disagrees with "
+            f"{len(fsqs)} FSQ modules"
+        )
+    level_sets = [
+        [int(value) for value in fsq.num_levels.detach().cpu().reshape(-1).tolist()]
+        for fsq in fsqs
+    ]
+    levels_per_group = checked_uniform(level_sets, context="FSQ levels")
+    if not levels_per_group or any(level < 2 for level in levels_per_group):
+        fail(f"invalid FSQ levels {levels_per_group}")
+    embed_dim = int(getattr(quantizer, "codebook_dim"))
+    expected_embed_dim = n_codebooks * len(levels_per_group)
+    if embed_dim != expected_embed_dim:
+        fail(
+            f"quantizer codebook_dim {embed_dim} != groups {n_codebooks} * "
+            f"levels width {len(levels_per_group)}"
+        )
+    return n_codebooks, levels_per_group, embed_dim
+
+
+def prepare_decoder(model: AudioCodecModel) -> tuple[dict[str, torch.Tensor], dict]:
+    decoder = getattr(model, "audio_decoder", None)
+    if decoder is None or decoder.__class__.__name__ != "CausalHiFiGANDecoder":
+        fail(
+            f"expected CausalHiFiGANDecoder, got "
+            f"{type(decoder).__module__}.{type(decoder).__name__}"
+        )
+    if decoder.out_activation.__class__.__name__ != "ClampActivation":
+        fail(
+            f"expected ClampActivation, got {decoder.out_activation.__class__.__name__}"
+        )
+
+    pre = decoder.pre_conv.conv
+    post = decoder.post_conv.conv
+    if pre.padding_mode != "zeros" or post.padding_mode != "zeros":
+        fail(
+            f"expected causal zero padding, got pre={pre.padding_mode}, "
+            f"post={post.padding_mode}"
+        )
+    upsample_rates = [int(rate) for rate in decoder.up_sample_rates]
+    if not upsample_rates or any(rate <= 0 for rate in upsample_rates):
+        fail(f"invalid upsample rates {upsample_rates}")
+    if not (
+        len(decoder.activations)
+        == len(decoder.up_sample_conv_layers)
+        == len(decoder.res_layers)
+        == len(upsample_rates)
+    ):
+        fail("decoder stage lists have inconsistent lengths")
+
+    if not decoder.res_layers:
+        fail("decoder has no residual layers")
+    first_layer = decoder.res_layers[0]
+    if not first_layer.res_blocks:
+        fail("decoder has no residual kernel branches")
+    resblock_kernel_sizes = [
+        int(branch.res_blocks[0].input_conv.conv.kernel_size[0])
+        for branch in first_layer.res_blocks
+    ]
+    resblock_dilations = [
+        int(block.input_conv.conv.dilation[0])
+        for block in first_layer.res_blocks[0].res_blocks
+    ]
+    if not resblock_dilations:
+        fail("decoder has no residual dilation blocks")
+
+    tensors: dict[str, torch.Tensor] = {}
+    add_conv(tensors, "nanocodec.pre_conv", decoder.pre_conv)
+    for stage, (activation, upsample, residual_layer) in enumerate(
+        zip(
+            decoder.activations,
+            decoder.up_sample_conv_layers,
+            decoder.res_layers,
+            strict=True,
+        )
+    ):
+        stage_prefix = f"nanocodec.stage.{stage}"
+        add_half_snake(tensors, f"{stage_prefix}.activation", activation)
+        dense = dense_grouped_conv_transpose(
+            upsample, context=f"{stage_prefix}.upsample"
+        )
+        add_tensor(tensors, f"{stage_prefix}.upsample.weight", dense)
+        if upsample.conv.bias is None:
+            fail(f"{stage_prefix}.upsample has no bias")
+        add_tensor(
+            tensors, f"{stage_prefix}.upsample.bias", upsample.conv.bias
+        )
+        if len(residual_layer.res_blocks) != len(resblock_kernel_sizes):
+            fail(f"stage {stage} residual branch count drift")
+        for branch, (branch_module, expected_kernel) in enumerate(
+            zip(
+                residual_layer.res_blocks,
+                resblock_kernel_sizes,
+                strict=True,
+            )
+        ):
+            if len(branch_module.res_blocks) != len(resblock_dilations):
+                fail(f"stage {stage} branch {branch} dilation count drift")
+            for block, (block_module, expected_dilation) in enumerate(
+                zip(
+                    branch_module.res_blocks,
+                    resblock_dilations,
+                    strict=True,
+                )
+            ):
+                actual_kernel = int(block_module.input_conv.conv.kernel_size[0])
+                actual_dilation = int(block_module.input_conv.conv.dilation[0])
+                skip_dilation = int(block_module.skip_conv.conv.dilation[0])
+                if actual_kernel != expected_kernel:
+                    fail(
+                        f"stage {stage} branch {branch} block {block} kernel "
+                        f"{actual_kernel} != {expected_kernel}"
+                    )
+                if actual_dilation != expected_dilation or skip_dilation != 1:
+                    fail(
+                        f"stage {stage} branch {branch} block {block} dilations "
+                        f"input={actual_dilation}, skip={skip_dilation}"
+                    )
+                prefix = f"{stage_prefix}.branch.{branch}.block.{block}"
+                add_half_snake(
+                    tensors,
+                    f"{prefix}.input_activation",
+                    block_module.input_activation,
+                )
+                add_conv(tensors, f"{prefix}.input_conv", block_module.input_conv)
+                add_half_snake(
+                    tensors,
+                    f"{prefix}.skip_activation",
+                    block_module.skip_activation,
+                )
+                add_conv(tensors, f"{prefix}.skip_conv", block_module.skip_conv)
+
+    add_half_snake(tensors, "nanocodec.post_activation", decoder.post_activation)
+    add_conv(tensors, "nanocodec.post_conv", decoder.post_conv)
+
+    n_codebooks, levels_per_group, embed_dim = quantizer_geometry(model)
+    input_dim = int(pre.in_channels)
+    if input_dim != embed_dim:
+        fail(f"decoder input_dim {input_dim} != quantizer embed_dim {embed_dim}")
+    frame_hop = int(getattr(model, "samples_per_frame"))
+    sample_rate = int(getattr(model, "sample_rate"))
+    generator_hop = math.prod(upsample_rates)
+
+    geometry = {
+        "format_version": FORMAT_VERSION,
+        "target_class": decoder.__class__.__name__,
+        "sample_rate": sample_rate,
+        "frame_hop": frame_hop,
+        "generator_hop": generator_hop,
+        "n_codebooks": n_codebooks,
+        "levels_per_group": levels_per_group,
+        "embed_dim": embed_dim,
+        "base_channels": int(pre.out_channels),
+        "upsample_rates": upsample_rates,
+        "input_kernel_size": int(pre.kernel_size[0]),
+        "output_kernel_size": int(post.kernel_size[0]),
+        "resblock_kernel_sizes": resblock_kernel_sizes,
+        "resblock_dilations": resblock_dilations,
+        "activation": "HalfSnake",
+        "output_activation": decoder.out_activation.__class__.__name__,
+        "pad_mode": pre.padding_mode,
+        "grouped_upsample": True,
+        "nemo_speech_commit": NEMO_SPEECH_COMMIT,
+    }
+    return tensors, geometry
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkpoint", type=Path, required=True)
+    parser.add_argument("--model-id", required=True)
+    parser.add_argument(
+        "--revision",
+        required=True,
+        help="immutable 40-character Hugging Face repository commit",
+    )
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--config-output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not args.checkpoint.is_file():
+        fail(f"checkpoint does not exist: {args.checkpoint}")
+    expected_revision = AUDITED_REVISIONS.get(args.model_id)
+    if expected_revision is None:
+        fail(
+            "model id is not one of the three audited NVIDIA 22 kHz NanoCodec "
+            f"repositories: {args.model_id}"
+        )
+    if FULL_REVISION.fullmatch(args.revision) is None:
+        fail("--revision must be a full 40-character lowercase hexadecimal commit")
+    if args.revision != expected_revision:
+        fail(
+            f"revision {args.revision} does not match audited {expected_revision} "
+            f"for {args.model_id}"
+        )
+    if args.output.resolve() == args.config_output.resolve():
+        fail("--output and --config-output must be different files")
+
+    actual_checkpoint_sha256 = checkpoint_sha256(args.checkpoint)
+    expected_checkpoint_sha256 = AUDITED_CHECKPOINT_SHA256.get(args.model_id)
+    if (
+        expected_checkpoint_sha256 is not None
+        and actual_checkpoint_sha256 != expected_checkpoint_sha256
+    ):
+        fail(
+            f"checkpoint SHA-256 {actual_checkpoint_sha256} does not match audited "
+            f"{expected_checkpoint_sha256} for {args.model_id}"
+        )
+    nemo_source_url = verify_nemo_source()
+
+    model = AudioCodecModel.restore_from(
+        restore_path=str(args.checkpoint), map_location=torch.device("cpu")
+    )
+    model.eval()
+    with torch.inference_mode():
+        tensors, config = prepare_decoder(model)
+    validate_audited_geometry(args.model_id, config)
+    config.update(
+        {
+            "source_model_id": args.model_id,
+            "source_revision": args.revision,
+            "checkpoint_sha256": actual_checkpoint_sha256,
+            "nemo_source_url": nemo_source_url,
+        }
+    )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.config_output.parent.mkdir(parents=True, exist_ok=True)
+    tensor_tmp = args.output.with_name(f".{args.output.name}.tmp")
+    config_tmp = args.config_output.with_name(f".{args.config_output.name}.tmp")
+    try:
+        save_file(tensors, str(tensor_tmp))
+        config_tmp.write_text(
+            json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        os.replace(tensor_tmp, args.output)
+        os.replace(config_tmp, args.config_output)
+    finally:
+        tensor_tmp.unlink(missing_ok=True)
+        config_tmp.unlink(missing_ok=True)
+
+    print(
+        f"wrote {args.output} ({args.output.stat().st_size} bytes, "
+        f"{len(tensors)} decoder tensors) and {args.config_output}; "
+        f"model={args.model_id}@{args.revision}, "
+        f"groups={config['n_codebooks']}, embed_dim={config['embed_dim']}, "
+        f"sample_rate={config['sample_rate']}, frame_hop={config['frame_hop']}, "
+        f"generator_hop={config['generator_hop']}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/parity/nanocodec/pyproject.toml
+++ b/tools/parity/nanocodec/pyproject.toml
@@ -1,10 +1,12 @@
 [project]
 name = "vokra-nanocodec-parity"
 version = "0.1.0"
-description = "Pinned offline NeMo oracle for NanoCodec Group-FSQ fixtures; never shipped."
+description = "Pinned official-NeMo preparation and Group-FSQ parity tools for NanoCodec"
 requires-python = ">=3.12,<3.13"
 dependencies = [
     "nemo_toolkit[tts] @ git+https://github.com/NVIDIA-NeMo/Speech.git@4fcff72febec9395fdbd4bfa0747bfda2ecd3cef",
+    # The pinned NeMo TTS package imports PEFT while omitting it from its
+    # distribution metadata. Keep the import closure explicit and locked.
     "peft==0.20.0",
 ]
 


### PR DESCRIPTION
Closes #47

## Summary

- add the pinned Python 3.12/NeMo `.nemo` boundary and dependency-free `vokra-cli convert --model nanocodec` GGUF path
- derive and validate the complete decoder tensor manifest, FSQ/profile geometry, provenance, and NVIDIA OML attribution
- exercise the three NVIDIA-published profiles through one code path: 0.6 kbps, 1.78 kbps, and 1.89 kbps
- reject the issue-listed 0.8 kbps id fail-closed because no NVIDIA repository/revision exists for it as of the 2026-08-22 audit
- require checkpoint `generator_hop` to equal the product of its upsample rates; the official 1.89 kbps checkpoint records 1024 for both

No model was uploaded. NVIDIA OML publication remains separately blocked on #53 owner sign-off.

## TDD and verification

- red/green regression: a forged 1.89 kbps `generator_hop=2048` was initially accepted, then rejected after the checkpoint-derived consistency gate was added
- local focused test: `RUSTC_WRAPPER= CARGO_BUILD_JOBS=1 cargo test -p vokra-convert models::nanocodec::tests --lib` (4 passed)
- VAST official checkpoint preparation: all three profiles emitted 386 decoder tensors
- VAST real conversion/load: all three profiles emitted loadable GGUF v3 files with 386 tensors and 30 metadata keys
- VAST combined with #46 runtime: all three real GGUFs bound and decoded with input dims 16/52/32 and frame hops 1764/1764/1024
- VAST NeMo waveform parity for the 0.6 kbps real GGUF: 5292 samples, max abs `8.940696716e-7`, RMSE `1.564858532e-7`
- VAST `cargo test -p vokra-convert --no-fail-fast`: 1092 unit tests plus integration/doc tests passed (fixture-only ignores unchanged)
- VAST `cargo test -p vokra-cli --no-fail-fast`: 186 unit tests plus integration tests passed
- VAST `cargo clippy -p vokra-convert -p vokra-cli --all-targets -- -D warnings`
- VAST/local: `cargo fmt --all -- --check`, `git diff --check`, zero-deps, forbidden-symbols, fixture-EOL, ABI changelog, `uv lock --check`, Python 3.12 byte-compile

## Dependency note

The converter PR is standalone. Its real GGUF → PCM round-trip was verified by temporarily combining it with #46; merge #46 before declaring the end-to-end runtime chain complete. The grouped-FSQ codes path is tracked by #45.
