### PR TITLE
ci(release): enforce one package version contract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,11 @@ on:
         required: false
         type: boolean
         default: true
+      release_version:
+        description: "Candidate unprefixed SemVer for dry-run (empty = workspace version)"
+        required: false
+        type: string
+        default: ""
 
 concurrency:
   group: release-${{ github.ref }}
@@ -49,40 +54,35 @@ permissions:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # X-07-T18: semver tag gate. The tag glob `v*` (on.push.tags) accepts any
-  # `v…` string, including a non-semver one like `vfoo` that the per-job version
-  # derivation (`GITHUB_REF_NAME#v`) silently mis-parses. This job rejects a
-  # non-semver tag fail-loud so the whole release train refuses to run on a
-  # malformed tag.
-  #
-  # CRITICAL — non-tag refs ANNOUNCED-SKIP (pass): the entire dry-run / dispatch
-  # verification path runs on `workflow_dispatch` (a non-tag ref). If this job
-  # failed on non-tag refs, then `needs: validate-tag` on every other job would
-  # block the whole dry-run path (and T35's regression verify with it). So on a
-  # non-tag ref it emits a ::notice:: and PASSES — an announced skip (the gate
-  # is inapplicable when there is no tag to judge), NOT a fabricated pass.
-  # The current default version is 0.1.0-alpha.0 (Cargo.toml:21); the first
-  # release tag must be a valid `vX.Y.Z[-prerelease]` (e.g. v1.0.0-rc.1).
+  # X-07-T18: single release-version contract. The workspace version is the
+  # source of truth for an effectful tag release; `vX.Y.Z` must match it exactly
+  # before release-notes can create a GitHub Release. workflow_dispatch accepts
+  # an optional candidate so dry-run exercises every package with one version
+  # without prematurely changing source metadata.
   # ---------------------------------------------------------------------------
   validate-tag:
     name: validate-tag
     runs-on: ubuntu-latest
     timeout-minutes: 180
+    outputs:
+      version: ${{ steps.version-contract.outputs.version }}
     steps:
-      - name: Validate semver tag (announced-skip on non-tag refs)
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+        with:
+          enable-cache: false
+      - name: Resolve and validate the canonical release version
+        id: version-contract
+        env:
+          DISPATCH_VERSION: ${{ inputs.release_version }}
         run: |
-          if [[ "${GITHUB_REF}" != refs/tags/* ]]; then
-            echo "::notice::validate-tag: non-tag ref (${GITHUB_REF}) — semver gate not applicable (workflow_dispatch / branch). Passing (announced skip, not a fabricated pass)."
-            exit 0
-          fi
-          TAG="${GITHUB_REF#refs/tags/}"
-          # v-prefixed semver: vX.Y.Z with optional -prerelease and +build.
-          if [[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
-            echo "validate-tag: OK — '$TAG' is a valid semver tag"
-          else
-            echo "validate-tag: FAIL — tag '$TAG' is not semver (expected vX.Y.Z[-prerelease][+build])" >&2
-            exit 1
-          fi
+          uv run --no-project --python 3.12 python \
+            tools/release/version_contract.py \
+            --github-ref "$GITHUB_REF" \
+            --dispatch-version "$DISPATCH_VERSION" \
+            --github-output "$GITHUB_OUTPUT"
 
   ios-xcframework:
     name: ios-xcframework
@@ -311,24 +311,11 @@ jobs:
         with:
           lookup-only: true
 
-      - name: Compute release version (semver from tag, v-prefix stripped)
-        id: version
+      - name: Stamp validated release version into Unity package
+        working-directory: bindings/unity/com.vokra.unity
         run: |
-          # Tag path: refs/tags/v0.1.0-preview.1 -> version=0.1.0-preview.1
-          # workflow_dispatch path: fall back to package.json version so
-          # dry-runs are still meaningful.
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            V="${GITHUB_REF_NAME#v}"
-          else
-            V="$(awk -F'"' '/^[[:space:]]*"version"[[:space:]]*:/ { print $4; exit }' \
-              bindings/unity/com.vokra.unity/package.json)"
-          fi
-          if [ -z "$V" ]; then
-            echo "unity-package-release: FAIL could not derive version" >&2
-            exit 1
-          fi
-          echo "version=${V}" >> "$GITHUB_OUTPUT"
-          echo "Release version: ${V}"
+          npm version --no-git-tag-version --allow-same-version \
+            "${{ needs.validate-tag.outputs.version }}"
 
       - name: Download iOS XCFramework artifact from ios-xcframework job
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
@@ -495,7 +482,7 @@ jobs:
       - name: Verify tarball + compute .sha256
         id: pack
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
+          VERSION="${{ needs.validate-tag.outputs.version }}"
           # build-unity-plugin.sh names the tarball from package.json's
           # version. On tag push the CD flow expects that version to have
           # been bumped by a preceding commit; assert alignment or fail
@@ -570,7 +557,7 @@ jobs:
         if: inputs.dry_run == true || !startsWith(github.ref, 'refs/tags/v')
         run: |
           echo "== DRY RUN (unity-package-release) =="
-          echo "Version : ${{ steps.version.outputs.version }}"
+          echo "Version : ${{ needs.validate-tag.outputs.version }}"
           echo "Tarball : ${{ steps.pack.outputs.tarball }}"
           echo "SHA256  : ${{ steps.pack.outputs.sha256 }}"
           echo "Skipping: gh release upload, OpenUPM publish."
@@ -606,7 +593,7 @@ jobs:
     needs: validate-tag
     uses: ./.github/workflows/python-wheels.yml
     with:
-      version: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '0.1.0.dev0' }}
+      version: ${{ needs.validate-tag.outputs.version }}
 
   python-pypi-publish:
     name: python-pypi-publish
@@ -789,27 +776,6 @@ jobs:
         with:
           enable-cache: false
 
-      - name: Compute release version (semver from tag, v-prefix stripped)
-        id: version
-        run: |
-          # Tag path: refs/tags/v0.1.0-preview.1 -> version=0.1.0-preview.1
-          # workflow_dispatch path: fall back to the Cargo.toml version so
-          # dry-runs are still meaningful. build-godot-gdextension.sh --pack
-          # names the zip from that Cargo.toml value; asserting alignment
-          # here surfaces version drift before the tarball ships silently.
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            V="${GITHUB_REF_NAME#v}"
-          else
-            V="$(awk -F'"' '/^[[:space:]]*version[[:space:]]*=/ { print $2; exit }' \
-              integrations/vokra-godot/Cargo.toml)"
-          fi
-          if [ -z "$V" ]; then
-            echo "godot-package-release: FAIL could not derive version" >&2
-            exit 1
-          fi
-          echo "version=${V}" >> "$GITHUB_OUTPUT"
-          echo "Release version: ${V}"
-
       - name: Reuse per-target cdylibs from godot-crossbuild.yml matrix (advisory, record-only)
         id: reuse-godot-cdylibs
         # T16 crossbuild produces one vokra-godot-<triple> artifact per
@@ -905,6 +871,8 @@ jobs:
             --output dist/godot/vokra-godot/addons/vokra/vokra-godot-assetlib.spdx.json
 
       - name: Pack AssetLib zip (SOURCE_DATE_EPOCH pinned, --no-build)
+        env:
+          VOKRA_RELEASE_VERSION: ${{ needs.validate-tag.outputs.version }}
         run: |
           set -euo pipefail
           SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)"
@@ -916,7 +884,7 @@ jobs:
         id: pack
         run: |
           set -euo pipefail
-          VERSION="${{ steps.version.outputs.version }}"
+          VERSION="${{ needs.validate-tag.outputs.version }}"
           # build-godot-gdextension.sh names the zip from
           # integrations/vokra-godot/Cargo.toml's version. On tag push
           # the CD flow expects that version to have been bumped by a
@@ -984,7 +952,7 @@ jobs:
         if: inputs.dry_run == true || !startsWith(github.ref, 'refs/tags/v')
         run: |
           echo "== DRY RUN (godot-package-release) =="
-          echo "Version : ${{ steps.version.outputs.version }}"
+          echo "Version : ${{ needs.validate-tag.outputs.version }}"
           echo "Zip     : ${{ steps.pack.outputs.zip }}"
           echo "SHA256  : ${{ steps.pack.outputs.sha256 }}"
           echo "Skipping: gh release upload, Godot AssetLib API update."
@@ -1035,11 +1003,7 @@ jobs:
       - name: Compute release version (semver from tag, v-prefix stripped)
         id: version
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            V="${GITHUB_REF_NAME#v}"
-          else
-            V="0.0.0-dev.$(git rev-parse --short HEAD)"
-          fi
+          V="${{ needs.validate-tag.outputs.version }}"
           echo "version=$V" >> "$GITHUB_OUTPUT"
           case "$V" in
             *-rc.*) echo "disttag=rc" >> "$GITHUB_OUTPUT" ;;
@@ -1307,11 +1271,7 @@ jobs:
 
       - name: Extract release notes from CHANGELOG (X-07-T15/T16)
         run: |
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            VERSION="${GITHUB_REF_NAME#v}"
-          else
-            VERSION="Unreleased"
-          fi
+          VERSION="${{ needs.validate-tag.outputs.version }}"
           # Prefer the rolled [X.Y.Z] section; fall back to [Unreleased]. Never
           # fabricate: if both are absent/empty, fail loud.
           if uv run --no-project --python 3.12 python scripts/release/extract-changelog.py --version "$VERSION" --output release-notes.md 2>/dev/null; then
@@ -1411,7 +1371,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          V="${GITHUB_REF_NAME#v}"
+          V="${{ needs.validate-tag.outputs.version }}"
           mkdir -p dist/desktop
           # Linux glibc CLI (built here) + musl static CLI (deliverables §3.5).
           cargo build --release -p vokra-cli
@@ -1521,7 +1481,7 @@ jobs:
           ANDROID_NDK_HOME: ${{ env.ANDROID_NDK_ROOT }}
         run: |
           set -euo pipefail
-          V="${GITHUB_REF_NAME#v}"
+          V="${{ needs.validate-tag.outputs.version }}"
           bash scripts/build-android.sh
           # Assemble a minimal standalone AAR layout: jni/<abi>/libvokra.so +
           # AndroidManifest.xml. The persistentDataPath extraction helper
@@ -1545,7 +1505,7 @@ jobs:
         if: steps.gate.outputs.enabled == 'true'
         run: |
           set -euo pipefail
-          V="${GITHUB_REF_NAME#v}"
+          V="${{ needs.validate-tag.outputs.version }}"
           SOURCE_DATE_EPOCH="$(git log -1 --pretty=%ct)"
           export SOURCE_DATE_EPOCH
           uv run --no-project --python 3.12 python scripts/sbom/generate_spdx.py \

--- a/docs/handoff/x-07.md
+++ b/docs/handoff/x-07.md
@@ -25,6 +25,13 @@ runtime dependency closure. Owner steps, once:
    dry-run only for now. The initial version is `0.1.0-alpha.0`; align it with
    the release tag semver before the first real publish (crates.io is immutable).
 
+`[workspace.package].version` is the single source of truth for an effectful
+release. A tag whose unprefixed SemVer differs is rejected by `validate-tag`
+before a GitHub Release is created. For rehearsal, `workflow_dispatch` accepts
+an optional unprefixed `release_version`; Unity, Godot, Python, npm, desktop,
+and AAR packaging all consume that one validated value. Leaving it empty uses
+the current workspace version.
+
 **Chicken-and-egg to expect** (recorded in the ADR): `cargo publish --dry-run`
 for downstream crates cannot fully pass before the first real publish (it
 resolves version deps against the live index). The dry-run job therefore gates

--- a/scripts/build-godot-gdextension.sh
+++ b/scripts/build-godot-gdextension.sh
@@ -352,9 +352,12 @@ if [ "$DO_PACK" -eq 1 ]; then
     # Extract version from the crate's Cargo.toml without a TOML parser
     # (keep host requirements minimal — zero-dep spirit).
     CARGO_TOML="$GODOT_CRATE/Cargo.toml"
-    VERSION="$(
-        awk -F'"' '/^[[:space:]]*version[[:space:]]*=/ { print $2; exit }' "$CARGO_TOML"
-    )"
+    VERSION="${VOKRA_RELEASE_VERSION:-}"
+    if [ -z "$VERSION" ]; then
+        VERSION="$(
+            awk -F'"' '/^[[:space:]]*version[[:space:]]*=/ { print $2; exit }' "$CARGO_TOML"
+        )"
+    fi
     if [ -z "$VERSION" ]; then
         echo "build-godot-gdextension: FAIL could not parse version from $CARGO_TOML" >&2
         exit 1

--- a/tools/release/test_changelog.py
+++ b/tools/release/test_changelog.py
@@ -7,9 +7,8 @@ Covers:
     non-zero (never fabricated notes);
   * T17 roll-changelog idempotency (re-roll is a no-op) + post-roll integrity
     (--check passes) + the freshly-rolled [Unreleased] is empty (extract exits 2);
-  * T18 validate-tag: the release.yml job rejects non-semver tags AND
-    announced-skips (passes) on non-tag refs — the property that keeps the
-    dry-run/dispatch verify path from self-blocking.
+  * T18 validate-tag: the release.yml job delegates tag/candidate validation to
+    the single release-version contract and exposes its resolved job output.
 
 Zero-dep (NFR-DS-02): python3 stdlib only. FR-EX-08: no silent pass.
 Usage: python3 tools/release/test_changelog.py
@@ -27,6 +26,7 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), 
 EXTRACT = os.path.join(ROOT, "scripts", "release", "extract-changelog.py")
 ROLL = os.path.join(ROOT, "scripts", "release", "roll-changelog.py")
 RELEASE_YML = os.path.join(ROOT, ".github", "workflows", "release.yml")
+VERSION_CONTRACT = os.path.join(ROOT, "tools", "release", "version_contract.py")
 
 _pass = 0
 _fail = 0
@@ -86,21 +86,21 @@ def test_extract(scratch: str) -> None:
     open(fx, "w").write(FIXTURE)
 
     # round-trip: [1.2.0] body extracted verbatim.
-    p = run(["python3", EXTRACT, "--version", "1.2.0", "--changelog", fx])
+    p = run([sys.executable, EXTRACT, "--version", "1.2.0", "--changelog", fx])
     if p.returncode == 0 and p.stdout.strip() == "- shipped feature X":
         ok("T15 extract round-trip: [1.2.0] body extracted verbatim")
     else:
         bad(f"T15 extract round-trip wrong (rc={p.returncode}): {p.stdout!r}")
 
     # Unreleased multi-line body.
-    p = run(["python3", EXTRACT, "--version", "Unreleased", "--changelog", fx])
+    p = run([sys.executable, EXTRACT, "--version", "Unreleased", "--changelog", fx])
     if p.returncode == 0 and "unreleased change A" in p.stdout and "unreleased change B" in p.stdout:
         ok("T15 extract [Unreleased] returns its body")
     else:
         bad(f"T15 extract [Unreleased] wrong (rc={p.returncode})")
 
     # absent section -> non-zero.
-    p = run(["python3", EXTRACT, "--version", "9.9.9", "--changelog", fx])
+    p = run([sys.executable, EXTRACT, "--version", "9.9.9", "--changelog", fx])
     if p.returncode != 0:
         ok("T15 absent section exits non-zero (FR-EX-08)")
     else:
@@ -109,7 +109,7 @@ def test_extract(scratch: str) -> None:
     # empty section -> non-zero (no fabricated notes).
     fe = os.path.join(scratch, "EMPTY.md")
     open(fe, "w").write(EMPTY_UNRELEASED)
-    p = run(["python3", EXTRACT, "--version", "Unreleased", "--changelog", fe])
+    p = run([sys.executable, EXTRACT, "--version", "Unreleased", "--changelog", fe])
     if p.returncode != 0:
         ok("T15 empty [Unreleased] exits non-zero (no fabricated notes, FR-EX-08)")
     else:
@@ -121,7 +121,7 @@ def test_roll(scratch: str) -> None:
     open(fx, "w").write(FIXTURE)
 
     # roll to a new version.
-    p = run(["python3", ROLL, "--version", "1.3.0", "--date", "2026-06-01", "--changelog", fx])
+    p = run([sys.executable, ROLL, "--version", "1.3.0", "--date", "2026-06-01", "--changelog", fx])
     if p.returncode != 0:
         bad(f"T17 roll failed: {p.stderr.strip()}")
         return
@@ -139,7 +139,7 @@ def test_roll(scratch: str) -> None:
 
     # idempotent: re-roll same version = no change.
     before = open(fx).read()
-    run(["python3", ROLL, "--version", "1.3.0", "--date", "2026-06-01", "--changelog", fx])
+    run([sys.executable, ROLL, "--version", "1.3.0", "--date", "2026-06-01", "--changelog", fx])
     after = open(fx).read()
     if before == after:
         ok("T17 roll idempotent: re-rolling the same version is a no-op")
@@ -147,14 +147,14 @@ def test_roll(scratch: str) -> None:
         bad("T17 roll NOT idempotent: re-roll changed the file")
 
     # --check passes on the rolled file.
-    p = run(["python3", ROLL, "--check", "--changelog", fx])
+    p = run([sys.executable, ROLL, "--check", "--changelog", fx])
     if p.returncode == 0:
         ok("T17 --check passes on the rolled changelog")
     else:
         bad(f"T17 --check failed on rolled changelog: {p.stderr.strip()}")
 
     # freshly-rolled [Unreleased] is empty -> extract exits 2.
-    p = run(["python3", EXTRACT, "--version", "Unreleased", "--changelog", fx])
+    p = run([sys.executable, EXTRACT, "--version", "Unreleased", "--changelog", fx])
     if p.returncode != 0:
         ok("T17 fresh [Unreleased] is empty -> extract refuses (no fabricated notes)")
     else:
@@ -167,21 +167,25 @@ def test_validate_tag() -> None:
     if "validate-tag:" not in text:
         bad("T18 validate-tag job missing from release.yml")
         return
-    # The announced-skip property: non-tag ref passes (exit 0 with a ::notice::).
-    if "non-tag ref" in text and "announced skip" in text and 'refs/tags/*' in text:
-        ok("T18 validate-tag announced-skips (passes) on non-tag refs")
+    if "tools/release/version_contract.py" in text and "release_version:" in text:
+        ok("T18 validate-tag delegates tag and dry-run candidate validation")
     else:
-        bad("T18 validate-tag missing the non-tag announced-skip (dispatch path would be blocked)")
+        bad("T18 validate-tag does not call the release-version contract")
+
+    if "version: ${{ steps.version-contract.outputs.version }}" in text:
+        ok("T18 validate-tag exposes one canonical version to downstream jobs")
+    else:
+        bad("T18 validate-tag does not expose the canonical version output")
 
     # Replicate the semver check on sample tags to prove the regex is right.
     semver = re.compile(r"^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$")
     good = ["v1.0.0", "v1.0.0-rc.1", "v0.1.0-alpha.0", "v10.20.30+build.5"]
     bad_tags = ["vfoo", "v1.0", "1.0.0", "vv1.0.0", "v1.0.0-", "release"]
-    # Assert the SAME regex text is present in the job (so the job enforces it).
-    if r"^v[0-9]+\.[0-9]+\.[0-9]+" in text:
-        ok("T18 validate-tag uses a v-prefixed semver regex")
+    contract = open(VERSION_CONTRACT, encoding="utf-8").read()
+    if "SEMVER_RE" in contract and 'tag.startswith("v")' in contract:
+        ok("T18 version contract enforces v-prefixed SemVer tags")
     else:
-        bad("T18 validate-tag semver regex not found in release.yml")
+        bad("T18 version contract SemVer/tag-prefix guard missing")
     if all(semver.match(t) for t in good) and not any(semver.match(t) for t in bad_tags):
         ok("T18 semver regex accepts valid tags / rejects vfoo, v1.0, bare 1.0.0, etc.")
     else:

--- a/tools/release/test_version_contract.py
+++ b/tools/release/test_version_contract.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Oracle for the release version single-source-of-truth contract."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+CONTRACT = os.path.join(ROOT, "tools", "release", "version_contract.py")
+RELEASE_YML = os.path.join(ROOT, ".github", "workflows", "release.yml")
+GODOT_BUILD = os.path.join(ROOT, "scripts", "build-godot-gdextension.sh")
+
+
+def run(cargo_toml: str, ref: str, candidate: str = "") -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            sys.executable,
+            CONTRACT,
+            "--cargo-toml",
+            cargo_toml,
+            "--github-ref",
+            ref,
+            "--dispatch-version",
+            candidate,
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+
+def main() -> None:
+    checks: list[tuple[bool, str]] = []
+    with tempfile.TemporaryDirectory(prefix="release-version-contract.") as scratch:
+        cargo_toml = os.path.join(scratch, "Cargo.toml")
+        with open(cargo_toml, "w", encoding="utf-8") as handle:
+            handle.write('[workspace.package]\nversion = "1.2.3-rc.1"\n')
+
+        matched = run(cargo_toml, "refs/tags/v1.2.3-rc.1")
+        checks.append((matched.returncode == 0 and matched.stdout.strip() == "1.2.3-rc.1", "matching tag"))
+
+        mismatch = run(cargo_toml, "refs/tags/v1.2.3")
+        checks.append((mismatch.returncode != 0 and "does not match workspace" in mismatch.stderr, "mismatched tag fails"))
+
+        default_dispatch = run(cargo_toml, "refs/heads/main")
+        checks.append((default_dispatch.returncode == 0 and default_dispatch.stdout.strip() == "1.2.3-rc.1", "dispatch defaults to workspace"))
+
+        candidate = run(cargo_toml, "refs/heads/release-prep", "2.0.0-beta.2")
+        checks.append((candidate.returncode == 0 and candidate.stdout.strip() == "2.0.0-beta.2", "dispatch candidate"))
+
+        invalid = run(cargo_toml, "refs/heads/main", "v2.0.0")
+        checks.append((invalid.returncode != 0 and "unprefixed SemVer" in invalid.stderr, "invalid dispatch version fails"))
+
+    release = open(RELEASE_YML, encoding="utf-8").read()
+    checks.extend(
+        [
+            ("release_version:" in release, "workflow exposes dry-run candidate"),
+            ("tools/release/version_contract.py" in release, "workflow calls version contract"),
+            ("needs.validate-tag.outputs.version" in release, "jobs consume validated output"),
+            ("npm version --no-git-tag-version --allow-same-version" in release, "Unity manifest is stamped"),
+            ("VOKRA_RELEASE_VERSION" in release, "Godot pack receives validated version"),
+            ("VOKRA_RELEASE_VERSION" in open(GODOT_BUILD, encoding="utf-8").read(), "Godot pack honors override"),
+        ]
+    )
+
+    failures = [label for passed, label in checks if not passed]
+    for passed, label in checks:
+        print(f"  {'ok' if passed else 'FAIL'}: {label}")
+    print()
+    print(f"version-contract oracle: {len(checks) - len(failures)} passed, {len(failures)} failed")
+    raise SystemExit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/release/version_contract.py
+++ b/tools/release/version_contract.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Resolve the one canonical version used by every release artifact.
+
+The Rust workspace version is the release source of truth. A tag-triggered
+release must use exactly ``v<workspace-version>``. A workflow-dispatch dry-run
+may supply a candidate version explicitly so the same packaging paths can be
+exercised before the source version is bumped; otherwise it uses the current
+workspace version.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+
+
+SEMVER_RE = re.compile(
+    r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$"
+)
+
+
+def fail(message: str) -> "None":
+    print(f"version-contract: FAIL {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def workspace_version(cargo_toml: str) -> str:
+    in_workspace_package = False
+    with open(cargo_toml, encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if line.startswith("[") and line.endswith("]"):
+                in_workspace_package = line == "[workspace.package]"
+                continue
+            if in_workspace_package:
+                match = re.fullmatch(r'version\s*=\s*"([^"]+)"', line)
+                if match:
+                    return match.group(1)
+    fail(f"could not read [workspace.package] version from {cargo_toml}")
+
+
+def resolve_version(github_ref: str, dispatch_version: str, canonical: str) -> str:
+    if not SEMVER_RE.fullmatch(canonical):
+        fail(f"workspace version '{canonical}' is not SemVer")
+
+    if github_ref.startswith("refs/tags/"):
+        tag = github_ref.removeprefix("refs/tags/")
+        if not tag.startswith("v") or not SEMVER_RE.fullmatch(tag[1:]):
+            fail(f"tag '{tag}' is not v-prefixed SemVer")
+        version = tag[1:]
+        if version != canonical:
+            fail(
+                f"tag version '{version}' does not match workspace version "
+                f"'{canonical}'; bump all release metadata before tagging"
+            )
+        return version
+
+    version = dispatch_version or canonical
+    if version.startswith("v") or not SEMVER_RE.fullmatch(version):
+        fail(
+            f"dry-run version '{version}' must be unprefixed SemVer "
+            "(for example 1.0.0-rc.1)"
+        )
+    return version
+
+
+def main() -> None:
+    root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--github-ref", required=True)
+    parser.add_argument("--dispatch-version", default="")
+    parser.add_argument(
+        "--cargo-toml", default=os.path.join(root, "Cargo.toml")
+    )
+    parser.add_argument("--github-output")
+    args = parser.parse_args()
+
+    canonical = workspace_version(args.cargo_toml)
+    version = resolve_version(args.github_ref, args.dispatch_version, canonical)
+    if args.github_output:
+        with open(args.github_output, "a", encoding="utf-8") as handle:
+            handle.write(f"version={version}\n")
+    print(version)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- make the root workspace package version the single release version source of truth
- reject real tags whose version differs from the workspace version
- expose a validated dry-run candidate version to every package job
- stamp Unity and pass the validated override to Godot before packaging

## Validation
- version-contract oracle: 11 passed, 0 failed
- changelog oracle: 13 passed, 0 failed
- crates.io oracle: 9 passed, 0 failed
- workflow hygiene and `git diff --check`: green
- VAST workspace validation on integrated commit `5e9f1c0b`: `cargo test --workspace`, 0 failed; instance `48452775` destroyed after completion