### PR TITLE
docs(release): track 18-crate publish closure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1136,7 +1136,7 @@ jobs:
   # ---------------------------------------------------------------------------
   # X-07-T11: crates.io publish dry-run (NFR-DS-03 "Cargo crate", token-free).
   #
-  # Validates that the 15-crate publish set (topological closure of vokra-capi +
+  # Validates that the 18-crate publish set (topological closure of vokra-capi +
   # vokra-cli, derived by tools/release/crates_publish_order.py) packages
   # cleanly, WITHOUT contacting the registry for a real publish. Runs on tag AND
   # workflow_dispatch (no upload, so no gating needed).
@@ -1146,7 +1146,7 @@ jobs:
   # the graph LEAF (vokra-core, no path deps) can fully dry-run before the first
   # real publish — every downstream crate fails with "no matching package named
   # vokra-* found" until its deps are actually on the registry. The pre-publish
-  # package-ability gate for ALL 15 crates is therefore `cargo package --list`
+  # package-ability gate for ALL 18 crates is therefore `cargo package --list`
   # (uses local path deps, no registry); the downstream publish chain is
   # validated end-to-end incrementally by crates-io-publish (owner, T12/T14).
   #
@@ -1210,7 +1210,7 @@ jobs:
   # ---------------------------------------------------------------------------
   # X-07-T12: crates.io real publish (NFR-MT-08 CD auto-publish, NFR-LC-02).
   #
-  # Publishes the 15-crate set in topological order (deps before dependents) on
+  # Publishes the 18-crate set in topological order (deps before dependents) on
   # tag push, gated on secrets.CRATES_IO_TOKEN. Token absent = honest ::notice::
   # skip (the OPENUPM_TOKEN / NPM_TOKEN idiom) — the GitHub Release assets remain
   # the baseline channel and the owner opts into crates.io in X-07-T14. crates.io

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ rust-version = "1.85"
 # NFR-LC-01: the whole runtime is Apache-2.0.
 license = "Apache-2.0"
 # crates.io listing metadata (X-07-T09, NFR-DS-03 "Cargo crate"). Inherited by
-# the 15-crate publish set via `<field>.workspace = true` in each crate header;
+# the 18-crate publish set via `<field>.workspace = true` in each crate header;
 # the excluded crates (vokra-eval + the tests/parity / tests/wasm-harness
 # harnesses) do NOT inherit these and stay `publish = false`. `documentation`
 # is intentionally left UNSET so crates.io auto-links each crate to its own
@@ -41,7 +41,7 @@ keywords = ["audio", "speech", "inference", "tts", "asr"]
 categories = ["multimedia::audio", "science", "api-bindings"]
 # Default is NOT publishable: the workspace-level `publish = false` guards
 # against accidental publishes of any NEW crate (crates.io is an immutable
-# index — a mistaken publish is unrecoverable). Only the 15 crates in the
+# index — a mistaken publish is unrecoverable). Only the 18 crates in the
 # publish closure override this with an explicit `publish = true`; the closure
 # (topological set) is derived mechanically by
 # tools/release/crates_publish_order.py and fixed in the ADR.

--- a/docs/handoff/x-07.md
+++ b/docs/handoff/x-07.md
@@ -10,11 +10,13 @@ issuance, sign-off). CC pre-verified every surface with dry-run oracles.
 
 ## 1. crates.io (X-07-T14)
 
-The publish set is the **15-crate topological closure** of `vokra-capi` +
+The publish set is the **18-crate topological closure** of `vokra-capi` +
 `vokra-cli` (derived by `tools/release/crates_publish_order.py`; run it to see
-the exact list + order). Owner steps, once:
+the exact list + order). The original 15-crate X-07 snapshot grew by
+`vokra-math`, `vokra-vad-micro`, and `vokra-bert` as those crates entered the
+runtime dependency closure. Owner steps, once:
 
-1. **Reserve the 15 crate names** on crates.io (`vokra-core`, `vokra-cli`, the
+1. **Reserve the 18 crate names** on crates.io (`vokra-core`, `vokra-cli`, the
    6 backend crates, etc. — `uv run --no-project --python 3.12 python tools/release/crates_publish_order.py`
    prints them). crates.io names are first-come.
 2. **Add `secrets.CRATES_IO_TOKEN`** (repo secret). `crates-io-publish` is gated
@@ -26,7 +28,7 @@ the exact list + order). Owner steps, once:
 **Chicken-and-egg to expect** (recorded in the ADR): `cargo publish --dry-run`
 for downstream crates cannot fully pass before the first real publish (it
 resolves version deps against the live index). The dry-run job therefore gates
-on `cargo package --list` for all 15 crates + a real dry-run of the leaf
+on `cargo package --list` for all 18 crates + a real dry-run of the leaf
 (`vokra-core`); the downstream chain validates itself during the incremental
 topological publish (`crates-io-publish`), which cargo sequences correctly.
 

--- a/tools/release/crates_publish_order.py
+++ b/tools/release/crates_publish_order.py
@@ -24,11 +24,12 @@ DESIGN (fixed by ADR docs/adr/X-07-release-train.md §crates.io):
     - integrations/*      — excluded workspaces (own Cargo.lock; link
                             NON-`vokra-*` crates — never publishable as vokra).
 
-* The closure computed from the real graph is 15 crates (NOT the "11" the spec
-  intake estimated — the 4 GPU/NPU backend crates vulkan/webgpu/coreml/qnn were
-  added after that count, and `vokra-models` references all 6 backends as
-  `dep:`-optional so they are forced into the closure). Actual code wins; the
-  discrepancy is recorded in the ADR.
+* The closure computed from the real graph is currently 18 crates (NOT the
+  "11" the spec intake estimated). The original X-07 correction reached 15
+  after adding the 4 GPU/NPU backend crates vulkan/webgpu/coreml/qnn; the live
+  runtime graph later pulled in `vokra-math`, `vokra-vad-micro`, and
+  `vokra-bert`. Actual code wins, and `test_crates_io.py` checks that every
+  tracked release count follows this mechanically derived value.
 
 Zero-dep (NFR-DS-02): python3 stdlib only, driving `cargo metadata` (a built-in
 of the pinned toolchain). No third-party crate, so the root Cargo.lock cannot

--- a/tools/release/test_crates_io.py
+++ b/tools/release/test_crates_io.py
@@ -28,6 +28,7 @@ Usage: python3 tools/release/test_crates_io.py
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import subprocess
@@ -37,6 +38,22 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), 
 RELEASE_YML = os.path.join(ROOT, ".github", "workflows", "release.yml")
 ORDER_TOOL = os.path.join(ROOT, "tools", "release", "crates_publish_order.py")
 API_SNAPSHOT = os.path.join(ROOT, "docs", "abi", "vokra-rust-public-api.v1.0-rc.list")
+COUNT_CONTRACT_FILES = (
+    os.path.join(ROOT, "Cargo.toml"),
+    RELEASE_YML,
+    os.path.join(ROOT, "docs", "handoff", "x-07.md"),
+    ORDER_TOOL,
+)
+COUNT_PATTERNS = (
+    re.compile(r"\b(\d+)-crate publish set\b", re.IGNORECASE),
+    re.compile(r"\b(\d+)-crate topological closure\b", re.IGNORECASE),
+    re.compile(r"\bReserve the (\d+) crate names\b", re.IGNORECASE),
+    re.compile(r"\bcargo package --list`? for all (\d+) crates\b", re.IGNORECASE),
+    re.compile(r"\bALL (\d+) crates\b"),
+    re.compile(r"\bPublishes the (\d+)-crate set\b", re.IGNORECASE),
+    re.compile(r"\bOnly the (\d+) crates\b", re.IGNORECASE),
+    re.compile(r"\bcurrently (\d+) crates\b", re.IGNORECASE),
+)
 
 _pass = 0
 _fail = 0
@@ -130,7 +147,10 @@ def main() -> None:
 
     # (4) order tool self-verify.
     proc = subprocess.run(
-        ["python3", ORDER_TOOL, "--verify"], cwd=ROOT, capture_output=True, text=True
+        [sys.executable, ORDER_TOOL, "--verify"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
     )
     if proc.returncode == 0:
         ok(f"(4) crates_publish_order.py --verify OK ({proc.stdout.strip().splitlines()[-1] if proc.stdout.strip() else 'ok'})")
@@ -148,6 +168,39 @@ def main() -> None:
         ok("(6) Rust public-API snapshot present (publish-time contract record)")
     else:
         bad(f"(6) Rust public-API snapshot missing: {API_SNAPSHOT}")
+
+    # (7) Every tracked human-facing publish-count claim follows the current
+    # mechanically derived closure. This turns the 15 -> 18 documentation
+    # regression into a failing oracle instead of another manual audit item.
+    count_proc = subprocess.run(
+        [sys.executable, ORDER_TOOL, "--json"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if count_proc.returncode != 0:
+        bad(f"(7) could not derive publish count: {count_proc.stderr.strip()[:200]}")
+    else:
+        derived_count = json.loads(count_proc.stdout)["count"]
+        claims: list[tuple[str, int]] = []
+        for path in COUNT_CONTRACT_FILES:
+            body = open(path, encoding="utf-8").read()
+            for pattern in COUNT_PATTERNS:
+                claims.extend(
+                    (os.path.relpath(path, ROOT), int(match.group(1)))
+                    for match in pattern.finditer(body)
+                )
+        stale = [(path, count) for path, count in claims if count != derived_count]
+        if not claims:
+            bad("(7) no tracked publish-count claims found (oracle would be vacuous)")
+        elif stale:
+            detail = ", ".join(f"{path}={count}" for path, count in stale)
+            bad(f"(7) publish-count drift: graph={derived_count}; {detail}")
+        else:
+            ok(
+                f"(7) {len(claims)} tracked publish-count claims match "
+                f"the derived {derived_count}-crate closure"
+            )
 
     print()
     print(f"crates-io oracle: {_pass} passed, {_fail} failed")


### PR DESCRIPTION
## Summary
- replace stale 15-crate release claims with the mechanically-derived 18-crate closure
- document the three newly included crates
- add an oracle that fails when tracked count claims drift from the derived closure

## Validation
- `tools/release/test_crates_io.py`: 9 passed, 0 failed on this branch
- `crates_publish_order.py --verify`: 18 crates, valid topological order
- workflow hygiene and `git diff --check`: green
- VAST workspace validation on integrated commit `5e9f1c0b`: `cargo test --workspace`, 0 failed; instance `48452775` destroyed after completion