### PR TITLE
feat(capi): add streaming codec decoder

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -109,7 +109,7 @@ jobs:
               --find-links bindings/python/wheelhouse/final \
               --no-index --no-deps "vokra==${VOKRA_BUILD_VERSION}"
             uv run --no-project --python "$VENV_PYTHON" python -c \
-              'import os, vokra; from vokra import _bindings, _native; assert vokra.__version__ == os.environ["VOKRA_BUILD_VERSION"]; assert len(_bindings.PROTOTYPES) == 48; assert _native.load().vokra_version()'
+              'import os, vokra; from vokra import _bindings, _native; assert vokra.__version__ == os.environ["VOKRA_BUILD_VERSION"]; assert len(_bindings.PROTOTYPES) == 56; assert _native.load().vokra_version()'
           done
       - name: Run Python binding tests
         run: |
@@ -200,7 +200,7 @@ jobs:
               --find-links bindings/python/wheelhouse/final \
               --no-index --no-deps "vokra==${VOKRA_BUILD_VERSION}"
             uv run --no-project --python "$VENV_PYTHON" python -c \
-              'import os, vokra; from vokra import _bindings, _native; assert vokra.__version__ == os.environ["VOKRA_BUILD_VERSION"]; assert len(_bindings.PROTOTYPES) == 48; assert _native.load().vokra_version()'
+              'import os, vokra; from vokra import _bindings, _native; assert vokra.__version__ == os.environ["VOKRA_BUILD_VERSION"]; assert len(_bindings.PROTOTYPES) == 56; assert _native.load().vokra_version()'
           done
       - name: Run Python binding tests
         run: |
@@ -277,7 +277,7 @@ jobs:
               --find-links bindings/python/wheelhouse/final \
               --no-index --no-deps "vokra==${VOKRA_BUILD_VERSION}"
             uv run --no-project --python "$VENV_PYTHON" python -c \
-              'import os, vokra; from vokra import _bindings, _native; assert vokra.__version__ == os.environ["VOKRA_BUILD_VERSION"]; assert len(_bindings.PROTOTYPES) == 48; assert _native.load().vokra_version()'
+              'import os, vokra; from vokra import _bindings, _native; assert vokra.__version__ == os.environ["VOKRA_BUILD_VERSION"]; assert len(_bindings.PROTOTYPES) == 56; assert _native.load().vokra_version()'
           done
       - name: Run Python binding tests
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,17 @@ milestone below.
   allocation-free post-warmup push/pull paths. The generated Python `ctypes`
   table and C smoke suite cover the additive surface (#49).
 
+#### Generic streaming codec C ABI (2026-08-22)
+
+- Added `vokra_codec_decoder_*`: an opaque, single-owner streaming handle
+  accepting one call-time-sized codebook frame and yielding mono PCM. The
+  first complete family implementation is standalone Mimi; codec families
+  without a real terminal PCM decoder remain explicit unsupported errors.
+- Mimi code-frame streaming is bit-identical to whole-buffer decode, retains
+  checkpoint-derived sample rate / frame hop / codebook count, and reuses all
+  feature, causal-state, and PCM scratch after open. A counting-allocator test
+  pins zero allocations across warmed `push_codes` + `pull_pcm` calls.
+
 #### Audio-wide coverage expansion (2026-07-24 → 2026-08-16)
 
 Vokra's scope widened from speech to audio: music generation, source

--- a/bindings/python/src/vokra/_bindings.py
+++ b/bindings/python/src/vokra/_bindings.py
@@ -63,6 +63,7 @@ class vokra_event_t(ctypes.Structure):
 vokra_aec_ref_writer_t = ctypes.c_void_p
 vokra_aec_t = ctypes.c_void_p
 vokra_feat_t = ctypes.c_void_p
+vokra_codec_decoder_t = ctypes.c_void_p
 vokra_s2s_duplex_t = ctypes.c_void_p
 vokra_s2s_interrupt_t = ctypes.c_void_p
 vokra_session_options_t = ctypes.c_void_p
@@ -106,6 +107,38 @@ PROTOTYPES = {
     'vokra_string_free': (
         None,
         (ctypes.POINTER(ctypes.c_char),),
+    ),
+    'vokra_codec_decoder_open': (
+        ctypes.c_void_p,
+        (ctypes.c_void_p,),
+    ),
+    'vokra_codec_decoder_frame_hop': (
+        ctypes.c_int32,
+        (ctypes.c_void_p,),
+    ),
+    'vokra_codec_decoder_sample_rate': (
+        ctypes.c_int32,
+        (ctypes.c_void_p,),
+    ),
+    'vokra_codec_decoder_n_codebooks': (
+        ctypes.c_int32,
+        (ctypes.c_void_p,),
+    ),
+    'vokra_codec_decoder_push_codes': (
+        ctypes.c_int,
+        (ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint32), ctypes.c_size_t, ctypes.POINTER(ctypes.c_int32),),
+    ),
+    'vokra_codec_decoder_pull_pcm': (
+        ctypes.c_int,
+        (ctypes.c_void_p, ctypes.POINTER(ctypes.c_float), ctypes.c_size_t, ctypes.POINTER(ctypes.c_size_t),),
+    ),
+    'vokra_codec_decoder_reset': (
+        None,
+        (ctypes.c_void_p,),
+    ),
+    'vokra_codec_decoder_destroy': (
+        None,
+        (ctypes.c_void_p,),
     ),
     'vokra_last_error': (
         ctypes.c_char_p,

--- a/bindings/python/src/vokra/_bindings.py
+++ b/bindings/python/src/vokra/_bindings.py
@@ -62,8 +62,8 @@ class vokra_event_t(ctypes.Structure):
 # native runtime owns their layouts.
 vokra_aec_ref_writer_t = ctypes.c_void_p
 vokra_aec_t = ctypes.c_void_p
-vokra_feat_t = ctypes.c_void_p
 vokra_codec_decoder_t = ctypes.c_void_p
+vokra_feat_t = ctypes.c_void_p
 vokra_s2s_duplex_t = ctypes.c_void_p
 vokra_s2s_interrupt_t = ctypes.c_void_p
 vokra_session_options_t = ctypes.c_void_p

--- a/bindings/python/tests/test_codegen.py
+++ b/bindings/python/tests/test_codegen.py
@@ -146,11 +146,12 @@ def test_generated_struct_layout_matches_c_abi_contract() -> None:
     ] == expected_offsets
 
 
-def test_all_eight_opaque_handles_are_void_p_aliases() -> None:
+def test_all_nine_opaque_handles_are_void_p_aliases() -> None:
     names = generator.parse_opaque_structs(_header_source())
     assert names == [
         "vokra_aec_ref_writer_t",
         "vokra_aec_t",
+        "vokra_codec_decoder_t",
         "vokra_feat_t",
         "vokra_s2s_duplex_t",
         "vokra_s2s_interrupt_t",

--- a/bindings/python/tests/test_codegen.py
+++ b/bindings/python/tests/test_codegen.py
@@ -36,7 +36,7 @@ def test_every_current_header_function_has_one_prototype() -> None:
     parsed_names = [name for name, _, _ in parsed]
     discovered_names = generator.discover_function_names(source)
 
-    assert len(parsed_names) == 48
+    assert len(parsed_names) == 56
     assert len(parsed_names) == len(set(parsed_names))
     assert parsed_names == discovered_names
     assert set(bindings.PROTOTYPES) == set(parsed_names)

--- a/crates/vokra-capi/src/codec.rs
+++ b/crates/vokra-capi/src/codec.rs
@@ -370,6 +370,7 @@ mod tests {
         assert!(unsafe { vokra_codec_decoder_open(session) }.is_null());
         // SAFETY: NULL is the documented error branch.
         assert_eq!(
+            // SAFETY: NULL is explicitly accepted and reported as `-1`.
             unsafe { vokra_codec_decoder_n_codebooks(std::ptr::null()) },
             -1
         );

--- a/crates/vokra-capi/src/codec.rs
+++ b/crates/vokra-capi/src/codec.rs
@@ -43,8 +43,8 @@ pub struct vokra_codec_decoder_t {
 ///
 /// Returns `NULL` and records detail in `vokra_last_error()` when the loaded
 /// model does not expose a complete streaming token-to-PCM decoder. Currently
-/// standalone Mimi opts in; partial SNAC support remains an explicit error
-/// until its terminal PCM decoder exists.
+/// standalone Mimi and NVIDIA NanoCodec opt in; partial SNAC support remains
+/// an explicit error until its terminal PCM decoder exists.
 ///
 /// # Safety
 ///

--- a/crates/vokra-capi/src/codec.rs
+++ b/crates/vokra-capi/src/codec.rs
@@ -1,0 +1,379 @@
+//! Generic streaming codec-decoder C ABI (#48): token indices in, mono PCM
+//! out, without forcing the caller's acoustic model into Vokra.
+//!
+//! # Ownership and threads
+//!
+//! `vokra_codec_decoder_t` is an opaque, stateful, **single-owner-thread**
+//! handle, matching `vokra_s2s_duplex_t`: it may be moved to another thread,
+//! but the same live handle must never be pushed, pulled, reset, or destroyed
+//! concurrently. Each `vokra_codec_decoder_open` call creates independent
+//! causal state and retains a clone of its source session, so the caller may
+//! destroy the original `vokra_session_t` immediately after open.
+//!
+//! The immutable model weights can therefore be shared through multiple
+//! independently opened decoder handles without sharing mutable decode state.
+//! There is no worker thread and no callback: callers drive progress solely
+//! through push/pull, preserving the Unity WebGL thread-free contract checked
+//! by `scripts/check-capi-thread-free.sh`.
+//!
+//! # Shape and backpressure
+//!
+//! `n_codebooks` comes from the loaded checkpoint and is also a call-time
+//! argument to `push_codes`; it is deliberately not a header constant. One
+//! successful push accepts exactly one complete code frame. The caller must
+//! pull its PCM before pushing the next frame; violations fail loudly rather
+//! than overwriting pending audio.
+
+use vokra_core::{CodecDecoderHandle, Session, VokraError};
+
+use crate::error::{self, vokra_status_t};
+use crate::ffi_guard;
+use crate::handle::{self, vokra_session_t};
+
+/// Opaque single-owner streaming codec decoder (module docs).
+#[allow(non_camel_case_types)]
+pub struct vokra_codec_decoder_t {
+    /// Stateful decoder; drops before the retained model session below.
+    decoder: Box<dyn CodecDecoderHandle + Send>,
+    /// Keeps model weights alive independently of the source C handle.
+    _session: Session,
+}
+
+/// Opens a fresh streaming codec decoder for `session`.
+///
+/// Returns `NULL` and records detail in `vokra_last_error()` when the loaded
+/// model does not expose a complete streaming token-to-PCM decoder. Currently
+/// standalone Mimi opts in; partial SNAC support remains an explicit error
+/// until its terminal PCM decoder exists.
+///
+/// # Safety
+///
+/// `session` must be `NULL` or a live `vokra_session_t`. The returned handle,
+/// when non-NULL, must be destroyed exactly once with
+/// [`vokra_codec_decoder_destroy`].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vokra_codec_decoder_open(
+    session: *const vokra_session_t,
+) -> *mut vokra_codec_decoder_t {
+    ffi_guard::guard_ptr(|| {
+        // SAFETY: NULL is rejected; a non-NULL pointer is live per contract.
+        let s = match unsafe { ffi_guard::required_ref(session, "session") } {
+            Ok(s) => s,
+            Err(_) => return std::ptr::null_mut(),
+        };
+        match s.session.open_codec_decoder() {
+            Ok(decoder) => handle::into_raw(vokra_codec_decoder_t {
+                decoder,
+                _session: s.session.clone(),
+            }),
+            Err(err) => {
+                error::fail(&err);
+                std::ptr::null_mut()
+            }
+        }
+    })
+}
+
+/// Returns PCM samples emitted per complete code frame, or `-1` on error.
+///
+/// # Safety
+///
+/// `decoder` must be a live handle or `NULL` (reported as `-1`).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vokra_codec_decoder_frame_hop(
+    decoder: *const vokra_codec_decoder_t,
+) -> i32 {
+    direct_i32_property(decoder, "decoder", |d| d.decoder.frame_hop())
+}
+
+/// Returns the decoder PCM sample rate in Hz, or `-1` on error.
+///
+/// # Safety
+///
+/// `decoder` must be a live handle or `NULL` (reported as `-1`).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vokra_codec_decoder_sample_rate(
+    decoder: *const vokra_codec_decoder_t,
+) -> i32 {
+    direct_i32_property(decoder, "decoder", |d| d.decoder.sample_rate() as usize)
+}
+
+/// Returns the checkpoint's codebook count, or `-1` on error. This value is
+/// informational; callers must still pass the count to every push so shape
+/// mismatches remain observable at the ABI boundary.
+///
+/// # Safety
+///
+/// `decoder` must be a live handle or `NULL` (reported as `-1`).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vokra_codec_decoder_n_codebooks(
+    decoder: *const vokra_codec_decoder_t,
+) -> i32 {
+    direct_i32_property(decoder, "decoder", |d| d.decoder.n_codebooks())
+}
+
+fn direct_i32_property(
+    decoder: *const vokra_codec_decoder_t,
+    name: &str,
+    property: impl FnOnce(&vokra_codec_decoder_t) -> usize,
+) -> i32 {
+    let mut value = -1;
+    let status = ffi_guard::guard(|| {
+        // SAFETY: the caller-facing wrappers carry the live-or-NULL contract.
+        let d = unsafe { ffi_guard::required_ref(decoder, name)? };
+        value = i32::try_from(property(d)).map_err(|_| {
+            error::fail(&VokraError::InvalidArgument(
+                "codec decoder property exceeds INT32_MAX".into(),
+            ))
+        })?;
+        Ok(())
+    });
+    if status == vokra_status_t::VOKRA_OK {
+        value
+    } else {
+        -1
+    }
+}
+
+/// Pushes one complete code frame.
+///
+/// `n_codebooks` is a required call-time shape and must exactly match
+/// `vokra_codec_decoder_n_codebooks(decoder)`. On success,
+/// `*out_frames_emitted` is `1`; pull the corresponding PCM before the next
+/// push. The warmed successful push/pull path performs no heap allocation.
+///
+/// # Safety
+///
+/// `decoder` must be a live handle owned by the calling thread; `codes` must
+/// point to `n_codebooks` readable `uint32_t` values; `out_frames_emitted`
+/// must be valid and writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vokra_codec_decoder_push_codes(
+    decoder: *mut vokra_codec_decoder_t,
+    codes: *const u32,
+    n_codebooks: usize,
+    out_frames_emitted: *mut i32,
+) -> vokra_status_t {
+    ffi_guard::guard(|| {
+        // SAFETY: NULL-checked unique borrow per the caller contract.
+        let d = unsafe { ffi_guard::required_mut(decoder, "decoder")? };
+        ffi_guard::require_out_ptr(out_frames_emitted, "out_frames_emitted")?;
+        if n_codebooks != d.decoder.n_codebooks() {
+            return Err(error::fail_invalid(&format!(
+                "n_codebooks {n_codebooks} != checkpoint {}",
+                d.decoder.n_codebooks()
+            )));
+        }
+        // SAFETY: non-zero checkpoint width plus caller-readable buffer.
+        let codes = unsafe { ffi_guard::required_slice(codes, n_codebooks, "codes")? };
+        let emitted = d.decoder.push_codes(codes).map_err(|e| error::fail(&e))?;
+        let emitted = i32::try_from(emitted).map_err(|_| {
+            error::fail(&VokraError::InvalidArgument(
+                "codec emitted frame count exceeds INT32_MAX".into(),
+            ))
+        })?;
+        // SAFETY: out pointer was checked and is writable per contract.
+        unsafe { *out_frames_emitted = emitted };
+        Ok(())
+    })
+}
+
+/// Pulls one pending PCM frame into `out`.
+///
+/// `capacity` must be at least `vokra_codec_decoder_frame_hop(decoder)` when
+/// a frame is pending. `*out_len == 0` means there was nothing to pull.
+///
+/// # Safety
+///
+/// `decoder` must be a live handle owned by the calling thread; when
+/// `capacity > 0`, `out` must point to that many writable floats; `out_len`
+/// must be valid and writable.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vokra_codec_decoder_pull_pcm(
+    decoder: *mut vokra_codec_decoder_t,
+    out: *mut f32,
+    capacity: usize,
+    out_len: *mut usize,
+) -> vokra_status_t {
+    ffi_guard::guard(|| {
+        // SAFETY: NULL-checked unique borrow per the caller contract.
+        let d = unsafe { ffi_guard::required_mut(decoder, "decoder")? };
+        ffi_guard::require_out_ptr(out_len, "out_len")?;
+        let output: &mut [f32] = if capacity == 0 {
+            &mut []
+        } else {
+            if out.is_null() {
+                return Err(error::fail_invalid(
+                    "out must not be NULL when capacity is non-zero",
+                ));
+            }
+            // SAFETY: caller guarantees `capacity` writable floats.
+            unsafe { std::slice::from_raw_parts_mut(out, capacity) }
+        };
+        let written = d.decoder.pull_pcm(output).map_err(|e| error::fail(&e))?;
+        // SAFETY: out pointer was checked and is writable per contract.
+        unsafe { *out_len = written };
+        Ok(())
+    })
+}
+
+/// Resets the causal decoder to its as-new state and discards pending PCM.
+/// Errors (including `NULL`) are recorded in `vokra_last_error()`; this exact
+/// pre-freeze API is void, matching the issue contract.
+///
+/// # Safety
+///
+/// `decoder` must be a live handle owned by the calling thread.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vokra_codec_decoder_reset(decoder: *mut vokra_codec_decoder_t) {
+    let _ = ffi_guard::guard(|| {
+        // SAFETY: NULL-checked unique borrow per the caller contract.
+        let d = unsafe { ffi_guard::required_mut(decoder, "decoder")? };
+        d.decoder.reset().map_err(|e| error::fail(&e))?;
+        Ok(())
+    });
+}
+
+/// Destroys a decoder handle. `NULL` is a no-op; double-free or concurrent
+/// use/destroy is undefined behaviour.
+///
+/// # Safety
+///
+/// `decoder` must be `NULL` or a live handle returned by
+/// [`vokra_codec_decoder_open`] and not yet freed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn vokra_codec_decoder_destroy(decoder: *mut vokra_codec_decoder_t) {
+    ffi_guard::guard_void(|| {
+        // SAFETY: NULL or a unique live Box from open, per contract.
+        unsafe { handle::drop_raw(decoder) };
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use vokra_core::gguf::{GgufBuilder, GgufFile};
+    use vokra_core::{CodecDecoderEngine, Result};
+
+    use super::*;
+
+    struct FakeEngine;
+    struct FakeDecoder {
+        pending: bool,
+        value: f32,
+    }
+
+    impl CodecDecoderEngine for FakeEngine {
+        fn open_decoder(&self) -> Result<Box<dyn CodecDecoderHandle + Send>> {
+            Ok(Box::new(FakeDecoder {
+                pending: false,
+                value: 0.0,
+            }))
+        }
+    }
+
+    impl CodecDecoderHandle for FakeDecoder {
+        fn frame_hop(&self) -> usize {
+            4
+        }
+        fn sample_rate(&self) -> u32 {
+            22_050
+        }
+        fn n_codebooks(&self) -> usize {
+            3
+        }
+        fn push_codes(&mut self, codes: &[u32]) -> Result<usize> {
+            self.value = codes.iter().sum::<u32>() as f32;
+            self.pending = true;
+            Ok(1)
+        }
+        fn pull_pcm(&mut self, out: &mut [f32]) -> Result<usize> {
+            if !self.pending {
+                return Ok(0);
+            }
+            if out.len() < 4 {
+                return Err(VokraError::InvalidArgument("short output".into()));
+            }
+            out[..4].copy_from_slice(&[self.value, 1.0, -1.0, -self.value]);
+            self.pending = false;
+            Ok(4)
+        }
+        fn reset(&mut self) -> Result<()> {
+            self.pending = false;
+            self.value = 0.0;
+            Ok(())
+        }
+    }
+
+    fn session_handle(with_engine: bool) -> *mut vokra_session_t {
+        let mut b = GgufBuilder::new();
+        b.add_string("vokra.model.arch", "test");
+        let gguf = GgufFile::parse(b.to_bytes().unwrap()).unwrap();
+        let mut session = Session::from_gguf(gguf).build().unwrap();
+        if with_engine {
+            session = session.with_codec_decoder_engine(Arc::new(FakeEngine));
+        }
+        handle::into_raw(vokra_session_t { session })
+    }
+
+    #[test]
+    fn c_surface_roundtrip_and_call_time_codebook_shape() {
+        let session = session_handle(true);
+        // SAFETY: live session handle.
+        let decoder = unsafe { vokra_codec_decoder_open(session) };
+        assert!(!decoder.is_null());
+        // SAFETY: live decoder handle.
+        unsafe {
+            assert_eq!(vokra_codec_decoder_frame_hop(decoder), 4);
+            assert_eq!(vokra_codec_decoder_sample_rate(decoder), 22_050);
+            assert_eq!(vokra_codec_decoder_n_codebooks(decoder), 3);
+        }
+
+        let codes = [2u32, 3, 4];
+        let mut emitted = -7;
+        // SAFETY: live handle, readable codes, writable output.
+        let bad =
+            unsafe { vokra_codec_decoder_push_codes(decoder, codes.as_ptr(), 2, &mut emitted) };
+        assert_eq!(bad, vokra_status_t::VOKRA_ERROR_INVALID_ARGUMENT);
+        assert_eq!(emitted, -7, "out-param is untouched on error");
+
+        // SAFETY: live handle and exact checkpoint shape.
+        let ok = unsafe {
+            vokra_codec_decoder_push_codes(decoder, codes.as_ptr(), codes.len(), &mut emitted)
+        };
+        assert_eq!(ok, vokra_status_t::VOKRA_OK);
+        assert_eq!(emitted, 1);
+
+        let mut pcm = [0.0f32; 4];
+        let mut written = usize::MAX;
+        // SAFETY: live handle and writable output buffer.
+        let ok = unsafe {
+            vokra_codec_decoder_pull_pcm(decoder, pcm.as_mut_ptr(), pcm.len(), &mut written)
+        };
+        assert_eq!(ok, vokra_status_t::VOKRA_OK);
+        assert_eq!(written, 4);
+        assert_eq!(pcm, [9.0, 1.0, -1.0, -9.0]);
+
+        // SAFETY: live handles, each destroyed exactly once.
+        unsafe {
+            vokra_codec_decoder_reset(decoder);
+            vokra_codec_decoder_destroy(decoder);
+            handle::drop_raw(session);
+        }
+    }
+
+    #[test]
+    fn open_fails_loudly_without_codec_engine_and_null_queries_are_minus_one() {
+        let session = session_handle(false);
+        // SAFETY: live session but intentionally no codec engine.
+        assert!(unsafe { vokra_codec_decoder_open(session) }.is_null());
+        // SAFETY: NULL is the documented error branch.
+        assert_eq!(
+            unsafe { vokra_codec_decoder_n_codebooks(std::ptr::null()) },
+            -1
+        );
+        // SAFETY: session is live and freed once.
+        unsafe { handle::drop_raw(session) };
+    }
+}

--- a/crates/vokra-capi/src/lib.rs
+++ b/crates/vokra-capi/src/lib.rs
@@ -64,6 +64,7 @@
 // (FR-OP-60; split-handle thread contract, ADR M4-03 §D-(j)).
 mod aec;
 mod asr;
+mod codec;
 mod error;
 mod feature;
 mod ffi_guard;

--- a/crates/vokra-capi/src/session.rs
+++ b/crates/vokra-capi/src/session.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 use vokra_core::gguf::{AsBytes, GgufFile};
 use vokra_core::{BackendKind, CompliancePolicy, Session, VokraError};
-use vokra_models::codec::MimiStreamingCodec;
+use vokra_models::codec::{MimiStreamingCodec, NanoCodecStreamingCodec};
 use vokra_models::moshi::MoshiEngine;
 use vokra_models::piper_plus::PiperPlusTts;
 use vokra_models::silero_vad::SileroVadV5;
@@ -34,6 +34,8 @@ const ARCH_PIPER_PLUS: &str = "piper-plus-mb-istft-vits2";
 const ARCH_MOSHI: &str = "moshi";
 /// Standalone Kyutai Mimi codec (`vokra-cli convert --model mimi`).
 const ARCH_MIMI: &str = "mimi";
+/// NVIDIA NanoCodec decoder-only GGUF (`vokra-cli convert --model nanocodec`).
+const ARCH_NANOCODEC: &str = "nanocodec";
 /// CAM++ speaker encoder (`crates/vokra-convert/src/models/campplus.rs`), the
 /// `speaker_encode` model behind `vokra_speaker_embed`.
 const ARCH_CAMPLUS: &str = "campplus";
@@ -189,10 +191,15 @@ fn inject_engine(
             let decoder = MimiStreamingCodec::from_gguf(session.gguf())?;
             Ok(session.with_codec_decoder_engine(Arc::new(decoder)))
         }
+        ARCH_NANOCODEC => {
+            reject_cpu_only_backend(backend, "NanoCodec streaming codec decoder")?;
+            let decoder = NanoCodecStreamingCodec::from_gguf(session.gguf())?;
+            Ok(session.with_codec_decoder_engine(Arc::new(decoder)))
+        }
         other => Err(VokraError::InvalidArgument(format!(
             "unsupported model arch `{other}` (supported: `{ARCH_WHISPER}` / \
              `{ARCH_SILERO_VAD}` / `{ARCH_PIPER_PLUS}` / `{ARCH_MOSHI}` / `{ARCH_MIMI}` / \
-             `{ARCH_CAMPLUS}`)"
+             `{ARCH_NANOCODEC}` / `{ARCH_CAMPLUS}`)"
         ))),
     }
 }

--- a/crates/vokra-capi/src/session.rs
+++ b/crates/vokra-capi/src/session.rs
@@ -633,6 +633,27 @@ mod tests {
         }
     }
 
+    #[test]
+    fn build_session_binds_real_nanocodec_decoder_when_fixture_is_available() {
+        let Ok(model) = std::env::var("VOKRA_NANOCODEC_GGUF") else {
+            eprintln!("skipping NanoCodec leg: set VOKRA_NANOCODEC_GGUF to run");
+            return;
+        };
+        let session = build_session(&model, CPU).expect("NanoCodec session builds on CPU");
+        let mut decoder = session
+            .open_codec_decoder()
+            .expect("NanoCodec session injects codec decoder");
+        assert_eq!(decoder.sample_rate(), 22_050);
+        assert!(decoder.frame_hop() > 0);
+        assert!(decoder.n_codebooks() > 0);
+
+        let codes = vec![0; decoder.n_codebooks()];
+        let mut pcm = vec![0.0; decoder.frame_hop()];
+        assert_eq!(decoder.push_codes(&codes).unwrap(), 1);
+        assert_eq!(decoder.pull_pcm(&mut pcm).unwrap(), pcm.len());
+        assert!(pcm.iter().all(|sample| sample.is_finite()));
+    }
+
     /// The guard itself: CPU passes, every GPU backend is refused, and the
     /// refusal names the engine so the message is actionable.
     #[test]

--- a/crates/vokra-capi/src/session.rs
+++ b/crates/vokra-capi/src/session.rs
@@ -652,6 +652,10 @@ mod tests {
         assert_eq!(decoder.push_codes(&codes).unwrap(), 1);
         assert_eq!(decoder.pull_pcm(&mut pcm).unwrap(), pcm.len());
         assert!(pcm.iter().all(|sample| sample.is_finite()));
+        assert!(
+            pcm.iter().any(|sample| sample.abs() > 1.0e-8),
+            "real NanoCodec decode must not silently substitute zero PCM"
+        );
     }
 
     /// The guard itself: CPU passes, every GPU backend is refused, and the

--- a/crates/vokra-capi/src/session.rs
+++ b/crates/vokra-capi/src/session.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 
 use vokra_core::gguf::{AsBytes, GgufFile};
 use vokra_core::{BackendKind, CompliancePolicy, Session, VokraError};
+use vokra_models::codec::MimiStreamingCodec;
 use vokra_models::moshi::MoshiEngine;
 use vokra_models::piper_plus::PiperPlusTts;
 use vokra_models::silero_vad::SileroVadV5;
@@ -31,6 +32,8 @@ const ARCH_WHISPER: &str = "whisper";
 const ARCH_SILERO_VAD: &str = "silero-vad";
 const ARCH_PIPER_PLUS: &str = "piper-plus-mb-istft-vits2";
 const ARCH_MOSHI: &str = "moshi";
+/// Standalone Kyutai Mimi codec (`vokra-cli convert --model mimi`).
+const ARCH_MIMI: &str = "mimi";
 /// CAM++ speaker encoder (`crates/vokra-convert/src/models/campplus.rs`), the
 /// `speaker_encode` model behind `vokra_speaker_embed`.
 const ARCH_CAMPLUS: &str = "campplus";
@@ -181,9 +184,15 @@ fn inject_engine(
             }
             Ok(session)
         }
+        ARCH_MIMI => {
+            reject_cpu_only_backend(backend, "Mimi streaming codec decoder")?;
+            let decoder = MimiStreamingCodec::from_gguf(session.gguf())?;
+            Ok(session.with_codec_decoder_engine(Arc::new(decoder)))
+        }
         other => Err(VokraError::InvalidArgument(format!(
             "unsupported model arch `{other}` (supported: `{ARCH_WHISPER}` / \
-             `{ARCH_SILERO_VAD}` / `{ARCH_PIPER_PLUS}` / `{ARCH_MOSHI}` / `{ARCH_CAMPLUS}`)"
+             `{ARCH_SILERO_VAD}` / `{ARCH_PIPER_PLUS}` / `{ARCH_MOSHI}` / `{ARCH_MIMI}` / \
+             `{ARCH_CAMPLUS}`)"
         ))),
     }
 }

--- a/crates/vokra-core/src/engines.rs
+++ b/crates/vokra-core/src/engines.rs
@@ -88,6 +88,48 @@ pub trait SpeechFeatureStream {
     fn reset(&mut self);
 }
 
+/// A model family capable of opening a stateful streaming codec decoder.
+///
+/// The engine is immutable and session-shareable. Each call to
+/// [`Self::open_decoder`] creates an independently owned state machine, which
+/// is the unit exposed by the C ABI as `vokra_codec_decoder_t`. Codec families
+/// opt in only after their real token-to-PCM streaming path exists; a partial
+/// binder must fail loudly instead of masquerading as a decoder (FR-EX-08).
+pub trait CodecDecoderEngine: Send + Sync {
+    /// Opens a fresh token-to-PCM decoder state.
+    fn open_decoder(&self) -> Result<Box<dyn CodecDecoderHandle + Send>>;
+}
+
+/// One stateful streaming codec decoder (codes in, mono PCM out).
+///
+/// Handles are single-owner mutable objects. They are `Send` so ownership can
+/// move between threads, but callers must not use the same handle concurrently.
+/// All shape axes are queried from the loaded checkpoint; in particular,
+/// `n_codebooks` is never a build-time or ABI constant.
+pub trait CodecDecoderHandle {
+    /// PCM samples produced by one complete code frame.
+    fn frame_hop(&self) -> usize;
+
+    /// PCM sample rate in Hz.
+    fn sample_rate(&self) -> u32;
+
+    /// Number of token indices required by one code frame.
+    fn n_codebooks(&self) -> usize;
+
+    /// Pushes exactly one `[n_codebooks]` frame and returns the number of PCM
+    /// frames made available to [`Self::pull_pcm`] (currently zero or one).
+    /// The warmed successful path must not allocate.
+    fn push_codes(&mut self, codes: &[u32]) -> Result<usize>;
+
+    /// Copies one pending PCM frame into `out`, returning the number of samples
+    /// written (`0` when no frame is pending). The warmed successful path must
+    /// not allocate.
+    fn pull_pcm(&mut self, out: &mut [f32]) -> Result<usize>;
+
+    /// Restores as-new causal state and discards pending PCM.
+    fn reset(&mut self) -> Result<()>;
+}
+
 /// A speech-to-speech dialog engine (implemented natively in
 /// `vokra-models` — Sesame CSM-1B = M4-05; Moshi = M4-06).
 ///

--- a/crates/vokra-core/src/lib.rs
+++ b/crates/vokra-core/src/lib.rs
@@ -193,10 +193,10 @@ pub use decode::{
 };
 #[cfg(feature = "std")]
 pub use engines::{
-    AecEngine, AecStreamHandle, AsrEngine, DialogContextTurn, DialogRequest, DuplexInterruptHandle,
-    DuplexPushReport, DuplexSessionConfig, S2sDuplexEngine, S2sDuplexHandle, S2sEngine,
-    SpeakerEngine, SpeechFeatureEngine, SpeechFeatureStream, SynthesisRequest, TtsEngine,
-    TtsStreamHandle, VadEngine, VadStreamHandle,
+    AecEngine, AecStreamHandle, AsrEngine, CodecDecoderEngine, CodecDecoderHandle,
+    DialogContextTurn, DialogRequest, DuplexInterruptHandle, DuplexPushReport, DuplexSessionConfig,
+    S2sDuplexEngine, S2sDuplexHandle, S2sEngine, SpeakerEngine, SpeechFeatureEngine,
+    SpeechFeatureStream, SynthesisRequest, TtsEngine, TtsStreamHandle, VadEngine, VadStreamHandle,
 };
 #[cfg(feature = "std")]
 pub use ir::{AudioGraph, DType, Dim, GraphBuilder, Node, OpKind, TensorDesc, TensorId};

--- a/crates/vokra-core/src/session.rs
+++ b/crates/vokra-core/src/session.rs
@@ -21,8 +21,8 @@ use std::sync::atomic::AtomicU64;
 use crate::backend::BackendKind;
 use crate::compliance::AttributionInfo;
 use crate::engines::{
-    AsrEngine, S2sDuplexEngine, S2sEngine, SpeakerEngine, SpeechFeatureEngine, SpeechFeatureStream,
-    TtsEngine, VadEngine, VadStreamHandle,
+    AsrEngine, CodecDecoderEngine, CodecDecoderHandle, S2sDuplexEngine, S2sEngine, SpeakerEngine,
+    SpeechFeatureEngine, SpeechFeatureStream, TtsEngine, VadEngine, VadStreamHandle,
 };
 use crate::error::{Result, VokraError};
 use crate::gguf::GgufFile;
@@ -80,6 +80,7 @@ pub struct Session {
     s2s: Option<Arc<dyn S2sEngine>>,
     s2s_duplex: Option<Arc<dyn S2sDuplexEngine>>,
     speech_features: Option<Arc<dyn SpeechFeatureEngine>>,
+    codec_decoder: Option<Arc<dyn CodecDecoderEngine>>,
     /// Speaker-embedding engine (CAM++ = M0-08, FR-OP-80). Same shape as the
     /// engines above; the facade entry is [`Session::speaker`].
     speaker: Option<Arc<dyn SpeakerEngine>>,
@@ -101,6 +102,7 @@ impl Clone for Session {
             s2s: self.s2s.clone(),
             s2s_duplex: self.s2s_duplex.clone(),
             speech_features: self.speech_features.clone(),
+            codec_decoder: self.codec_decoder.clone(),
             speaker: self.speaker.clone(),
             attribution: self.attribution.clone(),
         }
@@ -119,6 +121,7 @@ impl fmt::Debug for Session {
             .field("s2s_engine", &self.s2s.is_some())
             .field("s2s_duplex_engine", &self.s2s_duplex.is_some())
             .field("speech_feature_engine", &self.speech_features.is_some())
+            .field("codec_decoder_engine", &self.codec_decoder.is_some())
             .field("speaker_engine", &self.speaker.is_some())
             .field("attribution", &self.attribution.is_some())
             .finish()
@@ -238,6 +241,14 @@ impl Session {
         self
     }
 
+    /// Attaches a streaming codec decoder engine. The engine is model-family
+    /// generic; only families with a complete token-to-PCM decoder opt in.
+    #[must_use]
+    pub fn with_codec_decoder_engine(mut self, engine: Arc<dyn CodecDecoderEngine>) -> Self {
+        self.codec_decoder = Some(engine);
+        self
+    }
+
     /// Attaches a speaker-embedding engine (CAM++ = M0-08, FR-OP-80); the
     /// [`Speaker`](crate::tasks::Speaker) facade delegates to it.
     #[must_use]
@@ -285,6 +296,19 @@ impl Session {
     /// [`S2s`](crate::S2s) facade's `duplex` entry).
     pub(crate) fn s2s_duplex_engine(&self) -> Option<&Arc<dyn S2sDuplexEngine>> {
         self.s2s_duplex.as_ref()
+    }
+
+    /// Opens an independently owned streaming codec decoder.
+    ///
+    /// Returns [`VokraError::NotImplemented`] when the loaded model does not
+    /// expose a complete streaming token-to-PCM path.
+    pub fn open_codec_decoder(&self) -> Result<Box<dyn CodecDecoderHandle + Send>> {
+        match &self.codec_decoder {
+            Some(engine) => engine.open_decoder(),
+            None => Err(VokraError::NotImplemented(
+                "no streaming codec decoder engine injected for this model",
+            )),
+        }
     }
 
     /// The injected speaker-embedding engine, if any (used by the
@@ -417,6 +441,7 @@ impl SessionBuilder {
             s2s: None,
             s2s_duplex: None,
             speech_features: None,
+            codec_decoder: None,
             speaker: None,
             attribution: None,
         })
@@ -745,5 +770,70 @@ pub(crate) mod tests {
         let mut out = [0.0f32; 4];
         assert_eq!(stream.pull_into(&mut out).unwrap(), (2, 0));
         assert_eq!(out, [0.0, 1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn codec_decoder_is_loud_when_absent_and_independent_when_injected() {
+        struct FakeCodec;
+        struct FakeDecoder {
+            next: f32,
+        }
+        impl CodecDecoderEngine for FakeCodec {
+            fn open_decoder(&self) -> Result<Box<dyn CodecDecoderHandle + Send>> {
+                Ok(Box::new(FakeDecoder { next: 0.0 }))
+            }
+        }
+        impl CodecDecoderHandle for FakeDecoder {
+            fn frame_hop(&self) -> usize {
+                2
+            }
+            fn sample_rate(&self) -> u32 {
+                16_000
+            }
+            fn n_codebooks(&self) -> usize {
+                3
+            }
+            fn push_codes(&mut self, codes: &[u32]) -> Result<usize> {
+                if codes.len() != self.n_codebooks() {
+                    return Err(VokraError::InvalidArgument("wrong code width".into()));
+                }
+                self.next = codes.iter().sum::<u32>() as f32;
+                Ok(1)
+            }
+            fn pull_pcm(&mut self, out: &mut [f32]) -> Result<usize> {
+                if out.len() < self.frame_hop() {
+                    return Err(VokraError::InvalidArgument("short PCM output".into()));
+                }
+                out[..2].copy_from_slice(&[self.next, -self.next]);
+                Ok(2)
+            }
+            fn reset(&mut self) -> Result<()> {
+                self.next = 0.0;
+                Ok(())
+            }
+        }
+
+        let file = TempModelFile::new("codec-engine");
+        let plain = Session::from_file(&file.0).build().expect("session builds");
+        assert!(matches!(
+            plain.open_codec_decoder(),
+            Err(VokraError::NotImplemented(_))
+        ));
+
+        let session = plain.with_codec_decoder_engine(Arc::new(FakeCodec));
+        let mut a = session.open_codec_decoder().expect("first decoder");
+        let mut b = session.open_codec_decoder().expect("second decoder");
+        assert_eq!(
+            (a.sample_rate(), a.frame_hop(), a.n_codebooks()),
+            (16_000, 2, 3)
+        );
+        assert_eq!(a.push_codes(&[1, 2, 3]).unwrap(), 1);
+        assert_eq!(b.push_codes(&[4, 5, 6]).unwrap(), 1);
+        let mut pcm_a = [0.0; 2];
+        let mut pcm_b = [0.0; 2];
+        assert_eq!(a.pull_pcm(&mut pcm_a).unwrap(), 2);
+        assert_eq!(b.pull_pcm(&mut pcm_b).unwrap(), 2);
+        assert_eq!(pcm_a, [6.0, -6.0]);
+        assert_eq!(pcm_b, [15.0, -15.0]);
     }
 }

--- a/crates/vokra-models/src/codec.rs
+++ b/crates/vokra-models/src/codec.rs
@@ -27,12 +27,13 @@
 //! `AttributionRequired` = admitted with attribution; DAC is `Permissive`).
 
 use std::sync::Arc;
-use vokra_core::gguf::{GgmlType, GgufFile};
+use vokra_core::gguf::{GgmlType, GgufFile, GgufMetadataValue};
 
 use vokra_core::{CodecDecoderEngine, CodecDecoderHandle, Result, VokraError};
-use vokra_ops::{CodebookTable, DacOutProj, DacRvqAttrs, MimiRvqAttrs};
+use vokra_ops::{CodebookTable, DacOutProj, DacRvqAttrs, MimiRvqAttrs, group_fsq_decode_into};
 
 use crate::mimi::{MimiDecoderState, MimiNeuralConfig, MimiNeuralDecoder};
+use crate::nanocodec::{CausalHifiGan, CausalHifiGanState};
 
 /// Reads a `u32` metadata key or fails loudly.
 fn get_u32(file: &GgufFile, key: &str) -> Result<u32> {
@@ -45,6 +46,41 @@ fn get_u32(file: &GgufFile, key: &str) -> Result<u32> {
              `vokra-cli convert --model mimi|dac`?)"
         ))),
     }
+}
+
+/// Reads a non-empty `u32` metadata array or fails loudly.
+fn get_u32_array(file: &GgufFile, key: &str) -> Result<Vec<u32>> {
+    let values = match file.get(key) {
+        Some(GgufMetadataValue::Array(array)) => &array.values,
+        Some(_) => {
+            return Err(VokraError::ModelLoad(format!(
+                "codec GGUF: metadata `{key}` is not an array"
+            )));
+        }
+        None => {
+            return Err(VokraError::ModelLoad(format!(
+                "codec GGUF: required metadata `{key}` missing"
+            )));
+        }
+    };
+    if values.is_empty() {
+        return Err(VokraError::ModelLoad(format!(
+            "codec GGUF: metadata array `{key}` is empty"
+        )));
+    }
+    values
+        .iter()
+        .map(|value| {
+            value
+                .as_u64()
+                .and_then(|value| u32::try_from(value).ok())
+                .ok_or_else(|| {
+                    VokraError::ModelLoad(format!(
+                        "codec GGUF: metadata array `{key}` contains a non-u32 value"
+                    ))
+                })
+        })
+        .collect()
 }
 
 /// Reads an F32 tensor's raw data + dimensions or fails loudly.
@@ -304,6 +340,198 @@ impl CodecDecoderHandle for MimiStreamingDecoder {
 
     fn reset(&mut self) -> Result<()> {
         self.state = self.decoder.state(1)?;
+        self.features.fill(0.0);
+        self.pcm.fill(0.0);
+        self.pending = false;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// NanoCodec
+// ---------------------------------------------------------------------------
+
+/// Complete NVIDIA NanoCodec grouped-FSQ-to-PCM streaming engine.
+///
+/// Immutable causal HiFi-GAN weights and quantizer geometry are shared across
+/// handles. Each opened handle owns independent causal state and fixed-size
+/// feature/PCM scratch buffers.
+#[derive(Clone)]
+pub struct NanoCodecStreamingCodec {
+    levels_per_group: Arc<Vec<u32>>,
+    n_codebooks: usize,
+    decoder: Arc<CausalHifiGan>,
+    sample_rate: u32,
+    frame_hop: usize,
+}
+
+impl std::fmt::Debug for NanoCodecStreamingCodec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NanoCodecStreamingCodec")
+            .field("levels_per_group", &self.levels_per_group)
+            .field("n_codebooks", &self.n_codebooks)
+            .field("sample_rate", &self.sample_rate)
+            .field("frame_hop", &self.frame_hop)
+            .finish_non_exhaustive()
+    }
+}
+
+impl NanoCodecStreamingCodec {
+    /// Binds the exact decoder-only GGUF emitted by the NanoCodec converter.
+    pub fn from_gguf(file: &GgufFile) -> Result<Self> {
+        let decoder = CausalHifiGan::from_gguf(file)?;
+        let n_codebooks = get_u32(file, "vokra.nanocodec.n_codebooks")? as usize;
+        let levels_per_group = get_u32_array(file, "vokra.nanocodec.levels_per_group")?;
+        let sample_rate = get_u32(file, "vokra.nanocodec.sample_rate")?;
+        Self::new(n_codebooks, levels_per_group, decoder, sample_rate)
+    }
+
+    /// Builds an engine from validated grouped-FSQ geometry and decoder
+    /// weights. Public for deterministic synthesized-weight tests.
+    pub fn new(
+        n_codebooks: usize,
+        levels_per_group: Vec<u32>,
+        decoder: CausalHifiGan,
+        sample_rate: u32,
+    ) -> Result<Self> {
+        if n_codebooks == 0 || levels_per_group.is_empty() || sample_rate == 0 {
+            return Err(VokraError::ModelLoad(
+                "nanocodec streaming codec: codebooks, scalar dimensions, and sample rate must be non-zero"
+                    .to_owned(),
+            ));
+        }
+        if levels_per_group.iter().any(|&level| level < 2) {
+            return Err(VokraError::ModelLoad(
+                "nanocodec streaming codec: levels_per_group entries must each be >= 2".to_owned(),
+            ));
+        }
+        levels_per_group.iter().try_fold(1usize, |vocab, &level| {
+            vocab.checked_mul(level as usize).ok_or_else(|| {
+                VokraError::ModelLoad(
+                    "nanocodec streaming codec: grouped-FSQ vocabulary overflows usize".to_owned(),
+                )
+            })
+        })?;
+        let feature_dim = n_codebooks
+            .checked_mul(levels_per_group.len())
+            .ok_or_else(|| {
+                VokraError::ModelLoad(
+                    "nanocodec streaming codec: feature dimension overflows usize".to_owned(),
+                )
+            })?;
+        if feature_dim != decoder.expected_feature_dim() {
+            return Err(VokraError::ModelLoad(format!(
+                "nanocodec streaming codec: n_codebooks {n_codebooks} * scalar dimensions {} = {feature_dim}, decoder expects {}",
+                levels_per_group.len(),
+                decoder.expected_feature_dim()
+            )));
+        }
+        let frame_hop = decoder.frame_hop();
+        Ok(Self {
+            levels_per_group: Arc::new(levels_per_group),
+            n_codebooks,
+            decoder: Arc::new(decoder),
+            sample_rate,
+            frame_hop,
+        })
+    }
+}
+
+impl CodecDecoderEngine for NanoCodecStreamingCodec {
+    fn open_decoder(&self) -> Result<Box<dyn CodecDecoderHandle + Send>> {
+        Ok(Box::new(NanoCodecStreamingDecoder {
+            state: self.decoder.state(1)?,
+            features: vec![0.0; self.decoder.expected_feature_dim()],
+            pcm: vec![0.0; self.frame_hop],
+            pending: false,
+            levels_per_group: Arc::clone(&self.levels_per_group),
+            n_codebooks: self.n_codebooks,
+            decoder: Arc::clone(&self.decoder),
+            sample_rate: self.sample_rate,
+            frame_hop: self.frame_hop,
+        }))
+    }
+}
+
+/// One independently stateful NanoCodec decoder handle.
+struct NanoCodecStreamingDecoder {
+    state: CausalHifiGanState,
+    features: Vec<f32>,
+    pcm: Vec<f32>,
+    pending: bool,
+    levels_per_group: Arc<Vec<u32>>,
+    n_codebooks: usize,
+    decoder: Arc<CausalHifiGan>,
+    sample_rate: u32,
+    frame_hop: usize,
+}
+
+impl CodecDecoderHandle for NanoCodecStreamingDecoder {
+    fn frame_hop(&self) -> usize {
+        self.frame_hop
+    }
+
+    fn sample_rate(&self) -> u32 {
+        self.sample_rate
+    }
+
+    fn n_codebooks(&self) -> usize {
+        self.n_codebooks
+    }
+
+    // ZERO-ALLOC-BEGIN — caller-owned grouped-FSQ and causal decoder scratch.
+    fn push_codes(&mut self, codes: &[u32]) -> Result<usize> {
+        if codes.len() != self.n_codebooks {
+            return Err(VokraError::InvalidArgument(format!(
+                "nanocodec push: n_codebooks {} != checkpoint {}",
+                codes.len(),
+                self.n_codebooks
+            )));
+        }
+        if self.pending {
+            return Err(VokraError::InvalidArgument(
+                "nanocodec push: pull the pending PCM frame before pushing another code frame"
+                    .into(),
+            ));
+        }
+        group_fsq_decode_into(
+            codes,
+            1,
+            self.levels_per_group.as_slice(),
+            &mut self.features,
+        )?;
+        let written = self
+            .decoder
+            .decode_into(&mut self.state, &self.features, &mut self.pcm)?;
+        if written != self.frame_hop {
+            return Err(VokraError::InvalidArgument(format!(
+                "nanocodec decoder wrote {written} samples, expected frame hop {}",
+                self.frame_hop
+            )));
+        }
+        self.pending = true;
+        Ok(1)
+    }
+
+    fn pull_pcm(&mut self, out: &mut [f32]) -> Result<usize> {
+        if !self.pending {
+            return Ok(0);
+        }
+        if out.len() < self.frame_hop {
+            return Err(VokraError::InvalidArgument(format!(
+                "nanocodec pull: output capacity {} < frame hop {}",
+                out.len(),
+                self.frame_hop
+            )));
+        }
+        out[..self.frame_hop].copy_from_slice(&self.pcm);
+        self.pending = false;
+        Ok(self.frame_hop)
+    }
+    // ZERO-ALLOC-END
+
+    fn reset(&mut self) -> Result<()> {
+        self.decoder.reset(&mut self.state)?;
         self.features.fill(0.0);
         self.pcm.fill(0.0);
         self.pending = false;

--- a/crates/vokra-models/src/codec.rs
+++ b/crates/vokra-models/src/codec.rs
@@ -403,8 +403,13 @@ impl DacCodecGguf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::nanocodec::{
+        CausalHifiGan, CausalHifiGanConfig, CausalHifiGanConv1dWeights,
+        CausalHifiGanConvTranspose1dWeights, CausalHifiGanHalfSnakeWeights,
+        CausalHifiGanResidualBlockWeights, CausalHifiGanStageWeights, CausalHifiGanWeights,
+    };
     use vokra_core::gguf::GgufBuilder;
-    use vokra_ops::mimi_rvq_decode;
+    use vokra_ops::{group_fsq_decode, mimi_rvq_decode};
 
     /// A hand-assembled Mimi codec GGUF (bypassing the converter — the
     /// converter e2e lives in tests/codec_gguf_roundtrip.rs).
@@ -494,6 +499,59 @@ mod tests {
         )
     }
 
+    fn nanocodec_conv(
+        out_channels: usize,
+        in_channels: usize,
+        kernel: usize,
+    ) -> CausalHifiGanConv1dWeights {
+        let len = out_channels * in_channels * kernel;
+        CausalHifiGanConv1dWeights {
+            weight: (0..len).map(|i| (i as f32 + 1.0) * 0.003).collect(),
+            bias: vec![0.001; out_channels],
+        }
+    }
+
+    fn nanocodec_half_snake(channels: usize) -> CausalHifiGanHalfSnakeWeights {
+        CausalHifiGanHalfSnakeWeights {
+            alpha: vec![0.8; channels / 2],
+            alpha_inv: vec![1.25; channels / 2],
+        }
+    }
+
+    fn synthesized_nanocodec_decoder(input_dim: usize) -> CausalHifiGan {
+        let config = CausalHifiGanConfig {
+            input_dim,
+            base_channels: 2,
+            frame_hop: 2,
+            upsample_rates: vec![2],
+            input_kernel_size: 3,
+            output_kernel_size: 3,
+            resblock_kernel_sizes: vec![3],
+            resblock_dilations: vec![1],
+        };
+        let residual = CausalHifiGanResidualBlockWeights {
+            input_activation: nanocodec_half_snake(1),
+            input_conv: nanocodec_conv(1, 1, 3),
+            skip_activation: nanocodec_half_snake(1),
+            skip_conv: nanocodec_conv(1, 1, 3),
+            dilation: 1,
+        };
+        let weights = CausalHifiGanWeights {
+            pre_conv: nanocodec_conv(2, input_dim, 3),
+            stages: vec![CausalHifiGanStageWeights {
+                activation: nanocodec_half_snake(2),
+                upsample: CausalHifiGanConvTranspose1dWeights {
+                    weight: (0..8).map(|i| (i as f32 + 1.0) * 0.002).collect(),
+                    bias: vec![0.001],
+                },
+                residual_branches: vec![vec![residual]],
+            }],
+            post_activation: nanocodec_half_snake(1),
+            post_conv: nanocodec_conv(1, 1, 3),
+        };
+        CausalHifiGan::new(config, weights).expect("tiny NanoCodec decoder")
+    }
+
     #[test]
     fn mimi_successive_pushes_are_bit_identical_to_whole_decode() {
         let seed = 0x48;
@@ -547,6 +605,72 @@ mod tests {
         let mut exact = vec![0.0; stream.frame_hop()];
         assert_eq!(stream.pull_pcm(&mut exact).unwrap(), exact.len());
         assert_eq!(stream.pull_pcm(&mut exact).unwrap(), 0);
+    }
+
+    #[test]
+    fn nanocodec_successive_pushes_are_bit_identical_to_whole_decode_and_reset() {
+        let levels = vec![4, 3];
+        let n_codebooks = 2;
+        let feature_dim = n_codebooks * levels.len();
+        let codes = vec![0, 1, 11, 3, 2, 5];
+        let frames = codes.len() / n_codebooks;
+        let features = group_fsq_decode(&codes, frames, &levels).unwrap();
+        let reference = synthesized_nanocodec_decoder(feature_dim)
+            .decode_all(&features)
+            .unwrap();
+        let engine = NanoCodecStreamingCodec::new(
+            n_codebooks,
+            levels,
+            synthesized_nanocodec_decoder(feature_dim),
+            22_050,
+        )
+        .unwrap();
+
+        let mut stream = engine.open_decoder().unwrap();
+        let mut got = Vec::with_capacity(reference.len());
+        let mut pcm = vec![0.0; stream.frame_hop()];
+        for code_frame in codes.chunks_exact(stream.n_codebooks()) {
+            assert_eq!(stream.push_codes(code_frame).unwrap(), 1);
+            let written = stream.pull_pcm(&mut pcm).unwrap();
+            got.extend_from_slice(&pcm[..written]);
+        }
+        assert_eq!(got, reference);
+
+        stream.reset().unwrap();
+        assert_eq!(stream.push_codes(&codes[..n_codebooks]).unwrap(), 1);
+        assert_eq!(stream.pull_pcm(&mut pcm).unwrap(), pcm.len());
+        assert_eq!(&pcm, &reference[..pcm.len()]);
+    }
+
+    #[test]
+    fn nanocodec_shape_code_range_and_backpressure_fail_loudly() {
+        let engine =
+            NanoCodecStreamingCodec::new(2, vec![4, 3], synthesized_nanocodec_decoder(4), 22_050)
+                .unwrap();
+        let mut stream = engine.open_decoder().unwrap();
+        assert!(matches!(
+            stream.push_codes(&[0]),
+            Err(VokraError::InvalidArgument(_))
+        ));
+        assert!(matches!(
+            stream.push_codes(&[0, 12]),
+            Err(VokraError::InvalidArgument(_))
+        ));
+        assert_eq!(stream.push_codes(&[0, 1]).unwrap(), 1);
+        assert!(matches!(
+            stream.push_codes(&[0, 1]),
+            Err(VokraError::InvalidArgument(_))
+        ));
+        let mut short = vec![0.0; stream.frame_hop() - 1];
+        assert!(matches!(
+            stream.pull_pcm(&mut short),
+            Err(VokraError::InvalidArgument(_))
+        ));
+
+        let err =
+            NanoCodecStreamingCodec::new(2, vec![4, 3], synthesized_nanocodec_decoder(3), 22_050)
+                .expect_err("feature geometry mismatch must be rejected");
+        assert!(matches!(err, VokraError::ModelLoad(_)));
     }
 
     #[test]

--- a/crates/vokra-models/src/codec.rs
+++ b/crates/vokra-models/src/codec.rs
@@ -26,9 +26,13 @@
 //! `vokra_core::check_weight_license` path first (Mimi is
 //! `AttributionRequired` = admitted with attribution; DAC is `Permissive`).
 
+use std::sync::Arc;
 use vokra_core::gguf::{GgmlType, GgufFile};
-use vokra_core::{Result, VokraError};
+
+use vokra_core::{CodecDecoderEngine, CodecDecoderHandle, Result, VokraError};
 use vokra_ops::{CodebookTable, DacOutProj, DacRvqAttrs, MimiRvqAttrs};
+
+use crate::mimi::{MimiDecoderState, MimiNeuralConfig, MimiNeuralDecoder};
 
 /// Reads a `u32` metadata key or fails loudly.
 fn get_u32(file: &GgufFile, key: &str) -> Result<u32> {
@@ -119,6 +123,191 @@ impl MimiCodecGguf {
             tables.push(CodebookTable::new(codebook_size, d_model, slice)?);
         }
         Ok(Self { attrs, tables })
+    }
+}
+
+/// Complete standalone Mimi token-to-PCM engine used by the generic streaming
+/// codec surface. The immutable tables and neural weights are shared by every
+/// opened handle; causal state and scratch buffers are handle-local.
+#[derive(Clone)]
+pub struct MimiStreamingCodec {
+    tables: Arc<Vec<CodebookTable>>,
+    attrs: MimiRvqAttrs,
+    decoder: Arc<MimiNeuralDecoder>,
+    sample_rate: u32,
+    frame_hop: usize,
+}
+
+impl std::fmt::Debug for MimiStreamingCodec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MimiStreamingCodec")
+            .field("attrs", &self.attrs)
+            .field("sample_rate", &self.sample_rate)
+            .field("frame_hop", &self.frame_hop)
+            .finish_non_exhaustive()
+    }
+}
+
+impl MimiStreamingCodec {
+    /// Binds a standalone Mimi GGUF into a complete streaming decoder.
+    ///
+    /// The standalone converter emits effective (already output-projected)
+    /// codebook tables, so their width must equal the neural decoder's input
+    /// width. A mixed or partial GGUF is rejected before a handle is exposed.
+    pub fn from_gguf(file: &GgufFile) -> Result<Self> {
+        let config = MimiNeuralConfig::from_gguf(file)?;
+        config.validate()?;
+        let codec = MimiCodecGguf::from_gguf(file)?;
+        let decoder = MimiNeuralDecoder::from_gguf(file, &config)?;
+        Self::new(codec, decoder, config.sample_rate)
+    }
+
+    /// Builds the engine from already-bound components. Public to support
+    /// deterministic synthesized-weight tests without fabricating source
+    /// checkpoint provenance.
+    pub fn new(codec: MimiCodecGguf, decoder: MimiNeuralDecoder, sample_rate: u32) -> Result<Self> {
+        if codec.attrs.n_codebooks == 0 || codec.tables.len() != codec.attrs.n_codebooks {
+            return Err(VokraError::ModelLoad(format!(
+                "mimi streaming codec: {} tables != n_codebooks {}",
+                codec.tables.len(),
+                codec.attrs.n_codebooks
+            )));
+        }
+        if codec.attrs.d_model != decoder.expected_feature_dim() {
+            return Err(VokraError::ModelLoad(format!(
+                "mimi streaming codec: effective codebook width {} != decoder input width {}",
+                codec.attrs.d_model,
+                decoder.expected_feature_dim()
+            )));
+        }
+        if decoder.config().quantizer.n_q != codec.attrs.n_codebooks {
+            return Err(VokraError::ModelLoad(format!(
+                "mimi streaming codec: decoder n_q {} != codebook count {}",
+                decoder.config().quantizer.n_q,
+                codec.attrs.n_codebooks
+            )));
+        }
+        if decoder.config().quantizer.bins != codec.attrs.codebook_size {
+            return Err(VokraError::ModelLoad(format!(
+                "mimi streaming codec: decoder bins {} != codebook size {}",
+                decoder.config().quantizer.bins,
+                codec.attrs.codebook_size
+            )));
+        }
+        if sample_rate == 0 || sample_rate != decoder.config().sample_rate {
+            return Err(VokraError::ModelLoad(format!(
+                "mimi streaming codec: sample rate {sample_rate} != decoder sample rate {}",
+                decoder.config().sample_rate
+            )));
+        }
+        let frame_hop = decoder.frame_hop()?;
+        Ok(Self {
+            tables: Arc::new(codec.tables),
+            attrs: codec.attrs,
+            decoder: Arc::new(decoder),
+            sample_rate,
+            frame_hop,
+        })
+    }
+}
+
+impl CodecDecoderEngine for MimiStreamingCodec {
+    fn open_decoder(&self) -> Result<Box<dyn CodecDecoderHandle + Send>> {
+        Ok(Box::new(MimiStreamingDecoder {
+            state: self.decoder.state(1)?,
+            features: vec![0.0; self.attrs.d_model],
+            pcm: vec![0.0; self.frame_hop],
+            pending: false,
+            tables: Arc::clone(&self.tables),
+            attrs: self.attrs,
+            decoder: Arc::clone(&self.decoder),
+            sample_rate: self.sample_rate,
+            frame_hop: self.frame_hop,
+        }))
+    }
+}
+
+/// One independently stateful Mimi decoder handle.
+struct MimiStreamingDecoder {
+    // Drop state/scratch before the shared immutable model fields below.
+    state: MimiDecoderState,
+    features: Vec<f32>,
+    pcm: Vec<f32>,
+    pending: bool,
+    tables: Arc<Vec<CodebookTable>>,
+    attrs: MimiRvqAttrs,
+    decoder: Arc<MimiNeuralDecoder>,
+    sample_rate: u32,
+    frame_hop: usize,
+}
+
+impl CodecDecoderHandle for MimiStreamingDecoder {
+    fn frame_hop(&self) -> usize {
+        self.frame_hop
+    }
+
+    fn sample_rate(&self) -> u32 {
+        self.sample_rate
+    }
+
+    fn n_codebooks(&self) -> usize {
+        self.attrs.n_codebooks
+    }
+
+    // ZERO-ALLOC-BEGIN — warmed successful code-frame decode; scratch and
+    // causal state are allocated by open/reset. Guarded by
+    // scripts/check-hot-path-allocs.sh and the counting-allocator test below.
+    fn push_codes(&mut self, codes: &[u32]) -> Result<usize> {
+        if codes.len() != self.attrs.n_codebooks {
+            return Err(VokraError::InvalidArgument(format!(
+                "mimi codec push: n_codebooks {} != checkpoint {}",
+                codes.len(),
+                self.attrs.n_codebooks
+            )));
+        }
+        if self.pending {
+            return Err(VokraError::InvalidArgument(
+                "mimi codec push: pull the pending PCM frame before pushing another code frame"
+                    .into(),
+            ));
+        }
+
+        self.features.fill(0.0);
+        for (cb, &index) in codes.iter().enumerate() {
+            let row = self.tables[cb].row(index)?;
+            for (dst, src) in self.features.iter_mut().zip(row) {
+                *dst += *src;
+            }
+        }
+        self.decoder
+            .decode_into(&mut self.state, &self.features, &mut self.pcm)?;
+        self.pending = true;
+        Ok(1)
+    }
+
+    fn pull_pcm(&mut self, out: &mut [f32]) -> Result<usize> {
+        if !self.pending {
+            return Ok(0);
+        }
+        if out.len() < self.frame_hop {
+            return Err(VokraError::InvalidArgument(format!(
+                "mimi codec pull: output capacity {} < frame hop {}",
+                out.len(),
+                self.frame_hop
+            )));
+        }
+        out[..self.frame_hop].copy_from_slice(&self.pcm);
+        self.pending = false;
+        Ok(self.frame_hop)
+    }
+    // ZERO-ALLOC-END
+
+    fn reset(&mut self) -> Result<()> {
+        self.state = self.decoder.state(1)?;
+        self.features.fill(0.0);
+        self.pcm.fill(0.0);
+        self.pending = false;
+        Ok(())
     }
 }
 
@@ -215,6 +404,7 @@ impl DacCodecGguf {
 mod tests {
     use super::*;
     use vokra_core::gguf::GgufBuilder;
+    use vokra_ops::mimi_rvq_decode;
 
     /// A hand-assembled Mimi codec GGUF (bypassing the converter — the
     /// converter e2e lives in tests/codec_gguf_roundtrip.rs).
@@ -277,6 +467,86 @@ mod tests {
             MimiCodecGguf::from_gguf(&file),
             Err(VokraError::ModelLoad(_))
         ));
+    }
+
+    fn synthesized_streaming_codec(seed: u64) -> (MimiStreamingCodec, MimiCodecGguf) {
+        let cfg = MimiNeuralConfig::tiny_for_tests();
+        let tables = (0..cfg.quantizer.n_q)
+            .map(|cb| {
+                let values = (0..cfg.quantizer.bins * cfg.seanet.dimension)
+                    .map(|i| ((cb * 97 + i) as f32 - 40.0) * 0.002)
+                    .collect();
+                CodebookTable::new(cfg.quantizer.bins, cfg.seanet.dimension, values).unwrap()
+            })
+            .collect::<Vec<_>>();
+        let codec = MimiCodecGguf {
+            attrs: MimiRvqAttrs {
+                n_codebooks: cfg.quantizer.n_q,
+                codebook_size: cfg.quantizer.bins,
+                d_model: cfg.seanet.dimension,
+            },
+            tables,
+        };
+        let neural = MimiNeuralDecoder::synthesized(&cfg, seed, false).unwrap();
+        (
+            MimiStreamingCodec::new(codec.clone(), neural, cfg.sample_rate).unwrap(),
+            codec,
+        )
+    }
+
+    #[test]
+    fn mimi_successive_pushes_are_bit_identical_to_whole_decode() {
+        let seed = 0x48;
+        let (engine, codec) = synthesized_streaming_codec(seed);
+        let cfg = MimiNeuralConfig::tiny_for_tests();
+        let codes = vec![0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3];
+        let frames = codes.len() / codec.attrs.n_codebooks;
+        let features = mimi_rvq_decode(&codes, frames, &codec.tables, &codec.attrs).unwrap();
+        let reference = MimiNeuralDecoder::synthesized(&cfg, seed, false)
+            .unwrap()
+            .decode_all(&features)
+            .unwrap();
+
+        let mut stream = engine.open_decoder().unwrap();
+        let mut got = Vec::with_capacity(reference.len());
+        let mut frame = vec![0.0; stream.frame_hop()];
+        for code_frame in codes.chunks_exact(stream.n_codebooks()) {
+            assert_eq!(stream.push_codes(code_frame).unwrap(), 1);
+            let written = stream.pull_pcm(&mut frame).unwrap();
+            assert_eq!(written, stream.frame_hop());
+            got.extend_from_slice(&frame[..written]);
+        }
+        assert_eq!(got, reference);
+
+        stream.reset().unwrap();
+        let n_codebooks = stream.n_codebooks();
+        assert_eq!(stream.push_codes(&codes[..n_codebooks]).unwrap(), 1);
+        stream.pull_pcm(&mut frame).unwrap();
+        let frame_hop = stream.frame_hop();
+        assert_eq!(&frame[..], &reference[..frame_hop]);
+    }
+
+    #[test]
+    fn mimi_streaming_shape_and_backpressure_fail_loudly() {
+        let (engine, _) = synthesized_streaming_codec(9);
+        let mut stream = engine.open_decoder().unwrap();
+        assert!(matches!(
+            stream.push_codes(&[0, 1]),
+            Err(VokraError::InvalidArgument(_))
+        ));
+        assert_eq!(stream.push_codes(&[0, 1, 2]).unwrap(), 1);
+        assert!(matches!(
+            stream.push_codes(&[0, 1, 2]),
+            Err(VokraError::InvalidArgument(_))
+        ));
+        let mut short = vec![0.0; stream.frame_hop() - 1];
+        assert!(matches!(
+            stream.pull_pcm(&mut short),
+            Err(VokraError::InvalidArgument(_))
+        ));
+        let mut exact = vec![0.0; stream.frame_hop()];
+        assert_eq!(stream.pull_pcm(&mut exact).unwrap(), exact.len());
+        assert_eq!(stream.pull_pcm(&mut exact).unwrap(), 0);
     }
 
     #[test]

--- a/crates/vokra-models/tests/codec_decoder_hot_path_alloc.rs
+++ b/crates/vokra-models/tests/codec_decoder_hot_path_alloc.rs
@@ -1,0 +1,101 @@
+//! #48: allocation-count proof for the generic codec handle's warmed
+//! `push_codes` + `pull_pcm` success path.
+
+#![allow(unsafe_code)]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use vokra_core::{CodecDecoderEngine, CodecDecoderHandle};
+use vokra_models::codec::{MimiCodecGguf, MimiStreamingCodec};
+use vokra_models::mimi::{MimiNeuralConfig, MimiNeuralDecoder};
+use vokra_ops::{CodebookTable, MimiRvqAttrs};
+
+struct CountingAlloc;
+static MEASURED_ALLOCS: AtomicUsize = AtomicUsize::new(0);
+
+thread_local! {
+    static MEASURING: Cell<bool> = const { Cell::new(false) };
+}
+
+fn count_if_measuring() {
+    if MEASURING.try_with(Cell::get).unwrap_or(false) {
+        MEASURED_ALLOCS.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+// SAFETY: every operation delegates unchanged to the system allocator; the
+// extra accounting is an allocation-free atomic increment on the measuring
+// thread only.
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        count_if_measuring();
+        // SAFETY: exact delegation of the requested layout.
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        // SAFETY: exact delegation of the pointer and its original layout.
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        count_if_measuring();
+        // SAFETY: exact delegation of the pointer/layout/new size.
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAlloc = CountingAlloc;
+
+fn fixture() -> Box<dyn CodecDecoderHandle + Send> {
+    let cfg = MimiNeuralConfig::tiny_for_tests();
+    let tables = (0..cfg.quantizer.n_q)
+        .map(|cb| {
+            let data = (0..cfg.quantizer.bins * cfg.seanet.dimension)
+                .map(|i| ((cb * 29 + i) as f32 - 20.0) * 0.001)
+                .collect();
+            CodebookTable::new(cfg.quantizer.bins, cfg.seanet.dimension, data).unwrap()
+        })
+        .collect::<Vec<_>>();
+    let codec = MimiCodecGguf {
+        attrs: MimiRvqAttrs {
+            n_codebooks: cfg.quantizer.n_q,
+            codebook_size: cfg.quantizer.bins,
+            d_model: cfg.seanet.dimension,
+        },
+        tables,
+    };
+    let neural = MimiNeuralDecoder::synthesized(&cfg, 48, false).unwrap();
+    MimiStreamingCodec::new(codec, neural, cfg.sample_rate)
+        .unwrap()
+        .open_decoder()
+        .unwrap()
+}
+
+#[test]
+fn warmed_push_and_pull_allocate_nothing() {
+    let mut decoder = fixture();
+    let codes = vec![1u32; decoder.n_codebooks()];
+    let mut pcm = vec![0.0f32; decoder.frame_hop()];
+
+    // Warm backend dispatch and every lazy one-time path before measuring.
+    decoder.push_codes(&codes).unwrap();
+    decoder.pull_pcm(&mut pcm).unwrap();
+
+    MEASURED_ALLOCS.store(0, Ordering::SeqCst);
+    MEASURING.with(|flag| flag.set(true));
+    for _ in 0..16 {
+        assert_eq!(decoder.push_codes(&codes).unwrap(), 1);
+        assert_eq!(decoder.pull_pcm(&mut pcm).unwrap(), pcm.len());
+    }
+    MEASURING.with(|flag| flag.set(false));
+
+    assert_eq!(
+        MEASURED_ALLOCS.load(Ordering::SeqCst),
+        0,
+        "warmed generic codec push+pull must allocate nothing"
+    );
+}

--- a/crates/vokra-models/tests/codec_decoder_hot_path_alloc.rs
+++ b/crates/vokra-models/tests/codec_decoder_hot_path_alloc.rs
@@ -8,8 +8,13 @@ use std::cell::Cell;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use vokra_core::{CodecDecoderEngine, CodecDecoderHandle};
-use vokra_models::codec::{MimiCodecGguf, MimiStreamingCodec};
+use vokra_models::codec::{MimiCodecGguf, MimiStreamingCodec, NanoCodecStreamingCodec};
 use vokra_models::mimi::{MimiNeuralConfig, MimiNeuralDecoder};
+use vokra_models::nanocodec::{
+    CausalHifiGan, CausalHifiGanConfig, CausalHifiGanConv1dWeights,
+    CausalHifiGanConvTranspose1dWeights, CausalHifiGanHalfSnakeWeights,
+    CausalHifiGanResidualBlockWeights, CausalHifiGanStageWeights, CausalHifiGanWeights,
+};
 use vokra_ops::{CodebookTable, MimiRvqAttrs};
 
 struct CountingAlloc;
@@ -75,27 +80,89 @@ fn fixture() -> Box<dyn CodecDecoderHandle + Send> {
         .unwrap()
 }
 
+fn nanocodec_conv(
+    out_channels: usize,
+    in_channels: usize,
+    kernel: usize,
+) -> CausalHifiGanConv1dWeights {
+    CausalHifiGanConv1dWeights {
+        weight: (0..out_channels * in_channels * kernel)
+            .map(|i| (i as f32 + 1.0) * 0.003)
+            .collect(),
+        bias: vec![0.001; out_channels],
+    }
+}
+
+fn nanocodec_half_snake(channels: usize) -> CausalHifiGanHalfSnakeWeights {
+    CausalHifiGanHalfSnakeWeights {
+        alpha: vec![0.8; channels / 2],
+        alpha_inv: vec![1.25; channels / 2],
+    }
+}
+
+fn nanocodec_fixture() -> Box<dyn CodecDecoderHandle + Send> {
+    let config = CausalHifiGanConfig {
+        input_dim: 1,
+        base_channels: 2,
+        frame_hop: 2,
+        upsample_rates: vec![2],
+        input_kernel_size: 3,
+        output_kernel_size: 3,
+        resblock_kernel_sizes: vec![3],
+        resblock_dilations: vec![1],
+    };
+    let residual = CausalHifiGanResidualBlockWeights {
+        input_activation: nanocodec_half_snake(1),
+        input_conv: nanocodec_conv(1, 1, 3),
+        skip_activation: nanocodec_half_snake(1),
+        skip_conv: nanocodec_conv(1, 1, 3),
+        dilation: 1,
+    };
+    let decoder = CausalHifiGan::new(
+        config,
+        CausalHifiGanWeights {
+            pre_conv: nanocodec_conv(2, 1, 3),
+            stages: vec![CausalHifiGanStageWeights {
+                activation: nanocodec_half_snake(2),
+                upsample: CausalHifiGanConvTranspose1dWeights {
+                    weight: (0..8).map(|i| (i as f32 + 1.0) * 0.002).collect(),
+                    bias: vec![0.001],
+                },
+                residual_branches: vec![vec![residual]],
+            }],
+            post_activation: nanocodec_half_snake(1),
+            post_conv: nanocodec_conv(1, 1, 3),
+        },
+    )
+    .unwrap();
+    NanoCodecStreamingCodec::new(1, vec![4], decoder, 22_050)
+        .unwrap()
+        .open_decoder()
+        .unwrap()
+}
+
 #[test]
 fn warmed_push_and_pull_allocate_nothing() {
-    let mut decoder = fixture();
-    let codes = vec![1u32; decoder.n_codebooks()];
-    let mut pcm = vec![0.0f32; decoder.frame_hop()];
+    for mut decoder in [fixture(), nanocodec_fixture()] {
+        let codes = vec![1u32; decoder.n_codebooks()];
+        let mut pcm = vec![0.0f32; decoder.frame_hop()];
 
-    // Warm backend dispatch and every lazy one-time path before measuring.
-    decoder.push_codes(&codes).unwrap();
-    decoder.pull_pcm(&mut pcm).unwrap();
+        // Warm backend dispatch and every lazy one-time path before measuring.
+        decoder.push_codes(&codes).unwrap();
+        decoder.pull_pcm(&mut pcm).unwrap();
 
-    MEASURED_ALLOCS.store(0, Ordering::SeqCst);
-    MEASURING.with(|flag| flag.set(true));
-    for _ in 0..16 {
-        assert_eq!(decoder.push_codes(&codes).unwrap(), 1);
-        assert_eq!(decoder.pull_pcm(&mut pcm).unwrap(), pcm.len());
+        MEASURED_ALLOCS.store(0, Ordering::SeqCst);
+        MEASURING.with(|flag| flag.set(true));
+        for _ in 0..16 {
+            assert_eq!(decoder.push_codes(&codes).unwrap(), 1);
+            assert_eq!(decoder.pull_pcm(&mut pcm).unwrap(), pcm.len());
+        }
+        MEASURING.with(|flag| flag.set(false));
+
+        assert_eq!(
+            MEASURED_ALLOCS.load(Ordering::SeqCst),
+            0,
+            "warmed generic codec push+pull must allocate nothing"
+        );
     }
-    MEASURING.with(|flag| flag.set(false));
-
-    assert_eq!(
-        MEASURED_ALLOCS.load(Ordering::SeqCst),
-        0,
-        "warmed generic codec push+pull must allocate nothing"
-    );
 }

--- a/docs/abi-changelog.md
+++ b/docs/abi-changelog.md
@@ -366,6 +366,27 @@ NeMo-Speech.cpp commit `4f9676226f667d14608487df744f375db87127f8`.
 No model weights are bundled and this entry makes no publication-license
 claim.
 
+### 2026-08-22 — 1.0.0-rc.1-dev (generic streaming codec decoder C ABI, issue #48)
+
+Additive prerelease C ABI and Rust engine contract. Codebook count is loaded
+from the GGUF and repeated as a call-time argument; no codec topology is frozen
+into the header. Each opaque decoder is single-owner-thread state retaining its
+source session. Standalone Mimi is the first complete implementation; partial
+codec binders do not opt in.
+
+| Crate / area | Symbol | Kind | Signature | Rationale | Breaking? | PR |
+| --- | --- | --- | --- | --- | --- | --- |
+| `include/vokra.h` | `vokra_codec_decoder_t` | Added | opaque struct | Independently owned streaming token-to-PCM state (#48) | no | #TBD |
+| `include/vokra.h` | `vokra_codec_decoder_destroy` | Added | `void vokra_codec_decoder_destroy(struct vokra_codec_decoder_t *decoder)` | Release a decoder handle; NULL-tolerant (#48) | no | #TBD |
+| `include/vokra.h` | `vokra_codec_decoder_frame_hop` | Added | `int32_t vokra_codec_decoder_frame_hop(const struct vokra_codec_decoder_t *decoder)` | Query checkpoint-derived PCM frame size (#48) | no | #TBD |
+| `include/vokra.h` | `vokra_codec_decoder_n_codebooks` | Added | `int32_t vokra_codec_decoder_n_codebooks(const struct vokra_codec_decoder_t *decoder)` | Query model-specific codebook width without an ABI constant (#48) | no | #TBD |
+| `include/vokra.h` | `vokra_codec_decoder_open` | Added | `struct vokra_codec_decoder_t *vokra_codec_decoder_open(const struct vokra_session_t *session)` | Open independent causal codec state (#48) | no | #TBD |
+| `include/vokra.h` | `vokra_codec_decoder_pull_pcm` | Added | `enum vokra_status_t vokra_codec_decoder_pull_pcm(struct vokra_codec_decoder_t *decoder, float *out, size_t capacity, size_t *out_len)` | Copy pending mono PCM without allocation (#48) | no | #TBD |
+| `include/vokra.h` | `vokra_codec_decoder_push_codes` | Added | `enum vokra_status_t vokra_codec_decoder_push_codes(struct vokra_codec_decoder_t *decoder, const uint32_t *codes, size_t n_codebooks, int32_t *out_frames_emitted)` | Push one call-time-shaped code frame (#48) | no | #TBD |
+| `include/vokra.h` | `vokra_codec_decoder_reset` | Added | `void vokra_codec_decoder_reset(struct vokra_codec_decoder_t *decoder)` | Restore as-new causal state (#48) | no | #TBD |
+| `include/vokra.h` | `vokra_codec_decoder_sample_rate` | Added | `int32_t vokra_codec_decoder_sample_rate(const struct vokra_codec_decoder_t *decoder)` | Query checkpoint-derived PCM rate (#48) | no | #TBD |
+| `vokra-core::engines` | `CodecDecoderEngine` / `CodecDecoderHandle` | Added | public traits | Codec-family-neutral session injection and stateful push/pull contract (#48) | no | #TBD |
+
 ### 2026-08-15 — 1.0.0-rc.1-dev (LLaMA-Omni2: the converter now stamps the full `vokra.llama_omni2.*` group its own binder reads, and refuses without `--config` — GGUF schema fill + Rust surface, advisory)
 
 **Behaviour change** plus additive Rust surface. The C ABI

--- a/docs/abi-changelog.md
+++ b/docs/abi-changelog.md
@@ -371,8 +371,8 @@ claim.
 Additive prerelease C ABI and Rust engine contract. Codebook count is loaded
 from the GGUF and repeated as a call-time argument; no codec topology is frozen
 into the header. Each opaque decoder is single-owner-thread state retaining its
-source session. Standalone Mimi is the first complete implementation; partial
-codec binders do not opt in.
+source session. Standalone Mimi and NVIDIA NanoCodec provide complete native
+implementations; partial codec binders do not opt in.
 
 | Crate / area | Symbol | Kind | Signature | Rationale | Breaking? | PR |
 | --- | --- | --- | --- | --- | --- | --- |

--- a/docs/abi-changelog.md
+++ b/docs/abi-changelog.md
@@ -376,16 +376,16 @@ codec binders do not opt in.
 
 | Crate / area | Symbol | Kind | Signature | Rationale | Breaking? | PR |
 | --- | --- | --- | --- | --- | --- | --- |
-| `include/vokra.h` | `vokra_codec_decoder_t` | Added | opaque struct | Independently owned streaming token-to-PCM state (#48) | no | #TBD |
-| `include/vokra.h` | `vokra_codec_decoder_destroy` | Added | `void vokra_codec_decoder_destroy(struct vokra_codec_decoder_t *decoder)` | Release a decoder handle; NULL-tolerant (#48) | no | #TBD |
-| `include/vokra.h` | `vokra_codec_decoder_frame_hop` | Added | `int32_t vokra_codec_decoder_frame_hop(const struct vokra_codec_decoder_t *decoder)` | Query checkpoint-derived PCM frame size (#48) | no | #TBD |
-| `include/vokra.h` | `vokra_codec_decoder_n_codebooks` | Added | `int32_t vokra_codec_decoder_n_codebooks(const struct vokra_codec_decoder_t *decoder)` | Query model-specific codebook width without an ABI constant (#48) | no | #TBD |
-| `include/vokra.h` | `vokra_codec_decoder_open` | Added | `struct vokra_codec_decoder_t *vokra_codec_decoder_open(const struct vokra_session_t *session)` | Open independent causal codec state (#48) | no | #TBD |
-| `include/vokra.h` | `vokra_codec_decoder_pull_pcm` | Added | `enum vokra_status_t vokra_codec_decoder_pull_pcm(struct vokra_codec_decoder_t *decoder, float *out, size_t capacity, size_t *out_len)` | Copy pending mono PCM without allocation (#48) | no | #TBD |
-| `include/vokra.h` | `vokra_codec_decoder_push_codes` | Added | `enum vokra_status_t vokra_codec_decoder_push_codes(struct vokra_codec_decoder_t *decoder, const uint32_t *codes, size_t n_codebooks, int32_t *out_frames_emitted)` | Push one call-time-shaped code frame (#48) | no | #TBD |
-| `include/vokra.h` | `vokra_codec_decoder_reset` | Added | `void vokra_codec_decoder_reset(struct vokra_codec_decoder_t *decoder)` | Restore as-new causal state (#48) | no | #TBD |
-| `include/vokra.h` | `vokra_codec_decoder_sample_rate` | Added | `int32_t vokra_codec_decoder_sample_rate(const struct vokra_codec_decoder_t *decoder)` | Query checkpoint-derived PCM rate (#48) | no | #TBD |
-| `vokra-core::engines` | `CodecDecoderEngine` / `CodecDecoderHandle` | Added | public traits | Codec-family-neutral session injection and stateful push/pull contract (#48) | no | #TBD |
+| `include/vokra.h` | `vokra_codec_decoder_t` | Added | opaque struct | Independently owned streaming token-to-PCM state (#48) | no | #62 |
+| `include/vokra.h` | `vokra_codec_decoder_destroy` | Added | `void vokra_codec_decoder_destroy(struct vokra_codec_decoder_t *decoder)` | Release a decoder handle; NULL-tolerant (#48) | no | #62 |
+| `include/vokra.h` | `vokra_codec_decoder_frame_hop` | Added | `int32_t vokra_codec_decoder_frame_hop(const struct vokra_codec_decoder_t *decoder)` | Query checkpoint-derived PCM frame size (#48) | no | #62 |
+| `include/vokra.h` | `vokra_codec_decoder_n_codebooks` | Added | `int32_t vokra_codec_decoder_n_codebooks(const struct vokra_codec_decoder_t *decoder)` | Query model-specific codebook width without an ABI constant (#48) | no | #62 |
+| `include/vokra.h` | `vokra_codec_decoder_open` | Added | `struct vokra_codec_decoder_t *vokra_codec_decoder_open(const struct vokra_session_t *session)` | Open independent causal codec state (#48) | no | #62 |
+| `include/vokra.h` | `vokra_codec_decoder_pull_pcm` | Added | `enum vokra_status_t vokra_codec_decoder_pull_pcm(struct vokra_codec_decoder_t *decoder, float *out, size_t capacity, size_t *out_len)` | Copy pending mono PCM without allocation (#48) | no | #62 |
+| `include/vokra.h` | `vokra_codec_decoder_push_codes` | Added | `enum vokra_status_t vokra_codec_decoder_push_codes(struct vokra_codec_decoder_t *decoder, const uint32_t *codes, size_t n_codebooks, int32_t *out_frames_emitted)` | Push one call-time-shaped code frame (#48) | no | #62 |
+| `include/vokra.h` | `vokra_codec_decoder_reset` | Added | `void vokra_codec_decoder_reset(struct vokra_codec_decoder_t *decoder)` | Restore as-new causal state (#48) | no | #62 |
+| `include/vokra.h` | `vokra_codec_decoder_sample_rate` | Added | `int32_t vokra_codec_decoder_sample_rate(const struct vokra_codec_decoder_t *decoder)` | Query checkpoint-derived PCM rate (#48) | no | #62 |
+| `vokra-core::engines` | `CodecDecoderEngine` / `CodecDecoderHandle` | Added | public traits | Codec-family-neutral session injection and stateful push/pull contract (#48) | no | #62 |
 
 ### 2026-08-15 — 1.0.0-rc.1-dev (LLaMA-Omni2: the converter now stamps the full `vokra.llama_omni2.*` group its own binder reads, and refuses without `--config` — GGUF schema fill + Rust surface, advisory)
 

--- a/docs/abi/vokra-rust-public-api.v1.0-rc.list
+++ b/docs/abi/vokra-rust-public-api.v1.0-rc.list
@@ -218,6 +218,14 @@ FN vokra-capi::aec::vokra_aec_ref_writer_destroy|pub unsafe extern "C" fn vokra_
 FN vokra-capi::aec::vokra_aec_reset|pub unsafe extern "C" fn vokra_aec_reset(aec: *mut vokra_aec_t) -> vokra_status_t {
 FN vokra-capi::asr::vokra_asr_transcribe|pub unsafe extern "C" fn vokra_asr_transcribe(
 FN vokra-capi::asr::vokra_string_free|pub unsafe extern "C" fn vokra_string_free(s: *mut c_char) {
+FN vokra-capi::codec::vokra_codec_decoder_destroy|pub unsafe extern "C" fn vokra_codec_decoder_destroy(decoder: *mut vokra_codec_decoder_t) {
+FN vokra-capi::codec::vokra_codec_decoder_frame_hop|pub unsafe extern "C" fn vokra_codec_decoder_frame_hop(
+FN vokra-capi::codec::vokra_codec_decoder_n_codebooks|pub unsafe extern "C" fn vokra_codec_decoder_n_codebooks(
+FN vokra-capi::codec::vokra_codec_decoder_open|pub unsafe extern "C" fn vokra_codec_decoder_open(
+FN vokra-capi::codec::vokra_codec_decoder_pull_pcm|pub unsafe extern "C" fn vokra_codec_decoder_pull_pcm(
+FN vokra-capi::codec::vokra_codec_decoder_push_codes|pub unsafe extern "C" fn vokra_codec_decoder_push_codes(
+FN vokra-capi::codec::vokra_codec_decoder_reset|pub unsafe extern "C" fn vokra_codec_decoder_reset(decoder: *mut vokra_codec_decoder_t) {
+FN vokra-capi::codec::vokra_codec_decoder_sample_rate|pub unsafe extern "C" fn vokra_codec_decoder_sample_rate(
 FN vokra-capi::error::vokra_last_error|pub extern "C" fn vokra_last_error() -> *const c_char {
 FN vokra-capi::feature::vokra_feat_destroy|pub unsafe extern "C" fn vokra_feat_destroy(feat: *mut vokra_feat_t) {
 FN vokra-capi::feature::vokra_feat_dim|pub unsafe extern "C" fn vokra_feat_dim(feat: *const vokra_feat_t) -> i32 {
@@ -659,10 +667,12 @@ FN vokra-core::session::gguf|pub fn gguf(&self) -> &GgufFile {
 FN vokra-core::session::kv_quant|pub fn kv_quant(&self) -> KvQuant {
 FN vokra-core::session::model_path|pub fn model_path(&self) -> &Path {
 FN vokra-core::session::open_speech_feature_stream|pub fn open_speech_feature_stream(&self) -> Result<Box<dyn SpeechFeatureStream + Send>> {
+FN vokra-core::session::open_codec_decoder|pub fn open_codec_decoder(&self) -> Result<Box<dyn CodecDecoderHandle + Send>> {
 FN vokra-core::session::open_vad_stream|pub fn open_vad_stream(&self) -> Result<Box<dyn VadStreamHandle + Send>> {
 FN vokra-core::session::with_asr_engine|pub fn with_asr_engine(mut self, engine: Arc<dyn AsrEngine>) -> Self {
 FN vokra-core::session::with_attribution|pub fn with_attribution(mut self, attribution: AttributionInfo) -> Self {
 FN vokra-core::session::with_backend|pub fn with_backend(mut self, backend: BackendKind) -> Result<Session> {
+FN vokra-core::session::with_codec_decoder_engine|pub fn with_codec_decoder_engine(mut self, engine: Arc<dyn CodecDecoderEngine>) -> Self {
 FN vokra-core::session::with_kv_quant|pub fn with_kv_quant(mut self, kv_quant: KvQuant) -> Self {
 FN vokra-core::session::with_s2s_duplex_engine|pub fn with_s2s_duplex_engine(mut self, engine: Arc<dyn S2sDuplexEngine>) -> Self {
 FN vokra-core::session::with_s2s_engine|pub fn with_s2s_engine(mut self, engine: Arc<dyn S2sEngine>) -> Self {
@@ -1220,6 +1230,7 @@ STRUCT vokra-capi::aec::vokra_aec_config_t|pub struct vokra_aec_config_t {
 STRUCT vokra-capi::aec::vokra_aec_ref_writer_t|pub struct vokra_aec_ref_writer_t {
 STRUCT vokra-capi::aec::vokra_aec_t|pub struct vokra_aec_t {
 STRUCT vokra-capi::handle::vokra_feat_t|pub struct vokra_feat_t {
+STRUCT vokra-capi::codec::vokra_codec_decoder_t|pub struct vokra_codec_decoder_t {
 STRUCT vokra-capi::handle::vokra_session_t|pub struct vokra_session_t {
 STRUCT vokra-capi::handle::vokra_stream_t|pub struct vokra_stream_t {
 STRUCT vokra-capi::options::vokra_session_options_t|pub struct vokra_session_options_t {
@@ -1492,6 +1503,8 @@ TRAIT vokra-core::decode::wfst::semiring::Semiring|pub trait Semiring: Copy + Cl
 TRAIT vokra-core::engines::AecEngine|pub trait AecEngine: Send + Sync {
 TRAIT vokra-core::engines::AecStreamHandle|pub trait AecStreamHandle {
 TRAIT vokra-core::engines::AsrEngine|pub trait AsrEngine: Send + Sync {
+TRAIT vokra-core::engines::CodecDecoderEngine|pub trait CodecDecoderEngine: Send + Sync {
+TRAIT vokra-core::engines::CodecDecoderHandle|pub trait CodecDecoderHandle {
 TRAIT vokra-core::engines::DenoiseEngine|pub trait DenoiseEngine: Send + Sync {
 TRAIT vokra-core::engines::DenoiseStreamHandle|pub trait DenoiseStreamHandle {
 TRAIT vokra-core::engines::KwsEngine|pub trait KwsEngine: Send + Sync {
@@ -1545,7 +1558,7 @@ USE vokra-core::decode::wfst::semiring::{Semiring, TropicalWeight}|pub use semir
 USE vokra-core::decode::wfst::{ Arc, Fst, Label, Semiring, StateId, TropicalWeight, WfstDecodeConfig, WfstDecoder, WfstHypothesis, WfstLattice, read_openfst_vector, }|pub use wfst::{ Arc, Fst, Label, Semiring, StateId, TropicalWeight, WfstDecodeConfig, WfstDecoder, WfstHypothesis, WfstLattice, read_openfst_vector, };
 USE vokra-core::decode::word_timing::{ APPEND_PUNCTUATIONS, AlignmentParams, CrossAttention, PREPEND_PUNCTUATIONS, WordTiming, merge_punctuations, token_alignment, words_from_alignment, }|pub use word_timing::{ APPEND_PUNCTUATIONS, AlignmentParams, CrossAttention, PREPEND_PUNCTUATIONS, WordTiming, merge_punctuations, token_alignment, words_from_alignment, };
 USE vokra-core::decode::{ CfgMode, DecodeStepper, LogitsSource, Sampler, SamplerConfig, TOKEN_FLAG_EOT, apply_cfg, apply_cfg_inplace, argmax, sample_sequence, }|pub use decode::{ CfgMode, DecodeStepper, LogitsSource, Sampler, SamplerConfig, TOKEN_FLAG_EOT, apply_cfg, apply_cfg_inplace, argmax, sample_sequence, };
-USE vokra-core::engines::{ AecEngine, AecStreamHandle, AsrEngine, DialogContextTurn, DialogRequest, DuplexInterruptHandle, DuplexPushReport, DuplexSessionConfig, S2sDuplexEngine, S2sDuplexHandle, S2sEngine, SpeakerEngine, SpeechFeatureEngine, SpeechFeatureStream, SynthesisRequest, TtsEngine, TtsStreamHandle, VadEngine, VadStreamHandle, }|pub use engines::{ AecEngine, AecStreamHandle, AsrEngine, DialogContextTurn, DialogRequest, DuplexInterruptHandle, DuplexPushReport, DuplexSessionConfig, S2sDuplexEngine, S2sDuplexHandle, S2sEngine, SpeakerEngine, SpeechFeatureEngine, SpeechFeatureStream, SynthesisRequest, TtsEngine, TtsStreamHandle, VadEngine, VadStreamHandle, };
+USE vokra-core::engines::{ AecEngine, AecStreamHandle, AsrEngine, CodecDecoderEngine, CodecDecoderHandle, DialogContextTurn, DialogRequest, DuplexInterruptHandle, DuplexPushReport, DuplexSessionConfig, S2sDuplexEngine, S2sDuplexHandle, S2sEngine, SpeakerEngine, SpeechFeatureEngine, SpeechFeatureStream, SynthesisRequest, TtsEngine, TtsStreamHandle, VadEngine, VadStreamHandle, }|pub use engines::{ AecEngine, AecStreamHandle, AsrEngine, CodecDecoderEngine, CodecDecoderHandle, DialogContextTurn, DialogRequest, DuplexInterruptHandle, DuplexPushReport, DuplexSessionConfig, S2sDuplexEngine, S2sDuplexHandle, S2sEngine, SpeakerEngine, SpeechFeatureEngine, SpeechFeatureStream, SynthesisRequest, TtsEngine, TtsStreamHandle, VadEngine, VadStreamHandle, };
 USE vokra-core::error::{Result, VokraError}|pub use error::{Result, VokraError};
 USE vokra-core::gguf::frontend_spec::{FieldMismatch, FrontendPolicy, FrontendSpec}|pub use frontend_spec::{FieldMismatch, FrontendPolicy, FrontendSpec};
 USE vokra-core::gguf::reader::{AsBytes, GgufFile}|pub use reader::{AsBytes, GgufFile};

--- a/docs/c-api-streaming-codec.md
+++ b/docs/c-api-streaming-codec.md
@@ -1,0 +1,46 @@
+# Streaming codec decoder C API
+
+The `vokra_codec_decoder_*` surface lets an application run its acoustic model
+elsewhere and use Vokra only for the stateful codec/vocoder half: one complete
+codebook frame goes in, one mono PCM frame comes out.
+
+## Ownership and threads
+
+Each successful `vokra_codec_decoder_open(session)` returns an independent
+causal state machine and retains the model session internally. The original
+`vokra_session_t` may be destroyed after open without invalidating the decoder.
+
+A decoder handle has one owner thread at a time. It may be moved between
+threads while idle, but the same handle must not be used concurrently by
+`push_codes`, `pull_pcm`, `reset`, or `destroy`. Applications needing parallel
+streams open one handle per stream. Immutable weights are shared; mutable
+causal state and scratch are not.
+
+Vokra creates no worker thread for this API. The owner drives all progress by
+calling push and pull, which keeps the surface valid for the single-threaded
+Unity WebGL build.
+
+## Shape and backpressure
+
+Call `vokra_codec_decoder_n_codebooks` after open and pass that value back as
+the `n_codebooks` argument of every `vokra_codec_decoder_push_codes` call. It
+is checkpoint data, not a header constant, so models with different codebook
+counts use the same ABI.
+
+One push accepts one complete `[n_codebooks]` frame. A successful push reports
+one emitted frame; pull it into a buffer of at least
+`vokra_codec_decoder_frame_hop` floats before the next push. A second push with
+PCM still pending returns `VOKRA_ERROR_INVALID_ARGUMENT` instead of dropping or
+overwriting audio. A pull with nothing pending succeeds with `out_len == 0`.
+
+After the first warmup cycle, successful push plus pull performs no heap
+allocation. `reset` may rebuild scratch/state and is intentionally outside that
+hot-path guarantee.
+
+## Family support
+
+The C layer is codec-family neutral: a model opts in through Vokra's streaming
+codec engine trait only when it has a complete, real token-to-PCM decoder.
+Standalone Mimi is currently connected. SNAC remains a loud unsupported open
+until its terminal PCM decoder lands; exposing its existing codes-to-features
+partial path as audio would violate the no-silent-fallback rule.

--- a/include/vokra.h
+++ b/include/vokra.h
@@ -139,15 +139,15 @@ typedef struct vokra_aec_ref_writer_t vokra_aec_ref_writer_t;
 // far-end queue. Owned by the inference thread. Opaque to C.
 typedef struct vokra_aec_t vokra_aec_t;
 
+// Opaque single-owner streaming codec decoder (module docs).
+typedef struct vokra_codec_decoder_t vokra_codec_decoder_t;
+
 // Opaque continuous speech-feature handle (#49).
 //
 // Created by `vokra_feat_open`, released by `vokra_feat_destroy`. It owns the
 // encoder's causal state and bounded pending-output ring, and retains the
 // originating session so model weights outlive the C handle.
 typedef struct vokra_feat_t vokra_feat_t;
-
-// Opaque single-owner streaming codec decoder (module docs).
-typedef struct vokra_codec_decoder_t vokra_codec_decoder_t;
 
 // Opaque duplex-session handle (module docs). Created by
 // `vokra_s2s_duplex_open`, released by `vokra_s2s_duplex_destroy`.
@@ -362,8 +362,8 @@ void vokra_string_free(char *s);
 //
 // Returns `NULL` and records detail in `vokra_last_error()` when the loaded
 // model does not expose a complete streaming token-to-PCM decoder. Currently
-// standalone Mimi opts in; partial SNAC support remains an explicit error
-// until its terminal PCM decoder exists.
+// standalone Mimi and NVIDIA NanoCodec opt in; partial SNAC support remains
+// an explicit error until its terminal PCM decoder exists.
 //
 // # Safety
 //

--- a/include/vokra.h
+++ b/include/vokra.h
@@ -146,6 +146,9 @@ typedef struct vokra_aec_t vokra_aec_t;
 // originating session so model weights outlive the C handle.
 typedef struct vokra_feat_t vokra_feat_t;
 
+// Opaque single-owner streaming codec decoder (module docs).
+typedef struct vokra_codec_decoder_t vokra_codec_decoder_t;
+
 // Opaque duplex-session handle (module docs). Created by
 // `vokra_s2s_duplex_open`, released by `vokra_s2s_duplex_destroy`.
 typedef struct vokra_s2s_duplex_t vokra_s2s_duplex_t;
@@ -354,6 +357,93 @@ enum vokra_status_t vokra_asr_transcribe(const struct vokra_session_t *session,
 // `s` must be `NULL` or a pointer returned by `vokra_asr_transcribe` that has
 // not already been freed.
 void vokra_string_free(char *s);
+
+// Opens a fresh streaming codec decoder for `session`.
+//
+// Returns `NULL` and records detail in `vokra_last_error()` when the loaded
+// model does not expose a complete streaming token-to-PCM decoder. Currently
+// standalone Mimi opts in; partial SNAC support remains an explicit error
+// until its terminal PCM decoder exists.
+//
+// # Safety
+//
+// `session` must be `NULL` or a live `vokra_session_t`. The returned handle,
+// when non-NULL, must be destroyed exactly once with
+// [`vokra_codec_decoder_destroy`].
+struct vokra_codec_decoder_t *vokra_codec_decoder_open(const struct vokra_session_t *session);
+
+// Returns PCM samples emitted per complete code frame, or `-1` on error.
+//
+// # Safety
+//
+// `decoder` must be a live handle or `NULL` (reported as `-1`).
+int32_t vokra_codec_decoder_frame_hop(const struct vokra_codec_decoder_t *decoder);
+
+// Returns the decoder PCM sample rate in Hz, or `-1` on error.
+//
+// # Safety
+//
+// `decoder` must be a live handle or `NULL` (reported as `-1`).
+int32_t vokra_codec_decoder_sample_rate(const struct vokra_codec_decoder_t *decoder);
+
+// Returns the checkpoint's codebook count, or `-1` on error. This value is
+// informational; callers must still pass the count to every push so shape
+// mismatches remain observable at the ABI boundary.
+//
+// # Safety
+//
+// `decoder` must be a live handle or `NULL` (reported as `-1`).
+int32_t vokra_codec_decoder_n_codebooks(const struct vokra_codec_decoder_t *decoder);
+
+// Pushes one complete code frame.
+//
+// `n_codebooks` is a required call-time shape and must exactly match
+// `vokra_codec_decoder_n_codebooks(decoder)`. On success,
+// `*out_frames_emitted` is `1`; pull the corresponding PCM before the next
+// push. The warmed successful push/pull path performs no heap allocation.
+//
+// # Safety
+//
+// `decoder` must be a live handle owned by the calling thread; `codes` must
+// point to `n_codebooks` readable `uint32_t` values; `out_frames_emitted`
+// must be valid and writable.
+enum vokra_status_t vokra_codec_decoder_push_codes(struct vokra_codec_decoder_t *decoder,
+                                                   const uint32_t *codes,
+                                                   size_t n_codebooks,
+                                                   int32_t *out_frames_emitted);
+
+// Pulls one pending PCM frame into `out`.
+//
+// `capacity` must be at least `vokra_codec_decoder_frame_hop(decoder)` when
+// a frame is pending. `*out_len == 0` means there was nothing to pull.
+//
+// # Safety
+//
+// `decoder` must be a live handle owned by the calling thread; when
+// `capacity > 0`, `out` must point to that many writable floats; `out_len`
+// must be valid and writable.
+enum vokra_status_t vokra_codec_decoder_pull_pcm(struct vokra_codec_decoder_t *decoder,
+                                                 float *out,
+                                                 size_t capacity,
+                                                 size_t *out_len);
+
+// Resets the causal decoder to its as-new state and discards pending PCM.
+// Errors (including `NULL`) are recorded in `vokra_last_error()`; this exact
+// pre-freeze API is void, matching the issue contract.
+//
+// # Safety
+//
+// `decoder` must be a live handle owned by the calling thread.
+void vokra_codec_decoder_reset(struct vokra_codec_decoder_t *decoder);
+
+// Destroys a decoder handle. `NULL` is a no-op; double-free or concurrent
+// use/destroy is undefined behaviour.
+//
+// # Safety
+//
+// `decoder` must be `NULL` or a live handle returned by
+// [`vokra_codec_decoder_open`] and not yet freed.
+void vokra_codec_decoder_destroy(struct vokra_codec_decoder_t *decoder);
 
 // Returns the calling thread's last error message as a NUL-terminated UTF-8
 // C string, or `NULL` if no error has been recorded on this thread.

--- a/scripts/check-hot-path-allocs.sh
+++ b/scripts/check-hot-path-allocs.sh
@@ -29,6 +29,9 @@ FILES=(
     "crates/vokra-models/src/nanocodec/causal_hifigan.rs"
     # #49: bounded continuous-feature queue behind vokra_feat_push/pull.
     "crates/vokra-models/src/moshi/feature.rs"
+    # #48: generic streaming codec handle. The Mimi implementation owns all
+    # codebook/decoder scratch before push/pull begins.
+    "crates/vokra-models/src/codec.rs"
     # M4-03: the AEC process()/DSP-kernel regions (FR-EX-05; the counting-
     # allocator proof lives in crates/vokra-ops/tests/aec_hot_path_alloc.rs).
     "crates/vokra-ops/src/aec.rs"

--- a/scripts/run-capi-smoke.sh
+++ b/scripts/run-capi-smoke.sh
@@ -7,7 +7,7 @@
 #   2. scripts/gen-c-abi.sh --check          (vokra.h has no drift — WP cond.)
 #   3. exported-symbol check                 (only vokra_* symbols are public)
 #   4. cc-build + run
-#      tests/capi/smoke_{vad,vad_bytes,aec,s2s,features,
+#      tests/capi/smoke_{vad,vad_bytes,aec,s2s,features,codec,
 #      backend_options,asr,tts}.c
 #      against <vokra.h>
 #
@@ -104,6 +104,11 @@ build_one s2s
 # are always on; the native Mimi happy path uses the same optional Moshi GGUF.
 build_one features
 "$TMP/smoke_features" "$ROOT/tests/parity/silero_vad/silero-vad-v5.gguf" || status=1
+
+# #48: generic streaming codec decoder. The committed Silero fixture proves a
+# non-codec session fails open loudly; a real Mimi push/pull is ENV-GATED.
+build_one codec
+"$TMP/smoke_codec" "$ROOT/tests/parity/silero_vad/silero-vad-v5.gguf" || status=1
 
 # 2026-08-14: backend selection through the opaque options object
 # (vokra_backend_t / vokra_session_options_* / vokra_backend_available) plus

--- a/tests/capi/README.md
+++ b/tests/capi/README.md
@@ -10,14 +10,16 @@ from C". They double as the single-header check (IF-01).
 | `smoke_vad_bytes.c` | Bytes-based create (M4-02): read GGUF → `create_from_bytes` → VAD stream | committed Silero fixture (also the WebGL emcc verify body) |
 | `smoke_aec.c` | AEC (M4-03): create → ref_push → process → reset → destroy | **none** — model-free, synthetic PCM |
 | `smoke_s2s.c` | Full-duplex S2S + attribution (M4-06): duplex open/push/pull/text/interrupt + `vokra_model_attribution` | committed Silero (error paths + permissive attribution) + **env** `VOKRA_MOSHI_GGUF` for the duplex leg |
+| `smoke_codec.c` | Generic streaming codec (#48): open/query/push/pull/reset/destroy + non-codec/null error paths | committed Silero (error paths) + **env** `VOKRA_MIMI_GGUF` for the real decoder leg |
 | `smoke_asr.c` | Whisper: create → transcribe → free string | **env** `VOKRA_WHISPER_GGUF` (uncommitted ~290 MB) |
 | `smoke_tts.c` | piper-plus native TTS: create → synthesize → free PCM | **env** `VOKRA_PIPER_GGUF` (uncommitted ~77 MB) |
 
 ASR/TTS **SKIP cleanly (exit 0)** when their env var is unset, matching the
 M0-05/06/07 parity gating (the large GGUFs are not committed). `smoke_s2s`'s
-full duplex leg SKIPs the same way on `VOKRA_MOSHI_GGUF` — its error-path and
-permissive-attribution legs always run. VAD / VAD(bytes) / AEC always run from
-the committed fixture (AEC needs no model at all).
+full duplex leg SKIPs the same way on `VOKRA_MOSHI_GGUF`; the codec round trip
+SKIPs on `VOKRA_MIMI_GGUF`. Their error-path legs always run. VAD /
+VAD(bytes) / AEC always run from the committed fixture (AEC needs no model at
+all).
 
 Audio input is raw little-endian **float32 PCM** read with `fread` — the C side
 has no WAV parser and no `strtod` / locale-dependent parsing (NFR-RL-01,
@@ -32,7 +34,8 @@ scripts/run-capi-smoke.sh
 
 # ASR + TTS + the S2S duplex leg live as well:
 VOKRA_WHISPER_GGUF=whisper-base.gguf VOKRA_PIPER_GGUF=voice.gguf \
-    VOKRA_MOSHI_GGUF=moshi.gguf scripts/run-capi-smoke.sh
+    VOKRA_MOSHI_GGUF=moshi.gguf VOKRA_MIMI_GGUF=mimi.gguf \
+    scripts/run-capi-smoke.sh
 ```
 
 Or build one by hand (from the repo root, after

--- a/tests/capi/smoke_codec.c
+++ b/tests/capi/smoke_codec.c
@@ -1,0 +1,132 @@
+/*
+ * smoke_codec.c — C-caller coverage for the generic streaming codec decoder
+ * (#48). The committed non-codec GGUF pins loud open failure and NULL safety;
+ * VOKRA_MIMI_GGUF enables one real all-zero code-frame -> PCM round trip.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "vokra.h"
+
+static int non_codec_and_null_paths(const char *non_codec_model) {
+    vokra_session_t *session = NULL;
+    enum vokra_status_t st = vokra_session_create_from_file(non_codec_model, &session);
+    if (st != VOKRA_OK || session == NULL) {
+        fprintf(stderr, "smoke_codec: non-codec fixture failed to load: %d (%s)\n", (int)st,
+                vokra_last_error());
+        return 1;
+    }
+    vokra_codec_decoder_t *decoder = vokra_codec_decoder_open(session);
+    if (decoder != NULL) {
+        fprintf(stderr, "smoke_codec: non-codec session unexpectedly opened decoder\n");
+        vokra_codec_decoder_destroy(decoder);
+        vokra_session_destroy(session);
+        return 1;
+    }
+    vokra_session_destroy(session);
+
+    if (vokra_codec_decoder_open(NULL) != NULL ||
+        vokra_codec_decoder_frame_hop(NULL) != -1 ||
+        vokra_codec_decoder_sample_rate(NULL) != -1 ||
+        vokra_codec_decoder_n_codebooks(NULL) != -1) {
+        fprintf(stderr, "smoke_codec: NULL constructor/query contract failed\n");
+        return 1;
+    }
+    int32_t emitted = -1;
+    size_t written = (size_t)-1;
+    const uint32_t code = 0;
+    float pcm = 0.0f;
+    if (vokra_codec_decoder_push_codes(NULL, &code, 1, &emitted) !=
+            VOKRA_ERROR_INVALID_ARGUMENT ||
+        vokra_codec_decoder_pull_pcm(NULL, &pcm, 1, &written) !=
+            VOKRA_ERROR_INVALID_ARGUMENT) {
+        fprintf(stderr, "smoke_codec: NULL push/pull did not fail invalid-argument\n");
+        return 1;
+    }
+    vokra_codec_decoder_reset(NULL);
+    vokra_codec_decoder_destroy(NULL);
+    return 0;
+}
+
+static int real_mimi_roundtrip(const char *path) {
+    vokra_session_t *session = NULL;
+    enum vokra_status_t st = vokra_session_create_from_file(path, &session);
+    if (st != VOKRA_OK || session == NULL) {
+        fprintf(stderr, "smoke_codec: Mimi session failed to load: %d (%s)\n", (int)st,
+                vokra_last_error());
+        return 1;
+    }
+    vokra_codec_decoder_t *decoder = vokra_codec_decoder_open(session);
+    /* The decoder retains the model independently. */
+    vokra_session_destroy(session);
+    if (decoder == NULL) {
+        fprintf(stderr, "smoke_codec: Mimi decoder open failed: %s\n", vokra_last_error());
+        return 1;
+    }
+
+    int32_t n_codebooks = vokra_codec_decoder_n_codebooks(decoder);
+    int32_t frame_hop = vokra_codec_decoder_frame_hop(decoder);
+    int32_t sample_rate = vokra_codec_decoder_sample_rate(decoder);
+    if (n_codebooks <= 0 || frame_hop <= 0 || sample_rate <= 0) {
+        fprintf(stderr, "smoke_codec: invalid model axes n=%d hop=%d rate=%d\n", n_codebooks,
+                frame_hop, sample_rate);
+        vokra_codec_decoder_destroy(decoder);
+        return 1;
+    }
+
+    uint32_t *codes = calloc((size_t)n_codebooks, sizeof(*codes));
+    float *pcm = calloc((size_t)frame_hop, sizeof(*pcm));
+    if (codes == NULL || pcm == NULL) {
+        fprintf(stderr, "smoke_codec: allocation failed\n");
+        free(codes);
+        free(pcm);
+        vokra_codec_decoder_destroy(decoder);
+        return 1;
+    }
+
+    int32_t emitted = 0;
+    size_t written = 0;
+    st = vokra_codec_decoder_push_codes(decoder, codes, (size_t)n_codebooks, &emitted);
+    if (st != VOKRA_OK || emitted != 1) {
+        fprintf(stderr, "smoke_codec: push failed: %d emitted=%d (%s)\n", (int)st, emitted,
+                vokra_last_error());
+        free(codes);
+        free(pcm);
+        vokra_codec_decoder_destroy(decoder);
+        return 1;
+    }
+    st = vokra_codec_decoder_pull_pcm(decoder, pcm, (size_t)frame_hop, &written);
+    if (st != VOKRA_OK || written != (size_t)frame_hop) {
+        fprintf(stderr, "smoke_codec: pull failed: %d written=%zu (%s)\n", (int)st, written,
+                vokra_last_error());
+        free(codes);
+        free(pcm);
+        vokra_codec_decoder_destroy(decoder);
+        return 1;
+    }
+
+    vokra_codec_decoder_reset(decoder);
+    vokra_codec_decoder_destroy(decoder);
+    free(codes);
+    free(pcm);
+    printf("smoke_codec: PASS (%d codebooks, %d samples/frame, %d Hz)\n", n_codebooks,
+           frame_hop, sample_rate);
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    const char *non_codec_model = argc > 1 ? argv[1] :
+        "tests/parity/silero_vad/silero-vad-v5.gguf";
+    if (non_codec_and_null_paths(non_codec_model) != 0) {
+        return 1;
+    }
+
+    const char *mimi = getenv("VOKRA_MIMI_GGUF");
+    if (mimi == NULL || *mimi == '\0') {
+        printf("smoke_codec: SKIP real Mimi leg (set VOKRA_MIMI_GGUF)\n");
+        return 0;
+    }
+    return real_mimi_roundtrip(mimi);
+}


### PR DESCRIPTION
Closes #48

## Summary

- add a codec-family-neutral `CodecDecoderEngine`/`CodecDecoderHandle` session contract and eight `vokra_codec_decoder_*` C ABI functions
- keep `n_codebooks` checkpoint-driven and require it again as a call-time `push_codes` shape; no codebook count is frozen in the header
- add independently owned, single-owner-thread decoder handles with explicit backpressure, reset, retained-session lifetime, and no worker threads
- connect the first complete family, standalone Mimi, from RVQ indices through its native causal neural decoder to PCM
- keep partial SNAC fail-closed until its terminal PCM decoder exists
- document ABI, ownership, thread, backpressure, and environment-gated C smoke behavior

## TDD and verification

- Mimi successive per-frame pushes are bit-identical to one whole-buffer decode
- wrong codebook width, pending-frame overwrite, short pull buffers, unsupported models, and NULL ABI arguments fail loudly
- counting allocator: 16 warmed `push_codes + pull_pcm` cycles perform 0 allocations
- VAST `cargo test -p vokra-core -p vokra-capi --no-fail-fast`: C API 83 tests, core 580 tests, integration/doc tests passed
- VAST `cargo test -p vokra-models codec::tests --lib`: 5 passed
- VAST `cargo test -p vokra-models --test codec_decoder_hot_path_alloc`: 1 passed
- VAST `cargo clippy -p vokra-core -p vokra-models -p vokra-capi --all-targets -- -D warnings`
- VAST/local: fmt, diff-check, zero-deps, forbidden symbols, fixture EOL, allocation marker, thread-free, generated header, ABI changelog, Rust public API snapshot
- VAST `scripts/run-capi-smoke.sh`: 49 `vokra_*` exports, no symbol leaks, all always-on C legs passed; real Mimi leg skipped because `VOKRA_MIMI_GGUF` was not present

## Dependency note

The ABI and Mimi implementation are standalone. NanoCodec support can opt into the same trait after #45, #46, and #47 land; this PR remains draft until that integration and CI are audited. SNAC still lacks a complete native terminal PCM decoder and therefore intentionally does not advertise support.
