### PR TITLE
ci(release): require explicit publish configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,11 @@ on:
         required: false
         type: string
         default: ""
+      enforce_publish_config:
+        description: "Require explicit channel variables and credentials during dry-run"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: release-${{ github.ref }}
@@ -92,6 +97,48 @@ jobs:
             tools/release/version_contract.py \
             --github-ref "$GITHUB_REF" \
             --dispatch-version "$DISPATCH_VERSION" \
+            --github-output "$GITHUB_OUTPUT"
+
+  release-config:
+    name: release-config
+    needs: validate-tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      crates_io: ${{ steps.publish-config.outputs.crates_io }}
+      npm: ${{ steps.publish-config.outputs.npm }}
+      openupm: ${{ steps.publish-config.outputs.openupm }}
+      pypi: ${{ steps.publish-config.outputs.pypi }}
+      desktop_aar: ${{ steps.publish-config.outputs.desktop_aar }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+        with:
+          enable-cache: false
+      - name: Validate explicit publication-channel decisions
+        id: publish-config
+        env:
+          CRATES_IO_PUBLISH_ENABLED: ${{ vars.CRATES_IO_PUBLISH_ENABLED }}
+          NPM_PUBLISH_ENABLED: ${{ vars.NPM_PUBLISH_ENABLED }}
+          OPENUPM_PUBLISH_ENABLED: ${{ vars.OPENUPM_PUBLISH_ENABLED }}
+          PYPI_PUBLISH_ENABLED: ${{ vars.PYPI_PUBLISH_ENABLED }}
+          DESKTOP_AAR_ENABLED: ${{ vars.DESKTOP_AAR_ENABLED }}
+          PYPI_TRUSTED_PUBLISHER_CONFIGURED: ${{ vars.PYPI_TRUSTED_PUBLISHER_CONFIGURED }}
+          CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          OPENUPM_TOKEN: ${{ secrets.OPENUPM_TOKEN }}
+          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+          ENFORCE_DRY_RUN: ${{ inputs.enforce_publish_config }}
+        run: |
+          STRICT=false
+          if [[ "${GITHUB_REF}" == refs/tags/v* || "$ENFORCE_DRY_RUN" == "true" ]]; then
+            STRICT=true
+          fi
+          uv run --no-project --python 3.12 python \
+            tools/release/publish_config.py \
+            --strict "$STRICT" \
             --github-output "$GITHUB_OUTPUT"
 
   ios-xcframework:
@@ -269,7 +316,7 @@ jobs:
   #
   # Assembles the com.vokra.unity-<version>.tgz release-signed tarball on
   # tag push (v*), uploads it (plus .sha256) to the GitHub Release, and
-  # optionally publishes to OpenUPM when secrets.OPENUPM_TOKEN is present.
+  # publishes to OpenUPM only when explicitly enabled and configured.
   #
   # Cross-compile strategy: iOS device slice is reused from the
   # ios-xcframework job artifact (needs dep). Linux libvokra.so is built
@@ -510,15 +557,19 @@ jobs:
             bindings/unity/com.vokra.unity/vokra-unity-package.spdx.json \
             --clobber
 
-      - name: OpenUPM publish (optional, gated on secrets.OPENUPM_TOKEN)
+      - name: OpenUPM publish (explicitly enabled and token-gated)
         if: startsWith(github.ref, 'refs/tags/v') && inputs.dry_run != true
         env:
+          OPENUPM_PUBLISH_ENABLED: ${{ vars.OPENUPM_PUBLISH_ENABLED }}
           OPENUPM_TOKEN: ${{ secrets.OPENUPM_TOKEN }}
         run: |
-          if [ -z "${OPENUPM_TOKEN:-}" ]; then
-            echo "unity-package-release: OPENUPM_TOKEN not set — skipping OpenUPM publish."
-            echo "  (GitHub Release asset is the baseline distribution channel; OpenUPM is opt-in.)"
+          if [ "$OPENUPM_PUBLISH_ENABLED" != "true" ]; then
+            echo "::notice::unity-package-release: OpenUPM explicitly disabled by OPENUPM_PUBLISH_ENABLED=false."
             exit 0
+          fi
+          if [ -z "${OPENUPM_TOKEN:-}" ]; then
+            echo "unity-package-release: FAIL OPENUPM_PUBLISH_ENABLED=true but OPENUPM_TOKEN is absent" >&2
+            exit 1
           fi
           # Compose an authenticated .npmrc scoped to the OpenUPM registry.
           # npm is preinstalled on ubuntu-latest; no extra setup step needed.
@@ -584,6 +635,9 @@ jobs:
       attestations: write
       contents: write
       id-token: write  # OIDC for PyPI trusted publishing (T17)
+    environment:
+      name: pypi
+      url: https://pypi.org/p/vokra
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
@@ -658,7 +712,7 @@ jobs:
           sbom-path: dist/vokra-python-wheel.spdx.json
 
       - name: Publish to PyPI (OIDC trusted publishing preferred, token fallback)
-        if: startsWith(github.ref, 'refs/tags/v') && inputs.dry_run != true
+        if: startsWith(github.ref, 'refs/tags/v') && inputs.dry_run != true && vars.PYPI_PUBLISH_ENABLED == 'true'
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33
         with:
           packages-dir: dist/
@@ -931,9 +985,10 @@ jobs:
   # semver into package.json, packs deterministically (SOURCE_DATE_EPOCH =
   # HEAD commit timestamp — the godot-package-release idiom), uploads the
   # tarball + SHA-256 as Release assets, and publishes to registry.npmjs.org
-  # **gated on secrets.NPM_TOKEN** (absent = honest skip annotation — the
-  # OPENUPM_TOKEN pattern; the owner registers the @vokra scope + token in
-  # M4-01-T27). Dry-run path (workflow_dispatch or no tag) runs
+  # **gated on vars.NPM_PUBLISH_ENABLED and secrets.NPM_TOKEN**. The variable
+  # must explicitly disable the channel or enable it with a configured token;
+  # the owner registers the @vokra scope + token in M4-01-T27. Dry-run path
+  # (workflow_dispatch or no tag) runs
   # `npm publish --dry-run` so the CD wiring is verifiable token-free.
   # Prerelease semver (1.0.0-rc.N) requires an explicit dist-tag: `rc` for
   # -rc.* tags, `dev` otherwise (npm refuses prerelease publishes to
@@ -1035,15 +1090,20 @@ jobs:
             web/pkg/vokra-npm-web.spdx.json \
             --clobber
 
-      - name: npm publish (gated on secrets.NPM_TOKEN)
+      - name: npm publish (explicitly enabled and token-gated)
         if: startsWith(github.ref, 'refs/tags/v') && inputs.dry_run != true
         env:
+          NPM_PUBLISH_ENABLED: ${{ vars.NPM_PUBLISH_ENABLED }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: web/pkg
         run: |
-          if [ -z "${NPM_TOKEN:-}" ]; then
-            echo "::notice::npm-web-release: NPM_TOKEN not set — skipping npm publish (the GitHub Release tarball is the baseline channel; registry publish is owner opt-in, M4-01-T27)."
+          if [ "$NPM_PUBLISH_ENABLED" != "true" ]; then
+            echo "::notice::npm-web-release: npm explicitly disabled by NPM_PUBLISH_ENABLED=false."
             exit 0
+          fi
+          if [ -z "${NPM_TOKEN:-}" ]; then
+            echo "npm-web-release: FAIL NPM_PUBLISH_ENABLED=true but NPM_TOKEN is absent" >&2
+            exit 1
           fi
           umask 077
           cat > "$HOME/.npmrc" <<EOF
@@ -1140,9 +1200,10 @@ jobs:
   # X-07-T12: crates.io real publish (NFR-MT-08 CD auto-publish, NFR-LC-02).
   #
   # Publishes the 18-crate set in topological order (deps before dependents) on
-  # tag push, gated on secrets.CRATES_IO_TOKEN. Token absent = honest ::notice::
-  # skip (the OPENUPM_TOKEN / NPM_TOKEN idiom) — the GitHub Release assets remain
-  # the baseline channel and the owner opts into crates.io in X-07-T14. crates.io
+  # tag push, gated on vars.CRATES_IO_PUBLISH_ENABLED and
+  # secrets.CRATES_IO_TOKEN. The variable must explicitly disable the channel
+  # or enable it with a configured token. The GitHub Release assets remain the
+  # baseline channel until the owner opts into crates.io in X-07-T14. crates.io
   # is an IMMUTABLE index, so a duplicate version FAILS LOUD (no --allow-dirty,
   # no skip-existing).
   #
@@ -1182,11 +1243,16 @@ jobs:
       - name: cargo publish (topo order, token-gated, immutable-index fail-loud)
         if: startsWith(github.ref, 'refs/tags/v') && inputs.dry_run != true
         env:
+          CRATES_IO_PUBLISH_ENABLED: ${{ vars.CRATES_IO_PUBLISH_ENABLED }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: |
-          if [ -z "${CARGO_REGISTRY_TOKEN:-}" ]; then
-            echo "::notice::crates-io-publish: CRATES_IO_TOKEN not set — skipping crates.io publish (owner opt-in, X-07-T14). GitHub Release assets remain the baseline channel; crates-io-dry-run validated the package set."
+          if [ "$CRATES_IO_PUBLISH_ENABLED" != "true" ]; then
+            echo "::notice::crates-io-publish: crates.io explicitly disabled by CRATES_IO_PUBLISH_ENABLED=false."
             exit 0
+          fi
+          if [ -z "${CARGO_REGISTRY_TOKEN:-}" ]; then
+            echo "crates-io-publish: FAIL CRATES_IO_PUBLISH_ENABLED=true but CRATES_IO_TOKEN is absent" >&2
+            exit 1
           fi
           set -euo pipefail
           ORDER="$(uv run --no-project --python 3.12 python tools/release/crates_publish_order.py)"
@@ -1221,7 +1287,7 @@ jobs:
   # ---------------------------------------------------------------------------
   release-notes:
     name: release-notes
-    needs: [validate-tag]
+    needs: [validate-tag, release-config]
     runs-on: ubuntu-latest
     timeout-minutes: 180
     permissions:

--- a/docs/handoff/x-07.md
+++ b/docs/handoff/x-07.md
@@ -19,8 +19,8 @@ runtime dependency closure. Owner steps, once:
 1. **Reserve the 18 crate names** on crates.io (`vokra-core`, `vokra-cli`, the
    6 backend crates, etc. — `uv run --no-project --python 3.12 python tools/release/crates_publish_order.py`
    prints them). crates.io names are first-come.
-2. **Add `secrets.CRATES_IO_TOKEN`** (repo secret). `crates-io-publish` is gated
-   on it — absent = honest `::notice::` skip, so nothing publishes accidentally.
+2. Decide `vars.CRATES_IO_PUBLISH_ENABLED=true|false`. If true, add
+   `secrets.CRATES_IO_TOKEN`; enabled-without-token is a hard preflight failure.
 3. **Decide first-publish timing**: publish on an rc tag (CD auto), or keep
    dry-run only for now. The initial version is `0.1.0-alpha.0`; align it with
    the release tag semver before the first real publish (crates.io is immutable).
@@ -88,6 +88,52 @@ interval ≤28d. With 0 releases today it honestly reports "not established".
 2. Set the repo **variable** `DESKTOP_AAR_ENABLED=true` to enable the effectful
    build+upload steps.
 
+## 4.1 Publication configuration contract
+
+Every real tag requires an explicit `true` or `false` decision for all five
+repository variables below. Missing values fail in `release-config` before
+`release-notes` can create a GitHub Release; a GitHub-only release is expressed
+by setting all five to `false`, not by leaving settings absent.
+
+| repository variable | `true` additionally requires | effect |
+|---|---|---|
+| `CRATES_IO_PUBLISH_ENABLED` | secret `CRATES_IO_TOKEN` | publish the mechanically-derived topological chain |
+| `NPM_PUBLISH_ENABLED` | secret `NPM_TOKEN` | publish `@vokra/web` |
+| `OPENUPM_PUBLISH_ENABLED` | secret `OPENUPM_TOKEN` | publish `com.vokra.unity` |
+| `PYPI_PUBLISH_ENABLED` | PyPI OIDC attestation below, or secret `PYPI_API_TOKEN` | publish `vokra` wheels |
+| `DESKTOP_AAR_ENABLED` | the T32 owner decision in §4 | build/upload desktop and standalone AAR assets |
+
+Set each decision explicitly, for example:
+
+```sh
+gh variable set CRATES_IO_PUBLISH_ENABLED --body false
+gh variable set NPM_PUBLISH_ENABLED --body false
+gh variable set OPENUPM_PUBLISH_ENABLED --body false
+gh variable set PYPI_PUBLISH_ENABLED --body false
+gh variable set DESKTOP_AAR_ENABLED --body false
+```
+
+For each enabled token channel, run `gh secret set <NAME>` and enter the value
+at the prompt; never put token values in this repository or a command line.
+
+PyPI trusted publishing uses the GitHub Environment `pypi` declared by
+`python-pypi-publish`. Configure the `vokra` project publisher with owner
+`ayutaz`, repository `vokra`, workflow `release.yml`, and environment `pypi`.
+Only after that external setting exists, record the owner attestation:
+
+```sh
+gh variable set PYPI_TRUSTED_PUBLISHER_CONFIGURED --body true
+```
+
+`PYPI_TRUSTED_PUBLISHER_CONFIGURED` is not a credential; it prevents the repo
+from claiming an unobservable PyPI-side configuration was verified. A strict
+non-publishing rehearsal is:
+
+```sh
+gh workflow run release.yml --ref <release-prep-branch> \
+  -f dry_run=true -f enforce_publish_config=true
+```
+
 ## 5. First `workflow_dispatch` runs (schedule/tag-only workflows)
 
 Dispatch each once from the default branch to confirm the first run is green
@@ -117,6 +163,7 @@ uv run --no-project --python 3.12 python tools/release/test_cadence.py
 uv run --no-project --python 3.12 python tools/release/test_package_managers.py
 uv run --no-project --python 3.12 python tools/release/test_reproducible.py
 uv run --no-project --python 3.12 python tools/release/test_release_artifact_handoff.py
+uv run --no-project --python 3.12 python tools/release/test_publish_config.py
 bash   scripts/sbom/test-generate-spdx.sh
 uv run --no-project --python 3.12 python tools/release/crates_publish_order.py --verify
 bash   scripts/check-workflow-hygiene.sh

--- a/tools/release/publish_config.py
+++ b/tools/release/publish_config.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Validate explicit release-channel decisions without exposing credentials."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+
+CHANNELS = {
+    "crates_io": "CRATES_IO_PUBLISH_ENABLED",
+    "npm": "NPM_PUBLISH_ENABLED",
+    "openupm": "OPENUPM_PUBLISH_ENABLED",
+    "pypi": "PYPI_PUBLISH_ENABLED",
+    "desktop_aar": "DESKTOP_AAR_ENABLED",
+}
+
+
+def enabled(name: str) -> bool:
+    return os.environ.get(name, "").lower() == "true"
+
+
+def validate(strict: bool) -> tuple[dict[str, bool], list[str]]:
+    decisions: dict[str, bool] = {}
+    errors: list[str] = []
+    for channel, variable in CHANNELS.items():
+        raw = os.environ.get(variable, "").lower()
+        if raw not in {"true", "false"}:
+            if strict:
+                errors.append(f"repository variable {variable} must be explicitly true or false")
+            decisions[channel] = False
+        else:
+            decisions[channel] = raw == "true"
+
+    credential_contracts = (
+        ("crates_io", "CRATES_IO_TOKEN"),
+        ("npm", "NPM_TOKEN"),
+        ("openupm", "OPENUPM_TOKEN"),
+    )
+    for channel, secret in credential_contracts:
+        if decisions[channel] and not os.environ.get(secret):
+            errors.append(f"{CHANNELS[channel]}=true requires secret {secret}")
+
+    if decisions["pypi"]:
+        oidc_attested = enabled("PYPI_TRUSTED_PUBLISHER_CONFIGURED")
+        token_present = bool(os.environ.get("PYPI_API_TOKEN"))
+        if not oidc_attested and not token_present:
+            errors.append(
+                "PYPI_PUBLISH_ENABLED=true requires either "
+                "PYPI_TRUSTED_PUBLISHER_CONFIGURED=true or secret PYPI_API_TOKEN"
+            )
+    return decisions, errors
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--strict", choices=("true", "false"), required=True)
+    parser.add_argument("--github-output")
+    args = parser.parse_args()
+
+    strict = args.strict == "true"
+    decisions, errors = validate(strict)
+    for channel, value in decisions.items():
+        print(f"publish-config: {channel}={'enabled' if value else 'disabled'}")
+    if args.github_output:
+        with open(args.github_output, "a", encoding="utf-8") as handle:
+            for channel, value in decisions.items():
+                handle.write(f"{channel}={'true' if value else 'false'}\n")
+    if errors:
+        for error in errors:
+            print(f"publish-config: FAIL {error}", file=sys.stderr)
+        raise SystemExit(1)
+    if not strict:
+        print(
+            "publish-config: advisory dry-run; pass enforce_publish_config=true "
+            "to require explicit repository settings"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/release/test_crates_io.py
+++ b/tools/release/test_crates_io.py
@@ -6,10 +6,9 @@ Asserts the crates.io wiring added by X-07-T09..T12:
   (1) `crates-io-dry-run` job exists and hits the publish set in TOPOLOGICAL
       order (drives tools/release/crates_publish_order.py + `cargo package
       --list`).
-  (2) `crates-io-publish` job exists and is TOKEN-GATED (secrets.CRATES_IO_TOKEN
-      + tag + dry_run != true), with an honest ::notice:: skip when the token is
-      absent (fabricated-pass forbidden), and IMMUTABLE-INDEX fail-loud (no
-      --allow-dirty, no skip-existing).
+  (2) `crates-io-publish` job exists and is explicitly enabled by a repository
+      variable, then TOKEN-GATED (secrets.CRATES_IO_TOKEN + tag + dry_run !=
+      true). Disabled is an honest ::notice:: skip; enabled-without-token fails.
   (3) the publish job re-checks the license/zero-dep closure right before
       publishing (NFR-LC-02 mechanized — crates.io cannot be un-published).
   (4) the publish order tool self-verifies (delegates to `--verify`).
@@ -114,17 +113,23 @@ def main() -> None:
         bad("(2) crates-io-publish job missing")
     else:
         gated = ("CRATES_IO_TOKEN" in pub
+                 and "CRATES_IO_PUBLISH_ENABLED" in pub
                  and "startsWith(github.ref, 'refs/tags/v')" in pub
                  and "inputs.dry_run != true" in pub)
         if gated:
-            ok("(2) crates-io-publish is tag + dry_run + CRATES_IO_TOKEN gated")
+            ok("(2) crates-io-publish is explicit-enable + tag + dry_run + token gated")
         else:
-            bad("(2) crates-io-publish gating incomplete (need tag + dry_run + token)")
+            bad("(2) crates-io-publish gating incomplete (need enable + tag + dry_run + token)")
 
-        if "::notice::" in pub and "CRATES_IO_TOKEN not set" in pub:
-            ok("(2) token-absent path is an honest ::notice:: skip (no fabricated pass)")
+        if "::notice::" in pub and "explicitly disabled" in pub:
+            ok("(2) explicitly-disabled path is an honest ::notice:: skip")
         else:
-            bad("(2) token-absent path must be an announced ::notice:: skip")
+            bad("(2) explicitly-disabled path must be an announced ::notice:: skip")
+
+        if "FAIL CRATES_IO_PUBLISH_ENABLED=true" in pub:
+            ok("(2) enabled-without-token path fails loud")
+        else:
+            bad("(2) enabled-without-token path must fail loud")
 
         # Immutable index: must NOT weaken publish with --allow-dirty / skip.
         # Only inspect NON-comment lines — the job keeps a comment documenting

--- a/tools/release/test_publish_config.py
+++ b/tools/release/test_publish_config.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Oracle for explicit, fail-closed release publication configuration."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+CHECK = os.path.join(ROOT, "tools", "release", "publish_config.py")
+RELEASE = os.path.join(ROOT, ".github", "workflows", "release.yml")
+HANDOFF = os.path.join(ROOT, "docs", "handoff", "x-07.md")
+VARIABLES = (
+    "CRATES_IO_PUBLISH_ENABLED",
+    "NPM_PUBLISH_ENABLED",
+    "OPENUPM_PUBLISH_ENABLED",
+    "PYPI_PUBLISH_ENABLED",
+    "DESKTOP_AAR_ENABLED",
+)
+
+
+def run(strict: bool, values: dict[str, str]) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    for name in (*VARIABLES, "CRATES_IO_TOKEN", "NPM_TOKEN", "OPENUPM_TOKEN", "PYPI_API_TOKEN", "PYPI_TRUSTED_PUBLISHER_CONFIGURED"):
+        env.pop(name, None)
+    env.update(values)
+    return subprocess.run(
+        [sys.executable, CHECK, "--strict", str(strict).lower()],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def main() -> None:
+    all_disabled = {name: "false" for name in VARIABLES}
+    checks: list[tuple[bool, str]] = []
+    checks.append((run(True, all_disabled).returncode == 0, "explicit GitHub-only release is valid"))
+
+    missing = run(True, {})
+    checks.append((missing.returncode != 0 and "must be explicitly true or false" in missing.stderr, "missing decisions fail strict preflight"))
+
+    crates_missing = run(True, {**all_disabled, "CRATES_IO_PUBLISH_ENABLED": "true"})
+    checks.append((crates_missing.returncode != 0 and "requires secret CRATES_IO_TOKEN" in crates_missing.stderr, "enabled crates.io requires token"))
+
+    crates_ready = run(True, {**all_disabled, "CRATES_IO_PUBLISH_ENABLED": "true", "CRATES_IO_TOKEN": "test-only"})
+    checks.append((crates_ready.returncode == 0, "enabled crates.io accepts present token"))
+
+    pypi_oidc = run(True, {**all_disabled, "PYPI_PUBLISH_ENABLED": "true", "PYPI_TRUSTED_PUBLISHER_CONFIGURED": "true"})
+    checks.append((pypi_oidc.returncode == 0, "PyPI OIDC owner attestation satisfies preflight"))
+
+    release = open(RELEASE, encoding="utf-8").read()
+    handoff = open(HANDOFF, encoding="utf-8").read()
+    checks.extend(
+        [
+            ("enforce_publish_config:" in release, "workflow exposes strict dry-run input"),
+            ("tools/release/publish_config.py" in release, "workflow runs publish preflight"),
+            ("needs: [validate-tag, release-config]" in release, "Release creation waits for config"),
+            ('name: pypi' in release and 'url: https://pypi.org/p/vokra' in release, "PyPI job declares trusted-publisher environment"),
+            (all(name in handoff for name in VARIABLES), "handoff lists every channel decision"),
+            ("PYPI_TRUSTED_PUBLISHER_CONFIGURED" in handoff, "handoff records PyPI OIDC attestation"),
+        ]
+    )
+
+    failures = [label for passed, label in checks if not passed]
+    for passed, label in checks:
+        print(f"  {'ok' if passed else 'FAIL'}: {label}")
+    print()
+    print(f"publish-config oracle: {len(checks) - len(failures)} passed, {len(failures)} failed")
+    raise SystemExit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a fail-closed preflight for crates.io, npm, OpenUPM, PyPI, and desktop/AAR publication decisions
- require enabled token-backed channels to have credentials and record PyPI trusted-publisher attestation
- make GitHub-only releases an explicit supported configuration
- expose strict publication-config validation during workflow-dispatch dry runs
- update the X-07 owner handoff and static release oracles

## Verification
- all 8 `tools/release/test_*.py` oracles passed
- publish-config 11/11; artifact handoff 15/15; version contract 11/11; crates.io 10/10
- `bash scripts/check-workflow-hygiene.sh` (46 workflows)
- `git diff --check origin/main...HEAD`
- tree matches VAST-green integrated commit `5e9f1c0b`; `cargo test --workspace` passed and instance was destroyed