### PR TITLE
ci(release): use same-run native artifacts

### DIFF
--- a/.github/workflows/godot-crossbuild.yml
+++ b/.github/workflows/godot-crossbuild.yml
@@ -65,6 +65,7 @@
 name: godot-crossbuild
 
 on:
+  workflow_call:
   workflow_dispatch:
   schedule:
     # Weekly Monday 08:30 UTC — the last slot in the weekly stagger (the

--- a/.github/workflows/release-desktop-preflight.yml
+++ b/.github/workflows/release-desktop-preflight.yml
@@ -1,0 +1,57 @@
+# Same-run desktop C ABI artifact producer for release.yml.
+#
+# A tag workflow cannot safely discover a separate ci.yml run by branch name:
+# tag refs do not trigger ci.yml, and a main-branch run at the same SHA has a
+# different head ref. Calling this workflow from release.yml makes the macOS
+# and Windows artifacts part of the same workflow run, so download-artifact is
+# fail-loud and race-free.
+
+name: Release desktop preflight
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-desktop-capi:
+    name: build-desktop-capi (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            artifact: vokra-capi-macos
+            path: target/release/libvokra.dylib
+          - os: windows-latest
+            artifact: vokra-capi-windows
+            path: target/release/vokra.dll
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
+        with:
+          lookup-only: true
+      - name: Build CPU-only release C ABI
+        run: cargo build --locked --release -p vokra-capi --no-default-features --features cpu
+      - name: Verify expected native artifact
+        shell: bash
+        env:
+          ARTIFACT_PATH: ${{ matrix.path }}
+        run: |
+          set -euo pipefail
+          test -f "$ARTIFACT_PATH"
+          ls -la "$ARTIFACT_PATH"
+      - name: Upload desktop C ABI artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.path }}
+          retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,16 @@ permissions:
   contents: read
 
 jobs:
+  release-desktop-preflight:
+    name: release-desktop-preflight
+    needs: validate-tag
+    uses: ./.github/workflows/release-desktop-preflight.yml
+
+  release-godot-preflight:
+    name: release-godot-preflight
+    needs: validate-tag
+    uses: ./.github/workflows/godot-crossbuild.yml
+
   # ---------------------------------------------------------------------------
   # X-07-T18: single release-version contract. The workspace version is the
   # source of truth for an effectful tag release; `vX.Y.Z` must match it exactly
@@ -289,7 +299,7 @@ jobs:
   # ---------------------------------------------------------------------------
   unity-package-release:
     name: unity-package-release
-    needs: [validate-tag, release-notes, ios-xcframework]
+    needs: [validate-tag, release-notes, ios-xcframework, release-desktop-preflight]
     runs-on: ubuntu-latest
     timeout-minutes: 180
     permissions:
@@ -372,48 +382,17 @@ jobs:
           rustup component add llvm-tools
           bash scripts/build-unity-webgl-lib.sh
 
-      - name: Reuse macOS + Windows cdylibs from ci.yml artifacts (advisory, record-only, best-effort)
-        id: reuse-desktop-cdylibs
-        # T13 unity-package CI job produces per-OS cdylibs. Attempt to fetch
-        # them via `gh run download` scoped to the tag SHA so the release
-        # tarball ships all five platforms. Missing artifacts are non-fatal
-        # for this wire-up; the summary flags any absence for owner review.
-        # §8.2 canonical form: name suffix `(advisory, record-only)` + explicit
-        # `id:` — required by scripts/check-workflow-advisory-suffix.sh
-        # (§8.2 tripwire, Commit L). "best-effort" retained as an operational
-        # descriptor after the canonical suffix.
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set +e
-          RUN_ID="$(gh run list \
-            --workflow=ci.yml \
-            --branch="${GITHUB_REF_NAME}" \
-            --limit=20 \
-            --json databaseId,headSha,conclusion \
-            --jq ".[] | select(.headSha==\"${GITHUB_SHA}\" and .conclusion==\"success\") | .databaseId" \
-            | head -n 1)"
-          if [ -z "$RUN_ID" ]; then
-            echo "unity-package-release: no successful ci.yml run for SHA ${GITHUB_SHA}; skipping desktop reuse"
-            exit 0
-          fi
-          echo "unity-package-release: reusing ci.yml run ${RUN_ID} for desktop cdylibs"
-          for artifact in vokra-capi-macos vokra-capi-windows; do
-            gh run download "$RUN_ID" --name "$artifact" --dir "reuse/${artifact}" \
-              || echo "unity-package-release: ${artifact} not available (T13 pending?)"
-          done
-          if [ -f reuse/vokra-capi-macos/libvokra.dylib ]; then
-            mkdir -p bindings/unity/com.vokra.unity/Plugins/macOS
-            cp reuse/vokra-capi-macos/libvokra.dylib \
-              bindings/unity/com.vokra.unity/Plugins/macOS/libvokra.dylib
-          fi
-          if [ -f reuse/vokra-capi-windows/vokra.dll ]; then
-            mkdir -p bindings/unity/com.vokra.unity/Plugins/Windows/x86_64
-            cp reuse/vokra-capi-windows/vokra.dll \
-              bindings/unity/com.vokra.unity/Plugins/Windows/x86_64/vokra.dll
-          fi
-          set -e
+      - name: Download same-run macOS C ABI artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: vokra-capi-macos
+          path: bindings/unity/com.vokra.unity/Plugins/macOS
+
+      - name: Download same-run Windows C ABI artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: vokra-capi-windows
+          path: bindings/unity/com.vokra.unity/Plugins/Windows/x86_64
 
       - name: Enforce NVIDIA runtime non-bundled (D7 / T12 / NFR-LC-01)
         run: bash scripts/check-unity-package-no-nvidia.sh
@@ -760,7 +739,7 @@ jobs:
   # ---------------------------------------------------------------------------
   godot-package-release:
     name: godot-package-release
-    needs: [validate-tag, release-notes]
+    needs: [validate-tag, release-notes, release-godot-preflight]
     runs-on: ubuntu-latest
     timeout-minutes: 180
     permissions:
@@ -776,49 +755,36 @@ jobs:
         with:
           enable-cache: false
 
-      - name: Reuse per-target cdylibs from godot-crossbuild.yml matrix (advisory, record-only)
-        id: reuse-godot-cdylibs
-        # T16 crossbuild produces one vokra-godot-<triple> artifact per
-        # platform. Fetch each via `gh run download` scoped to the tag
-        # SHA and reassemble under integrations/vokra-godot/pkg/lib/.
-        # Missing artifacts are non-fatal so the release zip still
-        # assembles with whichever platforms did land — the T18 scan
-        # will then note the empty per-platform slot as a package
-        # completeness gap rather than a bundled-NVIDIA failure.
-        # §8.2 canonical form: name suffix + explicit `id:` — see the
-        # sibling step above.
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download same-run Godot crossbuild artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          pattern: vokra-godot-*
+          path: staging/
+
+      - name: Require and stage all five Godot target artifacts
         run: |
-          set +e
-          RUN_ID="$(gh run list \
-            --workflow=godot-crossbuild.yml \
-            --branch="${GITHUB_REF_NAME}" \
-            --limit=20 \
-            --json databaseId,headSha,conclusion \
-            --jq ".[] | select(.headSha==\"${GITHUB_SHA}\" and .conclusion==\"success\") | .databaseId" \
-            | head -n 1)"
-          if [ -z "$RUN_ID" ]; then
-            echo "godot-package-release: no successful godot-crossbuild.yml run for SHA ${GITHUB_SHA}; skipping matrix reuse"
-            exit 0
-          fi
-          echo "godot-package-release: reusing godot-crossbuild.yml run ${RUN_ID}"
+          set -euo pipefail
           mkdir -p integrations/vokra-godot/pkg/lib
-          for TRIPLE in \
-            x86_64-apple-darwin \
-            aarch64-apple-darwin \
-            x86_64-unknown-linux-gnu \
-            x86_64-pc-windows-msvc \
-            aarch64-linux-android; do
-            gh run download "$RUN_ID" \
-              --name "vokra-godot-${TRIPLE}" \
-              --dir "integrations/vokra-godot/pkg/lib/${TRIPLE}" \
-              || echo "godot-package-release: ${TRIPLE} artifact missing (crossbuild leg red?)"
+          for SPEC in \
+            x86_64-apple-darwin:libvokra_godot.dylib \
+            aarch64-apple-darwin:libvokra_godot.dylib \
+            x86_64-unknown-linux-gnu:libvokra_godot.so \
+            x86_64-pc-windows-msvc:vokra_godot.dll \
+            aarch64-linux-android:libvokra_godot.so; do
+            TRIPLE="${SPEC%%:*}"
+            LIB="${SPEC#*:}"
+            SRC_DIR="staging/vokra-godot-${TRIPLE}"
+            if [ ! -f "${SRC_DIR}/${LIB}" ]; then
+              echo "godot-package-release: FAIL missing same-run artifact ${TRIPLE}/${LIB}" >&2
+              find staging -maxdepth 3 -type f | LC_ALL=C sort >&2 || true
+              exit 1
+            fi
+            DEST="integrations/vokra-godot/pkg/lib/${TRIPLE}"
+            mkdir -p "$DEST"
+            cp -f "${SRC_DIR}/${LIB}" "${DEST}/${LIB}"
           done
           echo "== Collected per-target artifacts =="
           find integrations/vokra-godot/pkg/lib -type f | LC_ALL=C sort
-          set -e
 
       - name: Reassemble AssetLib layout from staged cdylibs
         run: |
@@ -834,10 +800,9 @@ jobs:
           for TRIPLE in "${!DEST_SUBDIR[@]}"; do
             SRC_DIR="integrations/vokra-godot/pkg/lib/${TRIPLE}"
             DEST="dist/godot/vokra-godot/addons/vokra/bin/${DEST_SUBDIR[$TRIPLE]}"
-            if [ -d "$SRC_DIR" ] && [ "$(ls -A "$SRC_DIR" 2>/dev/null)" ]; then
-              mkdir -p "$DEST"
-              cp -f "$SRC_DIR"/* "$DEST/" || true
-            fi
+            test -d "$SRC_DIR"
+            mkdir -p "$DEST"
+            cp -f "$SRC_DIR"/* "$DEST/"
           done
           ADDON=dist/godot/vokra-godot/addons/vokra
           cp -f integrations/vokra-godot/vokra.gdextension "$ADDON/vokra.gdextension"
@@ -1330,7 +1295,7 @@ jobs:
   # ---------------------------------------------------------------------------
   desktop-release:
     name: desktop-release
-    needs: [validate-tag, release-notes]
+    needs: [validate-tag, release-notes, release-desktop-preflight]
     runs-on: ubuntu-latest
     timeout-minutes: 180
     permissions:
@@ -1365,10 +1330,22 @@ jobs:
         with:
           lookup-only: true
 
-      - name: Build Linux CLI (glibc + musl static) and reuse ci.yml cdylibs
+      - name: Download same-run macOS C ABI artifact for desktop release
         if: steps.gate.outputs.enabled == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: vokra-capi-macos
+          path: reuse/macos
+
+      - name: Download same-run Windows C ABI artifact for desktop release
+        if: steps.gate.outputs.enabled == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: vokra-capi-windows
+          path: reuse/windows
+
+      - name: Build Linux CLI and assemble same-run desktop C ABI artifacts
+        if: steps.gate.outputs.enabled == 'true'
         run: |
           set -euo pipefail
           V="${{ needs.validate-tag.outputs.version }}"
@@ -1384,20 +1361,12 @@ jobs:
           cargo build --release -p vokra-capi
           cp target/release/libvokra.so "dist/desktop/libvokra-${V}-x86_64-linux.so"
           cp include/vokra.h "dist/desktop/vokra.h"
-          # macOS/Windows cdylibs + CLI reused from the ci.yml run for this SHA
-          # (best-effort; a follow-up adds native macos/windows CLI builds).
-          RUN_ID="$(gh run list --workflow=ci.yml --branch="${GITHUB_REF_NAME}" \
-            --limit=20 --json databaseId,headSha,conclusion \
-            --jq ".[] | select(.headSha==\"${GITHUB_SHA}\" and .conclusion==\"success\") | .databaseId" \
-            | head -n 1 || true)"
-          if [ -n "$RUN_ID" ]; then
-            gh run download "$RUN_ID" --name vokra-capi-macos --dir reuse/macos || true
-            gh run download "$RUN_ID" --name vokra-capi-windows --dir reuse/windows || true
-            [ -f reuse/macos/libvokra.dylib ] && cp reuse/macos/libvokra.dylib "dist/desktop/libvokra-${V}-macos.dylib" || echo "desktop-release: macOS cdylib not available (follow-up)"
-            [ -f reuse/windows/vokra.dll ] && cp reuse/windows/vokra.dll "dist/desktop/vokra-${V}-windows.dll" || echo "desktop-release: Windows cdylib not available (follow-up)"
-          else
-            echo "desktop-release: no ci.yml run for SHA ${GITHUB_SHA}; shipping Linux slices only this run."
-          fi
+          # macOS/Windows cdylibs are guaranteed by the same-run reusable
+          # preflight; download-artifact fails before this step if absent.
+          test -f reuse/macos/libvokra.dylib
+          test -f reuse/windows/vokra.dll
+          cp reuse/macos/libvokra.dylib "dist/desktop/libvokra-${V}-macos.dylib"
+          cp reuse/windows/vokra.dll "dist/desktop/vokra-${V}-windows.dll"
 
       - name: SBOM + sha256 for desktop assets
         if: steps.gate.outputs.enabled == 'true'

--- a/docs/handoff/x-07.md
+++ b/docs/handoff/x-07.md
@@ -99,6 +99,14 @@ Actions):
 | `release.yml` (dry_run=true) | 6 oracles under `tools/release/` | **green 2026-08-22** — [run 32564192022](https://github.com/ayutaz/vokra/actions/runs/32564192022); evidence and fixes in `docs/handoff/release-dry-run-2026-08-22.md` |
 | `release-cadence.yml` | `tools/release/test_cadence.py` | pending |
 
+Current `release.yml` no longer searches another workflow run by tag/branch
+name. It calls `release-desktop-preflight.yml` and the reusable
+`godot-crossbuild.yml` directly, then downloads their artifacts from the same
+Release run. A missing macOS/Windows C ABI or any of the five Godot targets now
+fails before packaging; the three manual same-SHA dispatches recorded in
+`release-dry-run-2026-08-22.md` remain historical reproduction evidence, not a
+prerequisite for future tag releases.
+
 ## 6. CC pre-verify commands (reproduce locally)
 
 ```
@@ -108,6 +116,7 @@ uv run --no-project --python 3.12 python tools/release/test_changelog.py
 uv run --no-project --python 3.12 python tools/release/test_cadence.py
 uv run --no-project --python 3.12 python tools/release/test_package_managers.py
 uv run --no-project --python 3.12 python tools/release/test_reproducible.py
+uv run --no-project --python 3.12 python tools/release/test_release_artifact_handoff.py
 bash   scripts/sbom/test-generate-spdx.sh
 uv run --no-project --python 3.12 python tools/release/crates_publish_order.py --verify
 bash   scripts/check-workflow-hygiene.sh

--- a/tools/release/test_release_artifact_handoff.py
+++ b/tools/release/test_release_artifact_handoff.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Oracle for fail-loud, same-run release artifact handoff."""
+
+from __future__ import annotations
+
+import os
+import re
+
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+RELEASE = os.path.join(ROOT, ".github", "workflows", "release.yml")
+DESKTOP = os.path.join(ROOT, ".github", "workflows", "release-desktop-preflight.yml")
+GODOT = os.path.join(ROOT, ".github", "workflows", "godot-crossbuild.yml")
+
+
+def job_block(text: str, job_id: str) -> str:
+    match = re.search(
+        rf"^  {re.escape(job_id)}:\s*$([\s\S]*?)(?=^  [A-Za-z_][\w-]*:\s*$|\Z)",
+        text,
+        flags=re.MULTILINE,
+    )
+    if not match:
+        raise AssertionError(f"missing job {job_id}")
+    return match.group(0)
+
+
+def main() -> None:
+    release = open(RELEASE, encoding="utf-8").read()
+    desktop = open(DESKTOP, encoding="utf-8").read()
+    godot = open(GODOT, encoding="utf-8").read()
+    checks: list[tuple[bool, str]] = []
+
+    desktop_call = job_block(release, "release-desktop-preflight")
+    godot_call = job_block(release, "release-godot-preflight")
+    unity = job_block(release, "unity-package-release")
+    godot_release = job_block(release, "godot-package-release")
+    desktop_release = job_block(release, "desktop-release")
+
+    checks.extend(
+        [
+            ("release-desktop-preflight.yml" in desktop_call, "release calls desktop preflight"),
+            ("godot-crossbuild.yml" in godot_call, "release calls Godot preflight"),
+            ("release-desktop-preflight" in unity, "Unity waits for desktop preflight"),
+            (unity.count("actions/download-artifact@") >= 3, "Unity downloads same-run iOS/macOS/Windows artifacts"),
+            ("gh run list" not in unity and "gh run download" not in unity, "Unity has no cross-run lookup"),
+            ("release-godot-preflight" in godot_release, "Godot release waits for crossbuild"),
+            ("pattern: vokra-godot-*" in godot_release, "Godot downloads same-run matrix artifacts"),
+            (all(target in godot_release for target in (
+                "x86_64-apple-darwin:libvokra_godot.dylib",
+                "aarch64-apple-darwin:libvokra_godot.dylib",
+                "x86_64-unknown-linux-gnu:libvokra_godot.so",
+                "x86_64-pc-windows-msvc:vokra_godot.dll",
+                "aarch64-linux-android:libvokra_godot.so",
+            )), "Godot requires all five exact target files"),
+            ("continue-on-error: true" not in godot_release, "Godot handoff is fail-loud"),
+            ("gh run list" not in godot_release and "gh run download" not in godot_release, "Godot has no cross-run lookup"),
+            ("gh run list" not in desktop_release and "gh run download" not in desktop_release, "desktop release has no cross-run lookup"),
+            ("workflow_call:" in desktop, "desktop preflight is reusable"),
+            ("vokra-capi-macos" in desktop and "vokra-capi-windows" in desktop, "desktop preflight emits both artifacts"),
+            ("if-no-files-found: error" in desktop, "desktop upload is fail-loud"),
+            ("workflow_call:" in godot, "Godot crossbuild is reusable"),
+        ]
+    )
+
+    failures = [label for passed, label in checks if not passed]
+    for passed, label in checks:
+        print(f"  {'ok' if passed else 'FAIL'}: {label}")
+    print()
+    print(
+        f"release-artifact-handoff oracle: "
+        f"{len(checks) - len(failures)} passed, {len(failures)} failed"
+    )
+    raise SystemExit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- build Unity native artifacts through a same-run reusable desktop preflight
- call Godot crossbuild in the release run and require all five target artifacts
- remove cross-run artifact lookup and fail loudly on incomplete handoff
- add a static release artifact handoff oracle and update the X-07 handoff

## Verification
- `uv run --python 3.12 tools/release/test_release_artifact_handoff.py` (15 passed)
- `uv run --python 3.12 tools/release/test_version_contract.py` (11 passed)
- `uv run --python 3.12 tools/release/test_crates_io.py` (9 passed)
- `bash scripts/check-workflow-hygiene.sh` (46 workflows)
- `git diff --check origin/main...HEAD`
- integrated `cargo test --workspace` on Vast.ai at `5e9f1c0b` (green; instance destroyed)