### PR TITLE
bench(ios): add physical-device benchmark harness

### DIFF
--- a/docs/benchmarks/v0.5-device-benchmarks.md
+++ b/docs/benchmarks/v0.5-device-benchmarks.md
@@ -23,15 +23,40 @@
 **Metal 実装メモ** (提案の T01 spec の "MPS/MPSGraph/MLX" 記述は M2 実装で更新済): M2-01 Metal backend は **binding crate 不使用の生 objc/Metal FFI + MSL compute kernel** で実装 (CLAUDE.md M2 status)。iOS 実測時のバックエンド記録は `Metal` 表記でよいが、内部 kernel path は MPS 等外部フレームワークではなく Vokra 自前 MSL である旨を承知して測る。
 **Weight ライセンス**: Whisper base = MIT (M2-06-T16 の公式 zoo 搭載、research flag 対象外、watermark 対象外 = ASR 出力でない)。
 
-| Model | Task | Device (機種 + iOS ver) | Backend | Audio (s) | Warmup runs | Measured runs (N) | 推論時間 P50 (s) | RTF (P50) | 閾値 | Verdict (< 0.5) | Date | Measurer |
-|-------|------|------------------------|---------|-----------|-------------:|------------------:|-----------------:|----------:|:----:|:---------------:|------|----------|
-| whisper-base | ASR |                        | cpu (NEON) | 30.0 |             |                   |                  |           | <0.5 |   PASS / FAIL   |      |          |
-| whisper-base | ASR |                        | metal      | 30.0 |             |                   |                  |           | <0.5 |   PASS / FAIL   |      |          |
+| Model | Task | Device (機種 + iOS ver) | Backend | Audio (s) | Warmup | N | 推論時間 P50 (s) | RTF P50 | Peak RSS | Build SHA | 閾値 | Verdict | Date | Measurer |
+|-------|------|------------------------|---------|-----------|-------:|--:|------------------:|--------:|---------:|-----------|:----:|:-------:|------|----------|
+| whisper-base | ASR |                        | cpu (NEON) | 30.0 | 3 | 10 | | | | | <0.5 | PASS / FAIL | | |
+| whisper-base | ASR |                        | metal      | 30.0 | 3 | 10 | | | | | <0.5 | PASS / FAIL | | |
 
 **Notes**:
 - 両バックエンド行を用意している = M2-02-T13 § (e) 「使用バックエンド (CPU=NEON / Metal) の記録欄 — どちらが閾値を満たすかは実機計測で確定する」に整合。両方採れる場合は両行に記入、片方しか採れない場合はもう一方に `not measured` と明記 (行を消さない)。
-- warmup 回数・N runs は M2-06-T14 / M2-03-T25 と統一する運用を M2-14-T02 ランブックで確定する (提案: warmup = 1、N = 10、median = P50)。
+- iOS harness は既存の共通下限（warmup = 1、N = 10、median = P50）を
+  満たす warmup = 3、N = 10、median = P50 に固定する。
 - 音声長は fixture (`tests/fixtures/audio/jfk-30s.wav`、下記 §3) の 30.0 s を既定。異なる fixture を使った場合は行を追加してその旨を Notes 欄で明記する。
+
+**iOS measurement conditions（実測時必須）**:
+
+| Ambient | Starting thermal state | Screen | Charging | Case | Xcode | XCFramework SHA256 | Whisper GGUF SHA256 | Fixture SHA256 |
+|---------|------------------------|--------|----------|------|-------|--------------------|----------------------|----------------|
+|         |                        | on/off | yes/no   | installed/removed | | | | `58adb4ea501d955fcd40bfbb69128f8f40428b81d8716b9ed337949773be253f` |
+
+iOS は public API で内部温度（°C）を公開しないため、starting device
+temperature は `ProcessInfo.processInfo.thermalState` の
+`nominal/fair/serious/critical` として記録し、温度値を推測しない。
+
+### 1.1 Sustained streaming codec decoder（issue #52 / #48）
+
+同じ実機・条件で、codec の checkpoint-derived frame rate に pacing して
+1,800 秒連続 decode する。解析は
+`tools/bench/ios_sustained_analyze.py` の fail-closed report を転記する。
+
+| Codec | Device + iOS | Backend | Duration | Frames | p50 (ms) | p95 (ms) | p99 (ms) | Deadline misses | Peak RSS | First→last decile p50 ratio | Thermal start→end | Build SHA | Date |
+|-------|--------------|---------|----------|--------|---------:|---------:|---------:|----------------:|---------:|------------------------------:|-------------------|-----------|------|
+| Mimi  |              | cpu (NEON) | 1800 s | | | | | | | | | | |
+
+`First→last decile p50 ratio` と `last_decile_slower` は劣化傾向の記述値で
+あり、新しい合否閾値ではない。raw JSONL、analyzer JSON/Markdown、model
+SHA256 を同じ PR に保存する。
 
 **未達時記入欄** (RTF ≥ 0.5 の場合、M2-14-T05 § 「新規の緩和目標を発明しない」):
 - 未達値をそのまま記録・公開 (新規閾値を発明しない、M2-14-T01 § 「(提案) 未達時記入欄」)。

--- a/docs/benchmarks/v0.5-device-runbook.md
+++ b/docs/benchmarks/v0.5-device-runbook.md
@@ -80,8 +80,8 @@
 
 | パラメータ | 値 | 根拠 |
 |-----------|-----|------|
-| warmup runs | 1 | `tools/parity/cuda_rtf_variance.sh` default (§L12 コメント「the warmup absorbs session build + NVRTC JIT + weight upload cost」)、[`docs/m2-14-ios-rtf-handover.md`](../m2-14-ios-rtf-handover.md) § 3「Run 3 warm iterations」は上位互換 (warmup 数を増やすのは OK、減らすのは NG) |
-| Measured runs (N) | 10 | variance harness default (`cuda_rtf_variance.sh --iters 10`)、[`docs/m2-14-ios-rtf-handover.md`](../m2-14-ios-rtf-handover.md) § 3「the median of 5 timed runs (drop min/max)」より広い集合 → 集約法は下段の P50 に委ねる |
+| warmup runs | 1 | `tools/parity/cuda_rtf_variance.sh` default (§L12 コメント「the warmup absorbs session build + NVRTC JIT + weight upload cost」)、iOS harness の 3 warmup はこの下限の上位互換 (warmup 数を増やすのは OK、減らすのは NG) |
+| Measured runs (N) | 10 | variance harness と iOS harness の双方が N=10、集約法は下段の P50 に統一 |
 | 集約法 | median (P50) | NFR-PF-13、`tools/parity/cuda_rtf_analyze.py` の `median` フィールド |
 | Fixture | `jfk-30s.wav` | 上記 §1.3、両プラットフォーム共通 |
 | 音声長 | 30.0 s (bit-exact) | Whisper 入力長固定 |
@@ -111,9 +111,17 @@
 
 1. § 1 **Prerequisites checklist** — XCFramework build、Package.swift、Xcode 14+、`whisper-base.gguf`、`jfk-30s.wav` (§1.3 と同一 fixture)、iOS 15+ 実機、Developer signing profile。**動的ロード禁止 (I1)** / **JIT 不使用 (I2)** の遵守は既に XCFramework build 時に保証されるが、本 runbook § 0.2 で再確認する。
 2. § 2 **Xcode project setup** — SwiftUI + Local Swift Package 添付、fixture bundling、Signing、Bitcode = No。
-3. § 3 **Minimal measurement app (SwiftUI)** — `vokra_session_create_from_file` → `vokra_asr_transcribe` の 1 経路。**exact C symbol 名は `include/vokra.h` を参照する** (handover § 3 Notes 通り)。**warmup 3 + measured 5** の handover 記述は **§1.4 統一パラメータ (warmup 1 / N 10)** より広い集合に含まれる → **N は最終的に 10 まで拡張する** (warmup 数はそのまま handover の 3 で構わない、C5 と整合)。
+3. § 3 **Measurement app** — iPhoneOS SDK で typecheck 済みの
+   `tools/bench/ios-device/IOSDeviceBench.swift` を app target に追加する。
+   WAV は timing 前に mono Float32 PCM へ読み、Whisper は warmup 3 +
+   measured N=10、codec は checkpoint frame rate で 1,800 秒 pacing する。
+   P50 RTF、peak RSS、codec p50/p95/p99 と raw JSON(L) は harness が出力する。
 4. § 4 **Recording template** — CPU / Metal 両バックエンド行、Device model、iOS version、Elapsed、RTF、NFR-PF-03 判定。**この記入は [`docs/benchmarks/v0.5-device-benchmarks.md`](v0.5-device-benchmarks.md) § 1 表に転記する** (M2-14-T05、handover § 4 は raw 記録、公開ページは公開値)。
-5. § 5 **Backend selection** — `vokra_session_set_backend(s, VOKRA_BACKEND_METAL)` で Metal に切替。**FR-EX-08 (I3): unsupported op は explicit error として返る、silent CPU fallback しない**。rc をログに残す (fabricated pass 禁止)。
+5. § 5 **Backend selection** — `vokra_session_options_t` に
+   `VOKRA_BACKEND_METAL` を設定し、
+   `vokra_session_create_from_file_with_options` で Metal session を構築。
+   **FR-EX-08 (I3): unavailable/unsupported は explicit error、silent CPU
+   fallback しない**。status + `vokra_last_error()` をログに残す。
 6. § 6 **R4 boundary — Metal probe failure on iPhone** — Metal init が iPhone で失敗 (例: `MTLGPUFamily.Apple7` 未認識、M2-01 の device probe が macOS `MTLGPUFamily.Mac*` 前提で書かれていた場合) は、**本 runbook では patch せず**:
    - CPU-only RTF は測れる → 記録する
    - Metal 行は `blocked-by-M2-01` として記録

--- a/docs/m2-14-ios-rtf-handover.md
+++ b/docs/m2-14-ios-rtf-handover.md
@@ -12,6 +12,7 @@
 - [ ] `Package.swift` reachable — either local path `.binaryTarget(path: "build/ios/Vokra.xcframework")` (dev) or release URL + SHA256 (`.binaryTarget(url:, checksum:)`).
 - [ ] Xcode 14 or newer installed on macOS host (matches CI floor from M2-02 ADR).
 - [ ] Whisper base GGUF model file (`whisper-base.gguf`) converted via `vokra-cli convert` and bundled in the app target's Resources.
+- [ ] Mimi GGUF model file (`mimi.gguf`) for the 30-minute streaming-codec run; build from a revision containing issue #48's `vokra_codec_decoder_*` ABI.
 - [ ] Fixture WAV (16 kHz mono, 30 s) — recommend `tests/fixtures/audio/jfk-30s.wav` from the repo, bundled as an app resource.
 - [ ] Physical iOS 15+ device (iPhone or iPad); Simulator RTF is NOT valid for NFR-PF-03.
 - [ ] Apple Developer signing profile for on-device deployment.
@@ -24,60 +25,66 @@
 4. Signing & Capabilities → set Team; Bundle ID unique to依頼者.
 5. Build Settings → **Enable Bitcode = No** (Bitcode is deprecated by Apple; the XCFramework is not bitcode-bundled).
 
-## 3. Minimal measurement app (SwiftUI)
+## 3. Measurement app
 
-```swift
-import SwiftUI
-import Vokra
-import Foundation
+Use the checked and iPhoneOS-typechecked harness at
+[`tools/bench/ios-device/IOSDeviceBench.swift`](../tools/bench/ios-device/IOSDeviceBench.swift)
+and follow its [README](../tools/bench/ios-device/README.md). It fixes two
+defects in the historical snippet that used to live here:
 
-struct ContentView: View {
-    @State private var result: String = "Idle"
-    var body: some View {
-        VStack(spacing: 20) {
-            Text(result).font(.system(.body, design: .monospaced))
-            Button("Run RTF Measurement") { measure() }
-        }.padding()
-    }
-    func measure() {
-        guard let gguf = Bundle.main.path(forResource: "whisper-base", ofType: "gguf"),
-              let wav  = Bundle.main.path(forResource: "jfk-30s",     ofType: "wav")
-        else { result = "resource missing"; return }
-        var session: OpaquePointer?
-        let rc = vokra_session_create_from_file(gguf, &session)
-        guard rc == 0, let s = session else { result = "session_create err=\(rc)"; return }
-        defer { vokra_session_destroy(s) }
+- `vokra_asr_transcribe` accepts mono `f32` PCM plus its sample count/rate; it
+  does **not** accept a WAV path. The harness decodes the WAV before timing and
+  passes exactly 480,000 samples at 16 kHz.
+- Backend selection happens on `vokra_session_options_t` before session
+  construction; there is no `vokra_session_set_backend` mutation API.
 
-        let audioSec: Double = 30.0
-        let t0 = Date()
-        var out: UnsafeMutablePointer<CChar>?
-        let arc = vokra_asr_transcribe(s, wav, &out)
-        let elapsed = Date().timeIntervalSince(t0)
-        let rtf = elapsed / audioSec
-        let text = out.map { String(cString: $0) } ?? "<null>"
-        if let o = out { vokra_string_free(o) }
-        result = "rc=\(arc) elapsed=\(String(format: "%.3f", elapsed))s RTF=\(String(format: "%.4f", rtf))\n\(text.prefix(60))"
-    }
-}
+The harness performs 3 warm iterations then 10 measured iterations, reports
+P50 RTF, and samples Darwin `ru_maxrss` (process-lifetime peak RSS, so a peak
+inside the blocking inference call cannot be missed). It hashes the model and
+fixture before loading the session and writes a JSON report to the app's
+Documents directory.
+
+For the codec leg it opens a `vokra_codec_decoder_t`, derives the real
+`frame_hop`, sample rate, and codebook count from the GGUF, then paces one valid
+code frame at the model frame rate for 1,800 seconds. Export the JSONL and run:
+
+```sh
+uv run --project tools/parity --python 3.12 python tools/bench/ios_sustained_analyze.py \
+  vokra-ios-codec-sustained-....jsonl \
+  --json-output sustained-report.json \
+  --markdown-output sustained-report.md
 ```
 
-Notes:
-- Exact C symbol names may differ; consult `include/vokra.h` in the XCFramework `Headers/` and adjust. The Clang module `Vokra` re-exports all `vokra_*` symbols.
-- Run 3 warm iterations, then record the median of 5 timed runs (drop min/max).
-- Fix CPU governor by keeping device plugged in + screen on; disable Low Power Mode.
+The analyzer fails closed on a short, sparse, non-contiguous, non-finite, or
+conditions-incomplete log. Its report contains p50/p95/p99, peak RSS, deadline
+misses, thermal-state transition, and the exact last-decile/first-decile p50
+ratio. It does not invent a pass threshold for degradation.
 
 ## 4. Recording template
 
-| Run | Backend | Device model | iOS version | Elapsed (s) | Audio (s) | RTF | NFR-PF-03 (<0.5) |
-|-----|---------|--------------|-------------|-------------|-----------|-----|------------------|
-| 1   | CPU     |              |             |             | 30.0      |     | pass / fail      |
-| 2   | Metal   |              |             |             | 30.0      |     | pass / fail      |
+| Run | Backend | Device model | iOS version | Elapsed P50 (s) | Audio (s) | RTF P50 | Peak RSS | Build SHA | NFR-PF-03 (<0.5) |
+|-----|---------|--------------|-------------|-----------------|-----------|---------|----------|-----------|------------------|
+| 1   | CPU     |              |             |                 | 30.0      |         |          |           | pass / fail      |
+| 2   | Metal   |              |             |                 | 30.0      |         |          |           | pass / fail      |
 
-Also record: Vokra `git rev-parse HEAD`, XCFramework SHA256, Xcode version, thermal state (`ProcessInfo.processInfo.thermalState`), whether device was plugged in.
+| Codec model | Backend | Duration | Frames | p50 (ms) | p95 (ms) | p99 (ms) | Deadline misses | Peak RSS | First→last decile p50 | Thermal start→end |
+|-------------|---------|----------|--------|----------|----------|----------|-----------------|----------|-----------------------|-------------------|
+| Mimi        | CPU     | 1800 s   |        |          |          |          |                 |          |                       |                   |
+
+Also record: XCFramework SHA256, Xcode version, model SHA256, fixture SHA256,
+ambient temperature, starting thermal state, screen on/off, charging or not,
+and case installed/removed. iOS does not expose internal device temperature in
+degrees through a public API, so record `ProcessInfo.processInfo.thermalState`
+instead and do not fabricate a Celsius value.
 
 ## 5. Backend selection
 
-Backend defaults to CPU. To try Metal, invoke `vokra_session_set_backend(s, VOKRA_BACKEND_METAL)` before `vokra_asr_transcribe` (see `vokra.h` for the exact enum name). Per FR-EX-08, unsupported ops on Metal must surface as **explicit errors** — never silent CPU fallback. Log the returned rc.
+Backend defaults to CPU. To try Metal, create `vokra_session_options_t`, call
+`vokra_session_options_set_backend(opts, VOKRA_BACKEND_METAL)`, then construct
+the model with `vokra_session_create_from_file_with_options`. Destroy the
+options after construction. Per FR-EX-08, unavailable/unsupported Metal must
+surface as an **explicit error** — never silent CPU fallback. Log the returned
+status and `vokra_last_error()`.
 
 ## 6. R4 boundary — Metal probe failure on iPhone
 
@@ -91,4 +98,7 @@ CPU pass alone satisfies NFR-PF-03 for this WP if RTF < 0.5; Metal is a separate
 
 ## 7. Handover deliverable back to Vokra
 
-Attach to the M2-14 completion ticket: the filled table above, raw logs, and the device video (optional) showing the run. If any RTF ≥ 0.5, open a perf ticket referencing this handover; do NOT close M2-14 as pass.
+Attach to the M2-14 completion ticket: the filled tables above, raw Whisper
+JSON, raw codec JSONL, analyzer JSON/Markdown, and the device video (optional)
+showing the run. If any RTF ≥ 0.5, open a perf ticket referencing this
+handover; do NOT close M2-14 as pass.

--- a/docs/tutorials/ios.ja.md
+++ b/docs/tutorials/ios.ja.md
@@ -68,6 +68,7 @@ Xcode で:
 import SwiftUI
 import Vokra   // Clang module がすべての `vokra_*` C シンボルを re-export
 import Foundation
+import AVFoundation
 
 struct ContentView: View {
     @State private var status = "Idle"
@@ -88,17 +89,36 @@ struct ContentView: View {
 
         var session: OpaquePointer?
         let rc = vokra_session_create_from_file(gguf, &session)
-        guard rc == 0, let s = session else {
-            status = "session_create err=\(rc)"; return
+        guard rc.rawValue == VOKRA_OK.rawValue, let s = session else {
+            status = "session_create err=\(rc.rawValue)"; return
         }
         defer { vokra_session_destroy(s) }
 
-        // 実機 RTF 計測の e2e harness は docs/m2-14-ios-rtf-handover.md 参照
-        var out: UnsafeMutablePointer<CChar>?
-        let arc = vokra_asr_transcribe(s, wav, &out)
-        let text = out.map { String(cString: $0) } ?? "<null>"
-        if let o = out { vokra_string_free(o) }
-        status = "rc=\(arc): \(text.prefix(120))"
+        do {
+            // WAV parse は C ABI の外。transcribe には mono Float32 PCM、
+            // sample 数、sample rate を渡す。
+            let file = try AVAudioFile(forReading: URL(fileURLWithPath: wav))
+            let format = file.processingFormat
+            guard format.channelCount == 1, format.sampleRate == 16_000,
+                  let buffer = AVAudioPCMBuffer(
+                      pcmFormat: format,
+                      frameCapacity: AVAudioFrameCount(file.length)
+                  )
+            else { status = "fixture must be mono 16 kHz"; return }
+            try file.read(into: buffer)
+            guard let pcm = buffer.floatChannelData?[0] else {
+                status = "fixture is not Float32 PCM"; return
+            }
+            var out: UnsafeMutablePointer<CChar>?
+            let arc = vokra_asr_transcribe(
+                s, pcm, Int(buffer.frameLength), 16_000, &out
+            )
+            let text = out.map { String(cString: $0) } ?? "<null>"
+            if let o = out { vokra_string_free(o) }
+            status = "rc=\(arc.rawValue): \(text.prefix(120))"
+        } catch {
+            status = "WAV read failed: \(error)"
+        }
     }
 }
 ```
@@ -119,10 +139,11 @@ Vokra iOS ビルドはプラットフォームの制約を強制します:
   `compile_error!(...)` により、動かせない CUDA 型シンボルを silent に
   リンクしてしまうのを防ぎます。
 - **アクセラレーションは Metal** — CPU（Apple Silicon の NEON）は常に
-  利用可能。Metal を有効にするには
-  `vokra_session_set_backend(s, VOKRA_BACKEND_METAL)`（enum 名は
-  `vokra.h` 参照）。FR-EX-08 により、Metal で未対応の op は明示エラー
-  で silent CPU fallback は行いません。
+  利用可能。Metal は `vokra_session_options_t` に
+  `VOKRA_BACKEND_METAL` を設定し、
+  `vokra_session_create_from_file_with_options` へ渡す construction-time
+  選択です。FR-EX-08 により、Metal unavailable / unsupported は明示
+  エラーで、silent CPU fallback は行いません。
 
 ## 6. 実機 RTF 計測
 

--- a/docs/tutorials/ios.md
+++ b/docs/tutorials/ios.md
@@ -68,6 +68,7 @@ In Xcode:
 import SwiftUI
 import Vokra   // Clang module re-exports all `vokra_*` C symbols.
 import Foundation
+import AVFoundation
 
 struct ContentView: View {
     @State private var status = "Idle"
@@ -88,18 +89,36 @@ struct ContentView: View {
 
         var session: OpaquePointer?
         let rc = vokra_session_create_from_file(gguf, &session)
-        guard rc == 0, let s = session else {
-            status = "session_create err=\(rc)"; return
+        guard rc.rawValue == VOKRA_OK.rawValue, let s = session else {
+            status = "session_create err=\(rc.rawValue)"; return
         }
         defer { vokra_session_destroy(s) }
 
-        // See docs/m2-14-ios-rtf-handover.md for a full end-to-end RTF
-        // measurement harness (fixture WAV -> transcribe -> record RTF).
-        var out: UnsafeMutablePointer<CChar>?
-        let arc = vokra_asr_transcribe(s, wav, &out)
-        let text = out.map { String(cString: $0) } ?? "<null>"
-        if let o = out { vokra_string_free(o) }
-        status = "rc=\(arc): \(text.prefix(120))"
+        do {
+            // WAV parsing is outside Vokra's C ABI: transcribe accepts mono
+            // Float32 PCM, its sample count, and its sample rate.
+            let file = try AVAudioFile(forReading: URL(fileURLWithPath: wav))
+            let format = file.processingFormat
+            guard format.channelCount == 1, format.sampleRate == 16_000,
+                  let buffer = AVAudioPCMBuffer(
+                      pcmFormat: format,
+                      frameCapacity: AVAudioFrameCount(file.length)
+                  )
+            else { status = "fixture must be mono 16 kHz"; return }
+            try file.read(into: buffer)
+            guard let pcm = buffer.floatChannelData?[0] else {
+                status = "fixture is not Float32 PCM"; return
+            }
+            var out: UnsafeMutablePointer<CChar>?
+            let arc = vokra_asr_transcribe(
+                s, pcm, Int(buffer.frameLength), 16_000, &out
+            )
+            let text = out.map { String(cString: $0) } ?? "<null>"
+            if let o = out { vokra_string_free(o) }
+            status = "rc=\(arc.rawValue): \(text.prefix(120))"
+        } catch {
+            status = "WAV read failed: \(error)"
+        }
     }
 }
 ```
@@ -121,10 +140,11 @@ The Vokra iOS build enforces the platform's static-linking / no-JIT rules:
   `vokra-backend-cuda` makes this explicit rather than silently linking a
   CUDA-shaped surface that cannot run.
 - **Metal is the accelerated path** — the CPU path (NEON on Apple
-  Silicon) is always available; opt into Metal via
-  `vokra_session_set_backend(s, VOKRA_BACKEND_METAL)` (see `vokra.h` for
-  the exact enum name). Per FR-EX-08, unsupported ops on Metal surface as
-  explicit errors, never silent CPU fallback.
+  Silicon) is always available. To opt into Metal, create
+  `vokra_session_options_t`, set `VOKRA_BACKEND_METAL`, and pass it to
+  `vokra_session_create_from_file_with_options`; backend selection is a
+  construction-time choice. Per FR-EX-08, unavailable or unsupported Metal
+  surfaces as an explicit error, never silent CPU fallback.
 
 ## 6. On-device RTF measurement
 

--- a/tools/bench/ios-device/IOSDeviceBench.swift
+++ b/tools/bench/ios-device/IOSDeviceBench.swift
@@ -1,0 +1,482 @@
+import AVFoundation
+import CryptoKit
+import Darwin
+import Foundation
+import UIKit
+import Vokra
+
+enum IOSBenchError: Error, CustomStringConvertible {
+    case invalidConfiguration(String)
+    case resource(String)
+    case vokra(String)
+    case io(String)
+
+    var description: String {
+        switch self {
+        case .invalidConfiguration(let message), .resource(let message),
+             .vokra(let message), .io(let message):
+            return message
+        }
+    }
+}
+
+enum IOSBenchBackend: String, Codable {
+    case cpu
+    case metal
+
+    var abiValue: Int32 {
+        switch self {
+        case .cpu:
+            return Int32(VOKRA_BACKEND_CPU.rawValue)
+        case .metal:
+            return Int32(VOKRA_BACKEND_METAL.rawValue)
+        }
+    }
+}
+
+/// Values the device cannot infer honestly. Fill these immediately before the
+/// run; the validator rejects placeholders and missing conditions.
+struct IOSBenchConfiguration {
+    let buildSHA: String
+    let deviceModel: String
+    let ambientTemperatureC: Double
+    let screen: String       // "on" or "off"
+    let charging: Bool
+    let caseState: String    // "installed" or "removed"
+
+    func validate() throws {
+        let hex = CharacterSet(charactersIn: "0123456789abcdefABCDEF")
+        guard buildSHA.count == 40,
+              buildSHA.unicodeScalars.allSatisfy(hex.contains)
+        else {
+            throw IOSBenchError.invalidConfiguration(
+                "buildSHA must be the exact 40-hex git rev-parse HEAD"
+            )
+        }
+        guard !deviceModel.isEmpty else {
+            throw IOSBenchError.invalidConfiguration("deviceModel must be recorded")
+        }
+        guard ambientTemperatureC.isFinite else {
+            throw IOSBenchError.invalidConfiguration("ambientTemperatureC must be finite")
+        }
+        guard screen == "on" || screen == "off" else {
+            throw IOSBenchError.invalidConfiguration("screen must be on/off")
+        }
+        guard caseState == "installed" || caseState == "removed" else {
+            throw IOSBenchError.invalidConfiguration("caseState must be installed/removed")
+        }
+    }
+}
+
+struct WhisperRun: Codable {
+    let backend: String
+    let elapsedS: Double
+    let audioS: Double
+    let rtf: Double
+    let peakRSSBytes: UInt64
+    let thermalState: String
+}
+
+struct WhisperReport: Codable {
+    let schema: String
+    let buildSHA: String
+    let modelSHA256: String
+    let fixtureSHA256: String
+    let deviceModel: String
+    let iosVersion: String
+    let ambientTemperatureC: Double
+    let startingThermalState: String
+    let screen: String
+    let charging: Bool
+    let caseState: String
+    let warmupRuns: Int
+    let measuredRuns: Int
+    let runs: [WhisperRun]
+    let elapsedP50S: Double
+    let rtfP50: Double
+    let peakRSSBytes: UInt64
+}
+
+struct CodecSummary {
+    let logURL: URL
+    let frameCount: Int
+    let durationS: Double
+    let p50MS: Double
+    let p95MS: Double
+    let p99MS: Double
+    let peakRSSBytes: UInt64
+}
+
+private struct CodecFrame {
+    let index: Int
+    let wallElapsedS: Double
+    let decodeMS: Double
+    let peakRSSBytes: UInt64
+    let thermalState: String
+}
+
+@available(iOS 15.0, *)
+final class IOSDeviceBench {
+    static let whisperWarmups = 3
+    static let whisperMeasuredRuns = 10
+    static let sustainedDurationS = 1_800.0
+
+    private let configuration: IOSBenchConfiguration
+
+    init(configuration: IOSBenchConfiguration) throws {
+        try configuration.validate()
+        self.configuration = configuration
+    }
+
+    /// Measures one backend. WAV decode, model SHA, session creation, and
+    /// warmups are deliberately outside the timed region. `ru_maxrss` is the
+    /// Darwin process-lifetime peak and therefore cannot miss a transient peak
+    /// inside the blocking C call.
+    func measureWhisper(
+        modelURL: URL,
+        wavURL: URL,
+        backend: IOSBenchBackend
+    ) throws -> (WhisperReport, URL) {
+        let modelSHA = try sha256(modelURL)
+        let fixtureSHA = try sha256(wavURL)
+        let pcm = try loadMonoFloat32WAV(wavURL, expectedRate: 16_000)
+        guard pcm.count == 30 * 16_000 else {
+            throw IOSBenchError.resource(
+                "Whisper fixture must contain exactly 480000 mono samples; got \(pcm.count)"
+            )
+        }
+        let session = try openSession(modelURL: modelURL, backend: backend)
+        defer { vokra_session_destroy(session) }
+
+        let startingThermal = thermalState()
+        for _ in 0..<Self.whisperWarmups {
+            _ = try transcribe(session: session, pcm: pcm)
+        }
+
+        var runs: [WhisperRun] = []
+        runs.reserveCapacity(Self.whisperMeasuredRuns)
+        for _ in 0..<Self.whisperMeasuredRuns {
+            let start = DispatchTime.now().uptimeNanoseconds
+            _ = try transcribe(session: session, pcm: pcm)
+            let elapsed = secondsSince(start)
+            runs.append(
+                WhisperRun(
+                    backend: backend.rawValue,
+                    elapsedS: elapsed,
+                    audioS: 30.0,
+                    rtf: elapsed / 30.0,
+                    peakRSSBytes: peakRSSBytes(),
+                    thermalState: thermalState()
+                )
+            )
+        }
+        let elapsedP50 = percentile(runs.map(\.elapsedS), 0.50)
+        let report = WhisperReport(
+            schema: "vokra.ios-whisper-rtf.v1",
+            buildSHA: configuration.buildSHA.lowercased(),
+            modelSHA256: modelSHA,
+            fixtureSHA256: fixtureSHA,
+            deviceModel: configuration.deviceModel,
+            iosVersion: UIDevice.current.systemVersion,
+            ambientTemperatureC: configuration.ambientTemperatureC,
+            startingThermalState: startingThermal,
+            screen: configuration.screen,
+            charging: configuration.charging,
+            caseState: configuration.caseState,
+            warmupRuns: Self.whisperWarmups,
+            measuredRuns: Self.whisperMeasuredRuns,
+            runs: runs,
+            elapsedP50S: elapsedP50,
+            rtfP50: elapsedP50 / 30.0,
+            peakRSSBytes: runs.map(\.peakRSSBytes).max() ?? peakRSSBytes()
+        )
+        let url = try writeJSON(report, stem: "vokra-ios-whisper-\(backend.rawValue)")
+        return (report, url)
+    }
+
+    /// Runs one valid all-zero code frame at the model's real frame rate for
+    /// 30 minutes. File I/O happens only after timing completes; samples are
+    /// pre-reserved, and push+pull timing excludes RSS/thermal sampling and
+    /// pacing sleep. Analyze the JSONL with ios_sustained_analyze.py.
+    ///
+    /// This method requires the `vokra_codec_decoder_*` ABI from issue #48.
+    func measureSustainedCodec(modelURL: URL) throws -> CodecSummary {
+        let modelSHA = try sha256(modelURL)
+        let session = try openSession(modelURL: modelURL, backend: .cpu)
+        defer { vokra_session_destroy(session) }
+        guard let decoder = vokra_codec_decoder_open(session) else {
+            throw IOSBenchError.vokra("codec decoder open failed: \(lastVokraError())")
+        }
+        defer { vokra_codec_decoder_destroy(decoder) }
+
+        let frameHop = Int(vokra_codec_decoder_frame_hop(decoder))
+        let sampleRate = Int(vokra_codec_decoder_sample_rate(decoder))
+        let nCodebooks = Int(vokra_codec_decoder_n_codebooks(decoder))
+        guard frameHop > 0, sampleRate > 0, nCodebooks > 0 else {
+            throw IOSBenchError.vokra("codec returned invalid model axes")
+        }
+        let periodS = Double(frameHop) / Double(sampleRate)
+        let frameCount = Int(ceil(Self.sustainedDurationS / periodS))
+        var frames: [CodecFrame] = []
+        frames.reserveCapacity(frameCount)
+        let codes = [UInt32](repeating: 0, count: nCodebooks)
+        var pcm = [Float](repeating: 0, count: frameHop)
+        let startingThermal = thermalState()
+        let start = DispatchTime.now().uptimeNanoseconds
+
+        UIApplication.shared.isIdleTimerDisabled = true
+        defer { UIApplication.shared.isIdleTimerDisabled = false }
+
+        for index in 0..<frameCount {
+            let decodeStart = DispatchTime.now().uptimeNanoseconds
+            var emitted: Int32 = 0
+            let pushStatus = codes.withUnsafeBufferPointer { codeBuffer in
+                vokra_codec_decoder_push_codes(
+                    decoder,
+                    codeBuffer.baseAddress,
+                    codeBuffer.count,
+                    &emitted
+                )
+            }
+            try check(pushStatus, operation: "codec push frame \(index)")
+            guard emitted == 1 else {
+                throw IOSBenchError.vokra(
+                    "codec push frame \(index) emitted \(emitted), expected 1"
+                )
+            }
+            var written = 0
+            let pullStatus = pcm.withUnsafeMutableBufferPointer { pcmBuffer in
+                vokra_codec_decoder_pull_pcm(
+                    decoder,
+                    pcmBuffer.baseAddress,
+                    pcmBuffer.count,
+                    &written
+                )
+            }
+            try check(pullStatus, operation: "codec pull frame \(index)")
+            guard written == frameHop else {
+                throw IOSBenchError.vokra(
+                    "codec pull frame \(index) wrote \(written), expected \(frameHop)"
+                )
+            }
+            let decodeMS = Double(
+                DispatchTime.now().uptimeNanoseconds - decodeStart
+            ) / 1_000_000.0
+
+            let deadline = start + UInt64(Double(index + 1) * periodS * 1_000_000_000.0)
+            let now = DispatchTime.now().uptimeNanoseconds
+            if deadline > now {
+                Thread.sleep(forTimeInterval: Double(deadline - now) / 1_000_000_000.0)
+            }
+            frames.append(
+                CodecFrame(
+                    index: index,
+                    wallElapsedS: secondsSince(start),
+                    decodeMS: decodeMS,
+                    peakRSSBytes: peakRSSBytes(),
+                    thermalState: thermalState()
+                )
+            )
+        }
+
+        let url = try writeCodecJSONL(
+            modelSHA: modelSHA,
+            sampleRate: sampleRate,
+            frameHop: frameHop,
+            nCodebooks: nCodebooks,
+            startingThermal: startingThermal,
+            frames: frames
+        )
+        let latencies = frames.map(\.decodeMS)
+        return CodecSummary(
+            logURL: url,
+            frameCount: frames.count,
+            durationS: frames.last?.wallElapsedS ?? 0.0,
+            p50MS: percentile(latencies, 0.50),
+            p95MS: percentile(latencies, 0.95),
+            p99MS: percentile(latencies, 0.99),
+            peakRSSBytes: frames.map(\.peakRSSBytes).max() ?? peakRSSBytes()
+        )
+    }
+
+    private func openSession(
+        modelURL: URL,
+        backend: IOSBenchBackend
+    ) throws -> OpaquePointer {
+        guard let options = vokra_session_options_create() else {
+            throw IOSBenchError.vokra("session options allocation failed")
+        }
+        defer { vokra_session_options_destroy(options) }
+        try check(
+            vokra_session_options_set_backend(options, backend.abiValue),
+            operation: "select backend \(backend.rawValue)"
+        )
+        var session: OpaquePointer?
+        let status = modelURL.path.withCString { path in
+            vokra_session_create_from_file_with_options(path, options, &session)
+        }
+        try check(status, operation: "create \(backend.rawValue) session")
+        guard let session else {
+            throw IOSBenchError.vokra("session create returned OK with NULL handle")
+        }
+        return session
+    }
+
+    private func transcribe(session: OpaquePointer, pcm: [Float]) throws -> String {
+        var output: UnsafeMutablePointer<CChar>?
+        let status = pcm.withUnsafeBufferPointer { buffer in
+            vokra_asr_transcribe(session, buffer.baseAddress, buffer.count, 16_000, &output)
+        }
+        try check(status, operation: "Whisper transcribe")
+        guard let output else {
+            throw IOSBenchError.vokra("transcribe returned OK with NULL text")
+        }
+        defer { vokra_string_free(output) }
+        return String(cString: output)
+    }
+
+    private func check(_ status: vokra_status_t, operation: String) throws {
+        guard status.rawValue == VOKRA_OK.rawValue else {
+            throw IOSBenchError.vokra(
+                "\(operation) failed rc=\(status.rawValue): \(lastVokraError())"
+            )
+        }
+    }
+
+    private func lastVokraError() -> String {
+        guard let pointer = vokra_last_error() else { return "<no error detail>" }
+        return String(cString: pointer)
+    }
+
+    private func loadMonoFloat32WAV(_ url: URL, expectedRate: Double) throws -> [Float] {
+        let file = try AVAudioFile(forReading: url)
+        let format = file.processingFormat
+        guard format.channelCount == 1, format.sampleRate == expectedRate else {
+            throw IOSBenchError.resource(
+                "WAV must be mono \(Int(expectedRate)) Hz; got " +
+                "\(format.channelCount) channel(s) at \(format.sampleRate) Hz"
+            )
+        }
+        guard let buffer = AVAudioPCMBuffer(
+            pcmFormat: format,
+            frameCapacity: AVAudioFrameCount(file.length)
+        ) else {
+            throw IOSBenchError.resource("cannot allocate WAV buffer")
+        }
+        try file.read(into: buffer)
+        guard let channel = buffer.floatChannelData?[0] else {
+            throw IOSBenchError.resource("AVAudioFile did not expose Float32 PCM")
+        }
+        return Array(UnsafeBufferPointer(start: channel, count: Int(buffer.frameLength)))
+    }
+
+    private func sha256(_ url: URL) throws -> String {
+        guard let handle = try? FileHandle(forReadingFrom: url) else {
+            throw IOSBenchError.io("cannot open for SHA-256: \(url.path)")
+        }
+        defer { try? handle.close() }
+        var hash = SHA256()
+        while true {
+            let chunk = try handle.read(upToCount: 1 << 20) ?? Data()
+            if chunk.isEmpty { break }
+            hash.update(data: chunk)
+        }
+        return hash.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func writeJSON<T: Encodable>(_ value: T, stem: String) throws -> URL {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(value)
+        let url = documentsURL().appendingPathComponent("\(stem)-\(timestamp()).json")
+        try data.write(to: url, options: .atomic)
+        return url
+    }
+
+    private func writeCodecJSONL(
+        modelSHA: String,
+        sampleRate: Int,
+        frameHop: Int,
+        nCodebooks: Int,
+        startingThermal: String,
+        frames: [CodecFrame]
+    ) throws -> URL {
+        var data = Data()
+        func append(_ object: [String: Any]) throws {
+            data.append(try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]))
+            data.append(0x0A)
+        }
+        try append([
+            "kind": "metadata",
+            "schema": "vokra.ios-codec-sustained.v1",
+            "build_sha": configuration.buildSHA.lowercased(),
+            "model_sha256": modelSHA,
+            "device_model": configuration.deviceModel,
+            "ios_version": UIDevice.current.systemVersion,
+            "backend": IOSBenchBackend.cpu.rawValue,
+            "sample_rate": sampleRate,
+            "frame_hop": frameHop,
+            "n_codebooks": nCodebooks,
+            "target_duration_s": Self.sustainedDurationS,
+            "conditions": [
+                "ambient_temperature_c": configuration.ambientTemperatureC,
+                "starting_thermal_state": startingThermal,
+                "screen": configuration.screen,
+                "charging": configuration.charging,
+                "case": configuration.caseState,
+            ],
+        ])
+        for frame in frames {
+            try append([
+                "kind": "frame",
+                "index": frame.index,
+                "wall_elapsed_s": frame.wallElapsedS,
+                "decode_ms": frame.decodeMS,
+                "peak_rss_bytes": frame.peakRSSBytes,
+                "thermal_state": frame.thermalState,
+            ])
+        }
+        let url = documentsURL().appendingPathComponent(
+            "vokra-ios-codec-sustained-\(timestamp()).jsonl"
+        )
+        try data.write(to: url, options: .atomic)
+        return url
+    }
+
+    private func documentsURL() -> URL {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+    }
+
+    private func timestamp() -> String {
+        let formatter = ISO8601DateFormatter()
+        return formatter.string(from: Date()).replacingOccurrences(of: ":", with: "-")
+    }
+
+    private func secondsSince(_ start: UInt64) -> Double {
+        Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000_000.0
+    }
+
+    private func percentile(_ values: [Double], _ q: Double) -> Double {
+        guard !values.isEmpty else { return .nan }
+        let sorted = values.sorted()
+        let index = max(0, Int(ceil(q * Double(sorted.count))) - 1)
+        return sorted[index]
+    }
+
+    private func peakRSSBytes() -> UInt64 {
+        var usage = rusage()
+        guard getrusage(RUSAGE_SELF, &usage) == 0 else { return 0 }
+        // Darwin documents ru_maxrss in bytes (unlike Linux's KiB unit).
+        return UInt64(max(0, usage.ru_maxrss))
+    }
+
+    private func thermalState() -> String {
+        switch ProcessInfo.processInfo.thermalState {
+        case .nominal: return "nominal"
+        case .fair: return "fair"
+        case .serious: return "serious"
+        case .critical: return "critical"
+        @unknown default: return "critical"
+        }
+    }
+}

--- a/tools/bench/ios-device/README.md
+++ b/tools/bench/ios-device/README.md
@@ -1,0 +1,71 @@
+# Physical iPhone benchmark harness
+
+This directory is the executable handoff for issue #52. It does not make a
+Simulator result look like an iPhone result and it does not ship invented
+numbers.
+
+## Before opening Xcode
+
+1. Build `build/ios/Vokra.xcframework` from the exact branch SHA and run
+   `scripts/verify-ios-xcframework.sh`.
+2. Create an iOS 15+ SwiftUI app, add this repository as a local package, and
+   attach the `Vokra` product.
+3. Add `IOSDeviceBench.swift`, `whisper-base.gguf`, `mimi.gguf`, and
+   `tests/fixtures/audio/jfk-30s.wav` to the app target. The codec GGUF requires
+   issue #48's `vokra_codec_decoder_*` ABI.
+4. Set a signing Team and a unique bundle identifier. Connect, unlock, and
+   trust a physical iPhone. Simulator output is not admissible.
+5. Fill `IOSBenchConfiguration` with `git rev-parse HEAD`, the exact device
+   model, measured ambient temperature, screen/charging/case conditions. iOS
+   exposes only `ProcessInfo.thermalState`, not an internal temperature in °C;
+   the harness records that categorical starting and ending state.
+
+Call the blocking methods from a background task so the UI remains responsive:
+
+```swift
+let config = IOSBenchConfiguration(
+    buildSHA: "<40-hex HEAD>",
+    deviceModel: "<marketing model + hw identifier>",
+    ambientTemperatureC: 23.0,
+    screen: "on",
+    charging: false,
+    caseState: "removed"
+)
+let bench = try IOSDeviceBench(configuration: config)
+
+Task.detached {
+    let whisper = try bench.measureWhisper(
+        modelURL: Bundle.main.url(forResource: "whisper-base", withExtension: "gguf")!,
+        wavURL: Bundle.main.url(forResource: "jfk-30s", withExtension: "wav")!,
+        backend: .cpu
+    )
+    print("Whisper report: \(whisper.1.path)")
+
+    let codec = try bench.measureSustainedCodec(
+        modelURL: Bundle.main.url(forResource: "mimi", withExtension: "gguf")!
+    )
+    print("Codec JSONL: \(codec.logURL.path)")
+}
+```
+
+Run CPU and Metal Whisper measurements as separate cold launches. A Metal
+construction/inference error is recorded as an error, not replaced with a CPU
+number. The Whisper run fixes 3 warmups and 10 measured iterations over the
+exact 30-second fixture and records median RTF plus process-lifetime peak RSS.
+
+The codec run is paced at `frame_hop / sample_rate` for 1800 seconds. It stores
+frame data in pre-reserved memory and writes JSONL only after timing, so file I/O
+is outside per-frame latency. Export the report from the app's Documents folder
+and validate it on the Mac:
+
+```sh
+uv run --project tools/parity --python 3.12 python tools/bench/ios_sustained_analyze.py \
+  vokra-ios-codec-sustained-....jsonl \
+  --json-output sustained-report.json \
+  --markdown-output sustained-report.md
+```
+
+The analyzer refuses a shortened/sparse/non-contiguous run. Its Markdown gives
+p50/p95/p99, frame-deadline misses, peak RSS, thermal transition, and the exact
+last-decile/first-decile p50 ratio. That ratio is descriptive; no unapproved
+performance threshold is invented.

--- a/tools/bench/ios_sustained_analyze.py
+++ b/tools/bench/ios_sustained_analyze.py
@@ -1,0 +1,297 @@
+"""Validate and summarize a physical-iPhone sustained codec JSONL log.
+
+Run through the repository's uv environment:
+
+    uv run --project tools/parity python tools/bench/ios_sustained_analyze.py LOG.jsonl
+
+The analyzer is deliberately fail-closed: a 30-minute target in metadata is
+not enough. It also requires the corresponding frame count, contiguous frame
+indices, and at least 1800 seconds of observed wall time before reporting
+percentiles. No pass/fail performance threshold is invented; the report gives
+the exact last-decile/first-decile median ratio and whether the last median was
+numerically slower.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "vokra.ios-codec-sustained.v1"
+MIN_SUSTAINED_SECONDS = 1_800.0
+THERMAL_STATES = {"nominal", "fair", "serious", "critical"}
+
+
+class AnalysisError(Exception):
+    """The log cannot substantiate the claimed physical-device run."""
+
+
+def load_jsonl(path: str | Path) -> list[dict[str, Any]]:
+    """Load non-empty JSON objects, retaining line numbers in failures."""
+    source = Path(path)
+    if not source.is_file():
+        raise AnalysisError(f"log file not found: {source}")
+    records: list[dict[str, Any]] = []
+    for line_no, raw in enumerate(source.read_text(encoding="utf-8").splitlines(), 1):
+        if not raw.strip():
+            continue
+        try:
+            value = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            raise AnalysisError(f"invalid JSON on line {line_no}: {exc}") from exc
+        if not isinstance(value, dict):
+            raise AnalysisError(f"line {line_no} is not a JSON object")
+        records.append(value)
+    if not records:
+        raise AnalysisError("log contains no JSON records")
+    return records
+
+
+def _finite_number(value: Any, label: str, *, positive: bool = False) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise AnalysisError(f"{label} must be numeric")
+    number = float(value)
+    if not math.isfinite(number) or (positive and number <= 0.0):
+        suffix = " and > 0" if positive else ""
+        raise AnalysisError(f"{label} must be finite{suffix}")
+    return number
+
+
+def _positive_int(value: Any, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise AnalysisError(f"{label} must be an integer > 0")
+    return value
+
+
+def _required_string(mapping: dict[str, Any], key: str, prefix: str = "metadata") -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise AnalysisError(f"{prefix}.{key} must be a non-empty string")
+    return value
+
+
+def _nearest_rank(sorted_values: list[float], percentile: float) -> float:
+    if not sorted_values:
+        raise AnalysisError("cannot compute a percentile over no frames")
+    index = max(0, math.ceil(percentile * len(sorted_values)) - 1)
+    return sorted_values[index]
+
+
+def _percentiles(values: list[float]) -> dict[str, float]:
+    ordered = sorted(values)
+    return {
+        "p50": _nearest_rank(ordered, 0.50),
+        "p95": _nearest_rank(ordered, 0.95),
+        "p99": _nearest_rank(ordered, 0.99),
+    }
+
+
+def analyze_records(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Validate a v1 JSONL record list and return a reproducible summary."""
+    if not records or records[0].get("kind") != "metadata":
+        raise AnalysisError("line 1 must be the single metadata record")
+    if any(record.get("kind") == "metadata" for record in records[1:]):
+        raise AnalysisError("log must contain exactly one metadata record")
+    meta = records[0]
+    if meta.get("schema") != SCHEMA:
+        raise AnalysisError(f"metadata.schema must equal {SCHEMA!r}")
+
+    build_sha = _required_string(meta, "build_sha")
+    model_sha256 = _required_string(meta, "model_sha256")
+    if len(build_sha) != 40 or any(c not in "0123456789abcdef" for c in build_sha.lower()):
+        raise AnalysisError("metadata.build_sha must be 40 hexadecimal characters")
+    if len(model_sha256) != 64 or any(
+        c not in "0123456789abcdef" for c in model_sha256.lower()
+    ):
+        raise AnalysisError("metadata.model_sha256 must be 64 hexadecimal characters")
+    device_model = _required_string(meta, "device_model")
+    ios_version = _required_string(meta, "ios_version")
+    backend = _required_string(meta, "backend")
+
+    conditions = meta.get("conditions")
+    if not isinstance(conditions, dict):
+        raise AnalysisError("metadata.conditions must be an object")
+    ambient = _finite_number(
+        conditions.get("ambient_temperature_c"),
+        "metadata.conditions.ambient_temperature_c",
+    )
+    starting_thermal = _required_string(conditions, "starting_thermal_state", "conditions")
+    if starting_thermal not in THERMAL_STATES:
+        raise AnalysisError(
+            "metadata.conditions.starting_thermal_state must be nominal/fair/serious/critical"
+        )
+    screen = _required_string(conditions, "screen", "conditions")
+    if screen not in {"on", "off"}:
+        raise AnalysisError("metadata.conditions.screen must be 'on' or 'off'")
+    charging = conditions.get("charging")
+    if not isinstance(charging, bool):
+        raise AnalysisError("metadata.conditions.charging must be boolean")
+    case = _required_string(conditions, "case", "conditions")
+    if case not in {"installed", "removed"}:
+        raise AnalysisError("metadata.conditions.case must be 'installed' or 'removed'")
+
+    sample_rate = _positive_int(meta.get("sample_rate"), "metadata.sample_rate")
+    frame_hop = _positive_int(meta.get("frame_hop"), "metadata.frame_hop")
+    n_codebooks = _positive_int(meta.get("n_codebooks"), "metadata.n_codebooks")
+    target_duration = _finite_number(
+        meta.get("target_duration_s"), "metadata.target_duration_s", positive=True
+    )
+
+    frames = records[1:]
+    if not frames:
+        raise AnalysisError("log contains no frame records")
+    decode_ms: list[float] = []
+    peak_rss = 0
+    end_thermal = starting_thermal
+    wall_elapsed = 0.0
+    for expected_index, frame in enumerate(frames):
+        if frame.get("kind") != "frame":
+            raise AnalysisError(f"record {expected_index + 2} kind must be 'frame'")
+        if frame.get("index") != expected_index:
+            raise AnalysisError(
+                f"frame indices must be contiguous from 0: expected {expected_index}, "
+                f"got {frame.get('index')!r}"
+            )
+        latency = _finite_number(frame.get("decode_ms"), f"frame[{expected_index}].decode_ms")
+        if latency < 0.0:
+            raise AnalysisError(f"frame[{expected_index}].decode_ms must be >= 0")
+        elapsed = _finite_number(
+            frame.get("wall_elapsed_s"),
+            f"frame[{expected_index}].wall_elapsed_s",
+            positive=True,
+        )
+        if elapsed <= wall_elapsed:
+            raise AnalysisError("frame wall_elapsed_s values must be strictly increasing")
+        rss = _positive_int(frame.get("peak_rss_bytes"), f"frame[{expected_index}].peak_rss_bytes")
+        thermal = frame.get("thermal_state")
+        if thermal not in THERMAL_STATES:
+            raise AnalysisError(
+                f"frame[{expected_index}].thermal_state must be nominal/fair/serious/critical"
+            )
+        decode_ms.append(latency)
+        wall_elapsed = elapsed
+        peak_rss = max(peak_rss, rss)
+        end_thermal = thermal
+
+    # A log cannot claim a reduced target and still satisfy issue #52.
+    if target_duration < MIN_SUSTAINED_SECONDS:
+        raise AnalysisError(
+            f"target_duration_s {target_duration:g} is below the required "
+            f"{MIN_SUSTAINED_SECONDS:g} seconds"
+        )
+    frame_period_s = frame_hop / sample_rate
+    expected_frames = math.ceil(target_duration / frame_period_s)
+    if len(frames) < expected_frames:
+        raise AnalysisError(
+            f"frame count {len(frames)} is below {expected_frames} required for "
+            f"{target_duration:g}s at hop={frame_hop}, rate={sample_rate}"
+        )
+    if wall_elapsed < target_duration:
+        raise AnalysisError(
+            f"observed duration {wall_elapsed:g}s is below target {target_duration:g}s"
+        )
+
+    decile_count = max(1, len(decode_ms) // 10)
+    first_p50 = _percentiles(decode_ms[:decile_count])["p50"]
+    last_p50 = _percentiles(decode_ms[-decile_count:])["p50"]
+    ratio = last_p50 / first_p50 if first_p50 > 0.0 else math.inf
+    deadline_ms = frame_period_s * 1_000.0
+    deadline_misses = sum(latency > deadline_ms for latency in decode_ms)
+
+    return {
+        "schema": "vokra.ios-codec-sustained-report.v1",
+        "source_schema": SCHEMA,
+        "build_sha": build_sha,
+        "model_sha256": model_sha256,
+        "device_model": device_model,
+        "ios_version": ios_version,
+        "backend": backend,
+        "sample_rate": sample_rate,
+        "frame_hop": frame_hop,
+        "n_codebooks": n_codebooks,
+        "target_duration_s": target_duration,
+        "actual_duration_s": wall_elapsed,
+        "frame_count": len(frames),
+        "decode_ms": _percentiles(decode_ms),
+        "frame_deadline_ms": deadline_ms,
+        "deadline_miss_frames": deadline_misses,
+        "peak_rss_bytes": peak_rss,
+        "start_thermal_state": starting_thermal,
+        "end_thermal_state": end_thermal,
+        "conditions": {
+            "ambient_temperature_c": ambient,
+            "screen": screen,
+            "charging": charging,
+            "case": case,
+        },
+        "degradation": {
+            "comparison": "last 10% p50 / first 10% p50",
+            "first_decile_p50_ms": first_p50,
+            "last_decile_p50_ms": last_p50,
+            "last_to_first_ratio": ratio,
+            "last_decile_slower": last_p50 > first_p50,
+        },
+    }
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    """Render the summary in a form ready for the device benchmark doc."""
+    latency = report["decode_ms"]
+    trend = report["degradation"]
+    conditions = report["conditions"]
+    return "\n".join(
+        [
+            "# iOS sustained codec run",
+            "",
+            f"- Device: `{report['device_model']}` / iOS `{report['ios_version']}`",
+            f"- Backend: `{report['backend']}`",
+            f"- Build SHA: `{report['build_sha']}`",
+            f"- Model SHA-256: `{report['model_sha256']}`",
+            f"- Duration: `{report['actual_duration_s']:.3f} s` "
+            f"({report['frame_count']} frames)",
+            f"- Decode latency: p50 `{latency['p50']:.6f} ms`, "
+            f"p95 `{latency['p95']:.6f} ms`, p99 `{latency['p99']:.6f} ms`",
+            f"- Frame deadline: `{report['frame_deadline_ms']:.6f} ms`; "
+            f"misses: `{report['deadline_miss_frames']}`",
+            f"- Peak RSS: `{report['peak_rss_bytes']} bytes`",
+            f"- Thermal state: `{report['start_thermal_state']}` → "
+            f"`{report['end_thermal_state']}`",
+            f"- Last/first decile p50 ratio: `{trend['last_to_first_ratio']:.6f}`; "
+            f"last decile slower: `{str(trend['last_decile_slower']).lower()}`",
+            f"- Conditions: ambient `{conditions['ambient_temperature_c']:.1f} °C`, "
+            f"screen `{conditions['screen']}`, charging "
+            f"`{str(conditions['charging']).lower()}`, case `{conditions['case']}`",
+            "",
+        ]
+    )
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("log", type=Path)
+    parser.add_argument("--json-output", type=Path)
+    parser.add_argument("--markdown-output", type=Path)
+    args = parser.parse_args(argv[1:])
+    try:
+        report = analyze_records(load_jsonl(args.log))
+    except AnalysisError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    encoded = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.json_output:
+        args.json_output.write_text(encoded, encoding="utf-8")
+    else:
+        print(encoded, end="")
+    if args.markdown_output:
+        args.markdown_output.write_text(render_markdown(report), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tools/bench/test_ios_sustained_analyze.py
+++ b/tools/bench/test_ios_sustained_analyze.py
@@ -1,0 +1,111 @@
+import json
+import math
+import tempfile
+import unittest
+from pathlib import Path
+
+from ios_sustained_analyze import AnalysisError, analyze_records, load_jsonl
+
+
+def metadata(target_duration_s=1_800.0):
+    return {
+        "kind": "metadata",
+        "schema": "vokra.ios-codec-sustained.v1",
+        "build_sha": "a" * 40,
+        "model_sha256": "b" * 64,
+        "device_model": "iPhone Test",
+        "ios_version": "26.0",
+        "backend": "cpu",
+        "sample_rate": 24_000,
+        "frame_hop": 1_920,
+        "n_codebooks": 8,
+        "target_duration_s": target_duration_s,
+        "conditions": {
+            "ambient_temperature_c": 23.5,
+            "starting_thermal_state": "nominal",
+            "screen": "on",
+            "charging": False,
+            "case": "removed",
+        },
+    }
+
+
+def complete_records(target_duration_s=1_800.0):
+    meta = metadata(target_duration_s)
+    period = meta["frame_hop"] / meta["sample_rate"]
+    count = math.ceil(target_duration_s / period)
+    records = [meta]
+    for index in range(count):
+        # Deliberately make the final decile slower so the trend field is
+        # independently testable from the aggregate percentiles.
+        decode_ms = 2.0 if index < count * 0.9 else 3.0
+        records.append(
+            {
+                "kind": "frame",
+                "index": index,
+                "wall_elapsed_s": (index + 1) * period,
+                "decode_ms": decode_ms,
+                "peak_rss_bytes": 100_000_000 + index,
+                "thermal_state": "nominal",
+            }
+        )
+    return records
+
+
+class IosSustainedAnalyzeTests(unittest.TestCase):
+    def test_complete_30_minute_run_reports_percentiles_rss_and_trend(self):
+        records = complete_records()
+        report = analyze_records(records)
+        self.assertEqual(report["frame_count"], 22_500)
+        self.assertAlmostEqual(report["actual_duration_s"], 1_800.0)
+        self.assertEqual(report["decode_ms"]["p50"], 2.0)
+        self.assertEqual(report["decode_ms"]["p95"], 3.0)
+        self.assertEqual(report["decode_ms"]["p99"], 3.0)
+        self.assertEqual(report["peak_rss_bytes"], 100_000_000 + 22_499)
+        self.assertEqual(report["degradation"]["first_decile_p50_ms"], 2.0)
+        self.assertEqual(report["degradation"]["last_decile_p50_ms"], 3.0)
+        self.assertTrue(report["degradation"]["last_decile_slower"])
+        self.assertEqual(report["deadline_miss_frames"], 0)
+
+    def test_short_or_sparse_run_is_rejected_instead_of_looking_complete(self):
+        records = complete_records(target_duration_s=1.0)
+        records[0]["target_duration_s"] = 1_800.0
+        with self.assertRaisesRegex(AnalysisError, "frame count"):
+            analyze_records(records)
+
+    def test_full_frame_count_cannot_hide_short_observed_wall_time(self):
+        records = complete_records()
+        period = records[0]["frame_hop"] / records[0]["sample_rate"]
+        for frame in records[1:]:
+            frame["wall_elapsed_s"] -= period / 2
+        with self.assertRaisesRegex(AnalysisError, "observed duration"):
+            analyze_records(records)
+
+    def test_missing_measurement_condition_is_rejected(self):
+        records = complete_records(target_duration_s=1.0)
+        del records[0]["conditions"]["case"]
+        with self.assertRaisesRegex(AnalysisError, "conditions.case"):
+            analyze_records(records)
+
+    def test_non_contiguous_frame_index_is_rejected(self):
+        records = complete_records(target_duration_s=1.0)
+        records[3]["index"] = 99
+        with self.assertRaisesRegex(AnalysisError, "contiguous"):
+            analyze_records(records)
+
+    def test_non_finite_latency_is_rejected(self):
+        records = complete_records(target_duration_s=1.0)
+        records[1]["decode_ms"] = float("nan")
+        with self.assertRaisesRegex(AnalysisError, "decode_ms"):
+            analyze_records(records)
+
+    def test_jsonl_loader_rejects_invalid_json_with_line_number(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "bad.jsonl"
+            path.write_text(json.dumps(metadata(1.0)) + "\n{bad}\n", encoding="utf-8")
+            with self.assertRaisesRegex(AnalysisError, "line 2"):
+                load_jsonl(path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an iPhoneOS-typechecked Swift harness for Whisper CPU/Metal RTF, peak RSS, and a 30-minute streaming codec run
- add a fail-closed JSONL analyzer with p50/p95/p99, deadline misses, RSS, thermal transition, and degradation trend
- correct the iOS C ABI examples and add complete measurement-condition templates

## Scope boundary
No physical iPhone measurement was performed. Result tables are intentionally blank, the physical-device acceptance criteria remain pending, and issue #52 must stay open.

The codec leg depends on #62 for the vokra_codec_decoder_* ABI.

Refs #52

## Verification
- Python 3.12 analyzer unit tests: 7 passed locally and on VAST
- analyzer py_compile: passed locally and on VAST
- Swift typecheck: passed for arm64-apple-ios15.0 with iPhoneOS 26.5 SDK against the #62 C header
- scripts/check-doc-references.sh: passed locally and on VAST
- scripts/check-zero-deps.sh: passed on VAST
- scripts/check-forbidden-symbols.sh: passed on VAST
- git diff --check: passed locally and on VAST

scripts/check-community-docs.sh remains at its pre-existing owner-contact PENDING state; all other legs in that script were green.