### PR TITLE
chore(release): prepare v0.1.0

### DIFF
--- a/.github/workflows/parity-sbv2-real.yml
+++ b/.github/workflows/parity-sbv2-real.yml
@@ -583,6 +583,7 @@ jobs:
           RUN_ZH: ${{ needs.setup.outputs.run_zh }}
         run: |
           set -euo pipefail
+          sidecar_failed=0
           verify_sidecar() {
             local artifact="$1"
             local sidecar="$2"
@@ -590,14 +591,16 @@ jobs:
             expected="$(awk 'NF && $1 !~ /^#/ { print $1; exit }' "$sidecar")"
             if ! [[ "$expected" =~ ^[0-9a-f]{64}$ ]]; then
               echo "::error::${sidecar} has no valid lowercase SHA-256 record"
-              return 1
+              sidecar_failed=1
+              return
             fi
             actual="$(sha256sum "$artifact" | awk '{ print $1 }')"
             if [ "$actual" != "$expected" ]; then
               echo "::error::SHA-256 mismatch for ${artifact}: got ${actual}, expected ${expected}"
-              return 1
+              sidecar_failed=1
+            else
+              echo "SHA-256 OK: ${artifact} = ${actual}"
             fi
-            echo "SHA-256 OK: ${artifact} = ${actual}"
           }
 
           verify_sidecar \
@@ -613,6 +616,9 @@ jobs:
             verify_sidecar \
               "$FIXTURE_DIR/chinese-roberta-wwm-ext-large.gguf" \
               "$FIXTURE_DIR/chinese-roberta-wwm-ext-large.gguf.sha256"
+          fi
+          if [ "$sidecar_failed" -ne 0 ]; then
+            exit 1
           fi
 
       - name: Regenerate reference dump (sbv2_dump_reference.py --do-dump)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,19 @@ follows [SemVer](https://semver.org/spec/v2.0.0.html).
 requirement IF-01). Every pre-1.0 release may change the C ABI without
 deprecation windows. Here "v1.0" means the **v1.0 GA** tag (M5 close, WP
 M5-13); the **v1.0-rc** prerelease (`1.0.0-rc.N`, M4) is still pre-1.0 and
-therefore not frozen — see the `[1.0.0-rc.1]` ABI-policy notes below.
+therefore not frozen — see the planned v1.0.0-rc.1 ABI-policy notes below.
 
 ## [Unreleased]
 
-This section accumulates **all** untagged feature deltas — **v0.5 (M2) +
-v0.9 (M3) + v1.0-rc (M4) + real-weight verify / HF publication (post-M5)**
-— that roll into `[1.0.0-rc.1]`. CC-side implementation is complete for
-the WPs listed below; owner-side verification (real-device RTF / GPU /
-NPU measurement, real-weight parity flip-the-switch, license sign-off,
-PyPI / Unity / npm / CDN provisioning) is tracked in the per-milestone
-owner checklists (`docs/m2-owner-verification-checklist.md`,
+## [0.1.0] — 2026-08-23
+
+This first tagged release includes the source-publication baseline plus the
+subsequently implemented v0.5 (M2), v0.9 (M3), v1.0-rc (M4), and real-weight
+verification / HF publication work. Owner-side verification
+(real-device RTF / GPU / NPU measurement, real-weight parity
+flip-the-switch, license sign-off, PyPI / Unity / npm / CDN provisioning) is
+tracked in the per-milestone owner checklists
+(`docs/m2-owner-verification-checklist.md`,
 `docs/m3-owner-verification-checklist.md`,
 `docs/m4-owner-verification-checklist.md`,
 `docs/m5-owner-verification-checklist.md`). Added entries are grouped by
@@ -814,15 +816,14 @@ failure mode this project treats as worse than a crash:
   `wyoming` 1.10.0 client now round-trips the canonical JFK transcript
   byte-identically to the HTTP route.
 
-## [1.0.0-rc.1]
+### Planned v1.0.0-rc.1 ABI policy
 
-First v1.0 release candidate (semver prerelease `1.0.0-rc.1`). The feature
-deltas for v0.5 (M2) / v0.9 (M3) / v1.0-rc (M4) accrue in `[Unreleased]`
-above and are rolled into this section by the M4 tag-preparation step (the
-v1.0-rc tag is an owner milestone decision, not WP M4-12). This section was
-added by **M4-12** to record the **ABI policy for the rc window**.
+The first v1.0 release candidate will use the semver prerelease
+`1.0.0-rc.1`. This note was added by **M4-12** to record the **ABI policy for
+the future rc window**; creating that rc tag remains a separate owner
+milestone decision.
 
-### ABI policy (v1.0-rc)
+#### ABI policy (v1.0-rc)
 
 - **Not frozen.** The C ABI (`include/vokra.h`) and the `vokra.*` GGUF
   metadata schema are a semver **prerelease** surface at `1.0.0-rc.N`; they
@@ -856,13 +857,14 @@ added by **M4-12** to record the **ABI policy for the rc window**.
   section that names these tiers in the header is added at the M5-13 freeze
   (`docs/handoff/m4-12.md` §(e)-1).
 
-## [0.1.0] — 2026-07-04
+### Initial source-publication baseline (2026-07-04)
 
-Initial public release. **v0.1 spike + v0.1 MVP** implementations
-complete; repository made public on 2026-07-04 with CI quality gates
-enforced (`.github/workflows/ci.yml`).
+The repository became public on 2026-07-04 with the **v0.1 spike + v0.1 MVP**
+implementation baseline and CI quality gates enforced
+(`.github/workflows/ci.yml`). No Git tag or GitHub Release was created then;
+this baseline is therefore included in the first tagged release.
 
-### Added
+#### Added
 
 - **Rust Cargo workspace** with 12 crates (`vokra-core` / `-ops` /
   `-backend-cpu` / `-backend-metal` / `-backend-cuda` / `-models` /
@@ -897,5 +899,4 @@ enforced (`.github/workflows/ci.yml`).
   audit, iOS build, Python wheel build, license audit, GPU backends.
 
 [Unreleased]: https://github.com/ayutaz/vokra/compare/v0.1.0...HEAD
-[1.0.0-rc.1]: https://github.com/ayutaz/vokra/releases/tag/v1.0.0-rc.1
 [0.1.0]: https://github.com/ayutaz/vokra/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,14 +4,14 @@ version = 4
 
 [[package]]
 name = "vokra-backend-coreml"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
 ]
 
 [[package]]
 name = "vokra-backend-cpu"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
  "vokra-math",
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "vokra-backend-cuda"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-backend-cpu",
  "vokra-core",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "vokra-backend-metal"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-backend-cpu",
  "vokra-core",
@@ -36,14 +36,14 @@ dependencies = [
 
 [[package]]
 name = "vokra-backend-qnn"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
 ]
 
 [[package]]
 name = "vokra-backend-vulkan"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-backend-cpu",
  "vokra-core",
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "vokra-backend-webgpu"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-backend-cpu",
  "vokra-core",
@@ -69,7 +69,7 @@ dependencies = [
 
 [[package]]
 name = "vokra-capi"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-convert",
  "vokra-core",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "vokra-cli"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-convert",
  "vokra-core",
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "vokra-convert"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
  "vokra-mmap",
@@ -101,11 +101,11 @@ dependencies = [
 
 [[package]]
 name = "vokra-core"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 
 [[package]]
 name = "vokra-eval"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-backend-cpu",
  "vokra-core",
@@ -121,18 +121,18 @@ dependencies = [
 
 [[package]]
 name = "vokra-math"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 
 [[package]]
 name = "vokra-mmap"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
 ]
 
 [[package]]
 name = "vokra-models"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-backend-coreml",
  "vokra-backend-cpu",
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "vokra-ops"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
  "vokra-math",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "vokra-parity"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
  "vokra-ops",
@@ -171,21 +171,21 @@ dependencies = [
 
 [[package]]
 name = "vokra-piper-plus"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
 ]
 
 [[package]]
 name = "vokra-vad-micro"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
 ]
 
 [[package]]
 name = "vokra-wasm-harness"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-backend-cpu",
  "vokra-backend-webgpu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = ["crates/*", "crates/vokra-bert", "crates/vokra-kws-micro", "tests/par
 exclude = ["integrations", "fuzz"]
 
 [workspace.package]
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 # Proposal per M0-02-T01: edition 2024; to be pinned together with the CI
 # toolchain during the spike (verified locally with rustc 1.95.0).
 edition = "2024"
@@ -54,31 +54,31 @@ publish = false
 # version to resolve. All crates share the workspace version (Cargo.toml:21), so
 # the requirement tracks it. Adding these does NOT change Cargo.lock (path
 # resolution is unchanged — verified by the zero-dep tripwire).
-vokra-core = { path = "crates/vokra-core", version = "0.1.0-alpha.0" }
-vokra-ops = { path = "crates/vokra-ops", version = "0.1.0-alpha.0" }
-vokra-backend-cpu = { path = "crates/vokra-backend-cpu", version = "0.1.0-alpha.0" }
-vokra-backend-metal = { path = "crates/vokra-backend-metal", version = "0.1.0-alpha.0" }
-vokra-backend-cuda = { path = "crates/vokra-backend-cuda", version = "0.1.0-alpha.0" }
-vokra-backend-vulkan = { path = "crates/vokra-backend-vulkan", version = "0.1.0-alpha.0" }
-vokra-backend-webgpu = { path = "crates/vokra-backend-webgpu", version = "0.1.0-alpha.0" }
-vokra-backend-coreml = { path = "crates/vokra-backend-coreml", version = "0.1.0-alpha.0" }
-vokra-backend-qnn = { path = "crates/vokra-backend-qnn", version = "0.1.0-alpha.0" }
-vokra-models = { path = "crates/vokra-models", version = "0.1.0-alpha.0" }
-vokra-piper-plus = { path = "crates/vokra-piper-plus", version = "0.1.0-alpha.0" }
-vokra-capi = { path = "crates/vokra-capi", version = "0.1.0-alpha.0" }
-vokra-mmap = { path = "crates/vokra-mmap", version = "0.1.0-alpha.0" }
-vokra-convert = { path = "crates/vokra-convert", version = "0.1.0-alpha.0" }
+vokra-core = { path = "crates/vokra-core", version = "0.1.0" }
+vokra-ops = { path = "crates/vokra-ops", version = "0.1.0" }
+vokra-backend-cpu = { path = "crates/vokra-backend-cpu", version = "0.1.0" }
+vokra-backend-metal = { path = "crates/vokra-backend-metal", version = "0.1.0" }
+vokra-backend-cuda = { path = "crates/vokra-backend-cuda", version = "0.1.0" }
+vokra-backend-vulkan = { path = "crates/vokra-backend-vulkan", version = "0.1.0" }
+vokra-backend-webgpu = { path = "crates/vokra-backend-webgpu", version = "0.1.0" }
+vokra-backend-coreml = { path = "crates/vokra-backend-coreml", version = "0.1.0" }
+vokra-backend-qnn = { path = "crates/vokra-backend-qnn", version = "0.1.0" }
+vokra-models = { path = "crates/vokra-models", version = "0.1.0" }
+vokra-piper-plus = { path = "crates/vokra-piper-plus", version = "0.1.0" }
+vokra-capi = { path = "crates/vokra-capi", version = "0.1.0" }
+vokra-mmap = { path = "crates/vokra-mmap", version = "0.1.0" }
+vokra-convert = { path = "crates/vokra-convert", version = "0.1.0" }
 # M5-03 (案1): the no_std(+alloc) Silero VAD forward core. `vokra-models`
 # depends on it (default features) and re-exports it; the Cortex-M55 Tier-3
 # build uses it with `--no-default-features`. First-party `vokra-*` crate with
 # only a `vokra-core` dep, so the root Cargo.lock stays vokra-* only (NFR-DS-02).
-vokra-vad-micro = { path = "crates/vokra-vad-micro", version = "0.1.0-alpha.0" }
+vokra-vad-micro = { path = "crates/vokra-vad-micro", version = "0.1.0" }
 # SBV2 v2 Stage A/Task 23: the BERT-family encoder + SentencePiece tokenizer
 # `sbv2::SbV2Model` loads (both DeBERTa v2 JA and DeBERTa v3 EN, multilingual —
 # `docs/superpowers/specs/2026-07-26-sbv2-v2-design.md` §6/§7). First-party
 # `vokra-*` crate with only a `vokra-core` + `vokra-mmap` dep, so the root
 # Cargo.lock stays vokra-* only (NFR-DS-02).
-vokra-bert = { path = "crates/vokra-bert", version = "0.1.0-alpha.0" }
+vokra-bert = { path = "crates/vokra-bert", version = "0.1.0" }
 # WP-07: the shared home for the scalar f32 transcendental primitives
 # (`exp`/`tanh`/`sqrt`/`sin`/`cos`/`log`/`log1p`) — extracted from
 # `crates/vokra-backend-cpu/src/kernels/scalar_transcendental.rs` so
@@ -88,7 +88,7 @@ vokra-bert = { path = "crates/vokra-bert", version = "0.1.0-alpha.0" }
 # — AVX-512, dotprod / i8mm, K-quants, thread pool — into every op crate).
 # Zero external deps (not even `vokra-core`): the whole crate is pure `core`
 # arithmetic, so the root Cargo.lock stays vokra-* only (NFR-DS-02).
-vokra-math = { path = "crates/vokra-math", version = "0.1.0-alpha.0" }
+vokra-math = { path = "crates/vokra-math", version = "0.1.0" }
 
 # Unsafe boundary policy (M0-02-T03; NFR-RL-07, SRS §5-(1)):
 # the workspace is safe-by-default (`unsafe_code = "deny"`). `unsafe` +

--- a/README.ja.md
+++ b/README.ja.md
@@ -14,10 +14,10 @@ Vokra は provenance を含む GGUF を読み込み、ランタイムでは ONNX
 ロードしません。デフォルトランタイムに外部 Cargo 依存はなく、root
 `Cargo.lock` は first-party の `vokra-*` crate だけで構成されます。
 
-> **リリース状況:** `0.1.0-alpha.0` はソース優先のプレビューです。Rust API、
-> C ABI、GGUF metadata、モデル対応範囲は v1.0 までに変更される可能性が
-> あります。他プロジェクトで評価するときは commit または release を固定して
-> ください。
+> **リリース状況:** `0.1.0` を最初のタグ付きリリースとして準備しています。
+> Rust API、C ABI、GGUF metadata、モデル対応範囲は引き続き pre-1.0 で、
+> 変更される可能性があります。他プロジェクトで評価するときは正確な release
+> を固定してください。
 
 ## Vokra の特徴
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Vokra loads provenance-aware GGUF files and does not load ONNX graphs at
 runtime. The default runtime has no third-party Cargo dependencies: the root
 `Cargo.lock` contains only first-party `vokra-*` crates.
 
-> **Release status:** `0.1.0-alpha.0` is a source-first preview. Rust APIs, the
-> C ABI, GGUF metadata, and model coverage may change before v1.0. Pin an exact
-> commit or release when evaluating Vokra in another project.
+> **Release status:** `0.1.0` is prepared as the first tagged release. Rust
+> APIs, the C ABI, GGUF metadata, and model coverage remain pre-1.0 and may
+> change. Pin an exact release when evaluating Vokra in another project.
 
 ## Why Vokra
 

--- a/SECURITY.ja.md
+++ b/SECURITY.ja.md
@@ -25,9 +25,9 @@ credit は advisory 内で調整し、匿名の希望を尊重します。
 
 ## サポート対象
 
-Vokra は現在 `0.1.0-alpha.0` のソース優先プレビューです。セキュリティ修正は
-現行 development line に適用します。古い commit、private build、未公開
-snapshot への backport は行いません。
+Vokra `0.1.0` を最初のタグ付きリリースとして準備しています。セキュリティ
+修正は現行 development line に適用します。古い commit、private build、
+未公開 snapshot への backport は行いません。
 
 ## 対象範囲
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,9 +27,9 @@ respected when requested.
 
 ## Supported versions
 
-Vokra is currently a `0.1.0-alpha.0` source-first preview. Security fixes are
-made on the current development line. Older commits, private builds, and
-unreleased snapshots do not receive backports.
+Vokra `0.1.0` is prepared as the first tagged release. Security fixes are made
+on the current development line. Older commits, private builds, and unreleased
+snapshots do not receive backports.
 
 ## In scope
 

--- a/bindings/unity/com.vokra.unity/CHANGELOG.md
+++ b/bindings/unity/com.vokra.unity/CHANGELOG.md
@@ -7,6 +7,8 @@ suffix conventions (`-preview.N` for pre-1.0 iterations).
 
 ## [Unreleased]
 
+## [0.1.0] — 2026-08-23
+
 ### Added
 - M4-02: **WebGL target** — `Plugins/WebGL/libvokra.a`
   (wasm32-unknown-emscripten staticlib, `DllImport("__Internal")`, CPU/WASM,
@@ -31,23 +33,23 @@ suffix conventions (`-preview.N` for pre-1.0 iterations).
   `EnsureLocalCopyAsync` gains a WebGL branch whose returned path is valid
   for managed (C#) file IO only — pass models to `CreateFromBytes` instead.
 
-## [0.1.0-preview.1] — TBD
+### Initial package baseline
 
-Initial preview release. M2-11 workstream.
+Initial package scaffold from the M2-11 workstream, included in `0.1.0`.
 
-### Added
+#### Added
 - Package layout at `bindings/unity/com.vokra.unity/`.
 - `Vokra.Runtime` and `Vokra.Editor` assembly definitions.
 - iOS PostProcessBuild hook wiring `libvokra.a`, `Metal.framework`,
   `Accelerate.framework` into the exported Xcode project.
 - Apache-2.0 license and NVIDIA-runtime non-bundling `NOTICE`.
 
-### Not included
+#### Not included in the initial scaffold
 - Native binaries (`libvokra.dylib` / `vokra.dll` / `libvokra.so` /
   `libvokra.a`) — populated by CD, not committed to git.
 - Model weights — fetched per-sample via
   `Samples~/VadAsrTts/scripts/fetch-demo-models.sh`.
 - CUDA runtime — resolved via `dlopen` at runtime per NVIDIA EULA.
 
-[Unreleased]: https://github.com/ayutaz/vokra/compare/v0.1.0-preview.1...HEAD
-[0.1.0-preview.1]: https://github.com/ayutaz/vokra/releases/tag/v0.1.0-preview.1
+[Unreleased]: https://github.com/ayutaz/vokra/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/ayutaz/vokra/releases/tag/v0.1.0

--- a/bindings/unity/com.vokra.unity/README.md
+++ b/bindings/unity/com.vokra.unity/README.md
@@ -9,7 +9,7 @@ around the C ABI declared in `include/vokra.h`.
 
 ## Status
 
-`0.1.0-preview.1` — M2-11 preview. Skeleton only; native binaries are
+`0.1.0` — first tagged release. Native binaries are
 assembled by CD (see `.github/workflows/release.yml` job `unity-package`).
 
 ## Supported Unity versions

--- a/bindings/unity/com.vokra.unity/package.json
+++ b/bindings/unity/com.vokra.unity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.vokra.unity",
-  "version": "0.1.0-preview.1",
+  "version": "0.1.0",
   "displayName": "Vokra",
   "description": "Vokra audio inference runtime for Unity (VAD/ASR/TTS/speaker).",
   "unity": "2022.3",

--- a/crates/vokra-core/src/gguf/chunks.rs
+++ b/crates/vokra-core/src/gguf/chunks.rs
@@ -178,17 +178,18 @@ pub const KEY_SILERO_VERSION: &str = "vokra.silero.version";
 /// answer, not an error: every GGUF converted up to that point lacks the key.
 /// Read it through [`crate::gguf::schema::schema_version`].
 ///
-/// **Not** the crate version: `CARGO_PKG_VERSION` has been `0.1.0-alpha.0`
-/// across M0…M5, so it cannot distinguish two artifacts from different
-/// converter generations. That is exactly the case this key exists for.
+/// **Not** the crate version: `CARGO_PKG_VERSION` stayed `0.1.0-alpha.0`
+/// across M0…M5 and now advances only with releases, so it cannot distinguish
+/// converter generations within one release. That is exactly the case this
+/// key exists for.
 pub const KEY_SCHEMA_VERSION: &str = "vokra.schema.version";
 
 /// `vokra.schema.producer` — the converter build that wrote the file, e.g.
-/// `"vokra-convert 0.1.0-alpha.0"` (`STRING`).
+/// `"vokra-convert 0.1.0"` (`STRING`).
 ///
 /// Diagnostic companion to [`KEY_SCHEMA_VERSION`]: it identifies the build for
 /// a bug report but must never gate behaviour, because the version string does
-/// not move between releases yet.
+/// is not a schema compatibility contract.
 pub const KEY_SCHEMA_PRODUCER: &str = "vokra.schema.producer";
 
 // `vokra.quant.*` — quantization policy metadata (M2-08, FR-QT-02).

--- a/crates/vokra-core/src/gguf/schema.rs
+++ b/crates/vokra-core/src/gguf/schema.rs
@@ -34,8 +34,9 @@
 //!
 //! Raise [`SCHEMA_VERSION`] when a converter begins emitting a group that
 //! loaders may come to depend on, and add a line to its changelog. Do not tie
-//! it to `CARGO_PKG_VERSION`: that string has been `0.1.0-alpha.0` since M0 and
-//! would have been identical on both sides of the incident above.
+//! it to `CARGO_PKG_VERSION`: that string stayed `0.1.0-alpha.0` throughout
+//! M0…M5 and would have been identical on both sides of the incident above.
+//! Package releases still do not identify schema changes within one release.
 
 use alloc::borrow::ToOwned;
 use alloc::format;
@@ -110,7 +111,7 @@ pub fn producer(file: &GgufFile) -> Option<&str> {
 }
 
 /// One-line provenance summary for logs and error messages, e.g.
-/// `"schema gen 1 (vokra-convert 0.1.0-alpha.0)"`.
+/// `"schema gen 1 (vokra-convert 0.1.0)"`.
 #[must_use]
 pub fn describe(file: &GgufFile) -> String {
     match producer(file) {

--- a/crates/vokra-kws-micro/Cargo.toml
+++ b/crates/vokra-kws-micro/Cargo.toml
@@ -32,7 +32,7 @@ publish = false
 # path dep; the `version` alongside `path` tracks the shared workspace version
 # for future `cargo publish` (a no-op for local path resolution today).
 [dependencies]
-vokra-core = { path = "../vokra-core", version = "0.1.0-alpha.0", default-features = false }
+vokra-core = { path = "../vokra-core", version = "0.1.0", default-features = false }
 
 # Mirror of `vokra-vad-micro`'s feature layout: `std` (default-ON) forwards to
 # `vokra-core/std`. This crate's own `lib.rs` uses

--- a/crates/vokra-vad-micro/Cargo.toml
+++ b/crates/vokra-vad-micro/Cargo.toml
@@ -33,7 +33,7 @@ categories.workspace = true
 # (NFR-DS-02); the `version` tracks the shared workspace version for `cargo
 # publish` (X-07-T10, a no-op for local path resolution).
 [dependencies]
-vokra-core = { path = "../vokra-core", version = "0.1.0-alpha.0", default-features = false }
+vokra-core = { path = "../vokra-core", version = "0.1.0", default-features = false }
 
 [features]
 # `std` (default-ON) forwards to `vokra-core/std` and lets the host-executable

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,8 +54,8 @@ and the publication scripts for release eligibility.
 
 ## Current release posture
 
-The workspace version is `0.1.0-alpha.0`. Rust APIs, the C ABI, GGUF metadata,
-and the model roster remain pre-1.0 and may change. The C header and Python
+The workspace version is `0.1.0`. Rust APIs, the C ABI, GGUF metadata, and the
+model roster remain pre-1.0 and may change. The C header and Python
 prototype table are checked for exact function-set equality; documentation
 therefore avoids copying a function count that would drift on the next ABI
 addition.

--- a/docs/handoff/m5-13.md
+++ b/docs/handoff/m5-13.md
@@ -36,7 +36,10 @@ The freeze itself is gated on the owner's v1.0 GA milestone decision **and** the
 
 - **NOT rotated**: the baseline anchor stays `v1.0-rc` (`scripts/check-abi-changelog.sh` `ANCHOR=`), the Rust surface snapshot stays `v1.0-rc.list`. Rotating to `v1.0` requires the GA tag commit (which does not exist yet).
 - **NOT frozen**: the STABILITY block in `crates/vokra-capi/cbindgen.toml` still says "the ABI is NOT frozen; … starts at v1.0 GA". It stays that way until the GA tag fires.
-- **NOT bumped**: `[workspace.package] version` stays `0.1.0-alpha.0`. The bump to `1.0.0` (M5-13-T20) belongs to the GA tag commit — it is part of the owner's tag-preparation step (G3 requires the GA tag commit to carry `version = "1.0.0"`).
+- **NOT bumped to GA**: `[workspace.package] version` is `0.1.0` for the first
+  tagged release. The later bump to `1.0.0` (M5-13-T20) belongs to the GA tag
+  commit — it is part of the owner's tag-preparation step (G3 requires the GA
+  tag commit to carry `version = "1.0.0"`).
 - **NOT wired required**: `--gate` is landed and self-tested but the ci.yml `abi-surface` job keeps its `continue-on-error: true` (advisory). Promotion to a required branch-protection check is the owner's repo-admin action (T18) after a stretch of green.
 - **NO NPU delegate / wfst C symbol added**: `include/vokra.h` carries no delegate-selector or `wfst_decode` C export. Adding one is gated on the owner's GO/NO-GO after the bakeoff (T19); a speculative reservation is forbidden.
 
@@ -84,6 +87,9 @@ Once T17/T19 give CC the GA tag commit + the two GO/NO-GO verdicts (and G4 bakeo
 
 ## (e) Non-negotiables carried forward
 
-- **zero-dep (NFR-DS-02)**: the change surface is bash + docs + `cbindgen.toml` + a regenerated header + one `Cargo.toml` version line. `Cargo.lock`'s only allowed diff at the bump is the version string (16 `vokra-*` lines `0.1.0-alpha.0` → `1.0.0`); dependency-package count must not change.
+- **zero-dep (NFR-DS-02)**: the change surface is bash + docs +
+  `cbindgen.toml` + a regenerated header + release-version metadata.
+  `Cargo.lock`'s only allowed diff at a bump is first-party `vokra-*` version
+  strings; dependency-package count must not change.
 - **fabricated pass / fabricated gate forbidden**: the gate is required only after its negative test proves it can fail; the snapshot is final only when every freeze-surface WP has landed and been recorded.
 - **owner-only stays owner-only**: the GA tag, branch-protection contexts, and the delegate/wfst GO/NO-GO are the owner's.

--- a/docs/handoff/x-07.md
+++ b/docs/handoff/x-07.md
@@ -21,9 +21,10 @@ runtime dependency closure. Owner steps, once:
    prints them). crates.io names are first-come.
 2. Decide `vars.CRATES_IO_PUBLISH_ENABLED=true|false`. If true, add
    `secrets.CRATES_IO_TOKEN`; enabled-without-token is a hard preflight failure.
-3. **Decide first-publish timing**: publish on an rc tag (CD auto), or keep
-   dry-run only for now. The initial version is `0.1.0-alpha.0`; align it with
-   the release tag semver before the first real publish (crates.io is immutable).
+3. **Decide first-publish timing**: publish on a release tag (CD auto), or keep
+   dry-run only for now. The selected first tagged version is `0.1.0`;
+   crates.io is immutable, so confirm the tag and workspace version still
+   match before the first real publish.
 
 `[workspace.package].version` is the single source of truth for an effectful
 release. A tag whose unprefixed SemVer differs is rejected by `validate-tag`

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -83,7 +83,7 @@ checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "vokra-core"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 
 [[package]]
 name = "vokra-fuzz"

--- a/integrations/vokra-android/Cargo.lock
+++ b/integrations/vokra-android/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
 
 [[package]]
 name = "vokra-backend-cpu"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
  "vokra-math",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "vokra-capi"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
  "vokra-mmap",
@@ -38,22 +38,22 @@ dependencies = [
 
 [[package]]
 name = "vokra-core"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 
 [[package]]
 name = "vokra-math"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 
 [[package]]
 name = "vokra-mmap"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
 ]
 
 [[package]]
 name = "vokra-models"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-backend-cpu",
  "vokra-bert",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "vokra-ops"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
  "vokra-math",
@@ -75,14 +75,14 @@ dependencies = [
 
 [[package]]
 name = "vokra-piper-plus"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
 ]
 
 [[package]]
 name = "vokra-vad-micro"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
 ]

--- a/integrations/vokra-godot/Cargo.lock
+++ b/integrations/vokra-godot/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "vokra-backend-cpu"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
  "vokra-math",
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "vokra-capi"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
  "vokra-mmap",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "vokra-core"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 
 [[package]]
 name = "vokra-godot"
@@ -42,18 +42,18 @@ dependencies = [
 
 [[package]]
 name = "vokra-math"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 
 [[package]]
 name = "vokra-mmap"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
 ]
 
 [[package]]
 name = "vokra-models"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-backend-cpu",
  "vokra-bert",
@@ -67,7 +67,7 @@ dependencies = [
 
 [[package]]
 name = "vokra-ops"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
  "vokra-math",
@@ -75,14 +75,14 @@ dependencies = [
 
 [[package]]
 name = "vokra-piper-plus"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
 ]
 
 [[package]]
 name = "vokra-vad-micro"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
 ]

--- a/integrations/vokra-misaki-g2p/Cargo.lock
+++ b/integrations/vokra-misaki-g2p/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "vokra-backend-cpu"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
  "vokra-math",
@@ -21,11 +21,11 @@ dependencies = [
 
 [[package]]
 name = "vokra-core"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 
 [[package]]
 name = "vokra-math"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 
 [[package]]
 name = "vokra-misaki-g2p"
@@ -37,14 +37,14 @@ dependencies = [
 
 [[package]]
 name = "vokra-mmap"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
 ]
 
 [[package]]
 name = "vokra-models"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-backend-cpu",
  "vokra-bert",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "vokra-ops"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
  "vokra-math",
@@ -66,14 +66,14 @@ dependencies = [
 
 [[package]]
 name = "vokra-piper-plus"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
 ]
 
 [[package]]
 name = "vokra-vad-micro"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
 ]

--- a/integrations/vokra-piper-g2p/Cargo.lock
+++ b/integrations/vokra-piper-g2p/Cargo.lock
@@ -1409,7 +1409,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vokra-backend-cpu"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
  "vokra-math",
@@ -1426,22 +1426,22 @@ dependencies = [
 
 [[package]]
 name = "vokra-core"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 
 [[package]]
 name = "vokra-math"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 
 [[package]]
 name = "vokra-mmap"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
 ]
 
 [[package]]
 name = "vokra-models"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-backend-cpu",
  "vokra-bert",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "vokra-ops"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
  "vokra-math",
@@ -1473,14 +1473,14 @@ dependencies = [
 
 [[package]]
 name = "vokra-piper-plus"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
 ]
 
 [[package]]
 name = "vokra-vad-micro"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
 ]

--- a/integrations/vokra-server/Cargo.lock
+++ b/integrations/vokra-server/Cargo.lock
@@ -2285,7 +2285,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vokra-backend-cpu"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
  "vokra-math",
@@ -2293,21 +2293,21 @@ dependencies = [
 
 [[package]]
 name = "vokra-backend-cuda"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
 ]
 
 [[package]]
 name = "vokra-backend-metal"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
 ]
 
 [[package]]
 name = "vokra-backend-vulkan"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
 ]
@@ -2323,22 +2323,22 @@ dependencies = [
 
 [[package]]
 name = "vokra-core"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 
 [[package]]
 name = "vokra-math"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 
 [[package]]
 name = "vokra-mmap"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
 ]
 
 [[package]]
 name = "vokra-models"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-backend-cpu",
  "vokra-backend-cuda",
@@ -2355,7 +2355,7 @@ dependencies = [
 
 [[package]]
 name = "vokra-ops"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
  "vokra-math",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "vokra-piper-plus"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
 ]
@@ -2401,7 +2401,7 @@ dependencies = [
 
 [[package]]
 name = "vokra-vad-micro"
-version = "0.1.0-alpha.0"
+version = "0.1.0"
 dependencies = [
  "vokra-core",
 ]

--- a/tests/fixtures/sbv2/deberta-v2-large-japanese-char-wwm.gguf.sha256
+++ b/tests/fixtures/sbv2/deberta-v2-large-japanese-char-wwm.gguf.sha256
@@ -1,1 +1,1 @@
-592f0a6b3f538b1b069562785205c8268f8351d654c7cdda53a695db947bb42a  deberta-v2-large-japanese-char-wwm.gguf
+b1c6bc1e91e6004b9255797aec0049f9d36c49306f9683bd3a888087a36682b9  deberta-v2-large-japanese-char-wwm.gguf

--- a/tests/fixtures/sbv2/deberta-v3-large.gguf.sha256
+++ b/tests/fixtures/sbv2/deberta-v3-large.gguf.sha256
@@ -1,1 +1,1 @@
-858c07bf3909b1b8d25d7ca7c1e0fed0e7c2bd9889a0068c6ebcfd689d0eb579  deberta-v3-large.gguf
+eae4dc95bc623a21c2e5c672a242fc75f7fbe86474272fc80a1b8997f90ea733  deberta-v3-large.gguf

--- a/tests/fixtures/sbv2/sbv2-v2-multilingual-base.gguf.sha256
+++ b/tests/fixtures/sbv2/sbv2-v2-multilingual-base.gguf.sha256
@@ -1,1 +1,1 @@
-19319c864ce210f630c021dece532d71d22a45b2573340601104f67cb3b26628  sbv2-v2-multilingual-base.gguf
+d92977ee9f87ebf8e5cc1577b64b8f9b78fdc1d9f33333f3293c5d0ed53e9760  sbv2-v2-multilingual-base.gguf

--- a/tools/release/test_version_contract.py
+++ b/tools/release/test_version_contract.py
@@ -3,16 +3,43 @@
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
 import tempfile
+import tomllib
 
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 CONTRACT = os.path.join(ROOT, "tools", "release", "version_contract.py")
 RELEASE_YML = os.path.join(ROOT, ".github", "workflows", "release.yml")
 GODOT_BUILD = os.path.join(ROOT, "scripts", "build-godot-gdextension.sh")
+ROOT_CARGO = os.path.join(ROOT, "Cargo.toml")
+ROOT_LOCK = os.path.join(ROOT, "Cargo.lock")
+UNITY_PACKAGE = os.path.join(
+    ROOT, "bindings", "unity", "com.vokra.unity", "package.json"
+)
+UNITY_CHANGELOG = os.path.join(
+    ROOT, "bindings", "unity", "com.vokra.unity", "CHANGELOG.md"
+)
+GODOT_CARGO = os.path.join(ROOT, "integrations", "vokra-godot", "Cargo.toml")
+CHANGELOG = os.path.join(ROOT, "CHANGELOG.md")
+EXTRACT_CHANGELOG = os.path.join(ROOT, "scripts", "release", "extract-changelog.py")
+LOCKFILES = (
+    ROOT_LOCK,
+    os.path.join(ROOT, "fuzz", "Cargo.lock"),
+    os.path.join(ROOT, "integrations", "vokra-android", "Cargo.lock"),
+    os.path.join(ROOT, "integrations", "vokra-godot", "Cargo.lock"),
+    os.path.join(ROOT, "integrations", "vokra-misaki-g2p", "Cargo.lock"),
+    os.path.join(ROOT, "integrations", "vokra-piper-g2p", "Cargo.lock"),
+    os.path.join(ROOT, "integrations", "vokra-server", "Cargo.lock"),
+)
+
+
+def load_toml(path: str) -> dict:
+    with open(path, "rb") as handle:
+        return tomllib.load(handle)
 
 
 def run(cargo_toml: str, ref: str, candidate: str = "") -> subprocess.CompletedProcess:
@@ -35,6 +62,81 @@ def run(cargo_toml: str, ref: str, candidate: str = "") -> subprocess.CompletedP
 
 def main() -> None:
     checks: list[tuple[bool, str]] = []
+
+    root_cargo = load_toml(ROOT_CARGO)
+    canonical = root_cargo["workspace"]["package"]["version"]
+    path_deps = [
+        (name, spec.get("version"))
+        for name, spec in root_cargo["workspace"]["dependencies"].items()
+        if isinstance(spec, dict) and "path" in spec
+    ]
+    checks.append(
+        (
+            bool(path_deps) and all(version == canonical for _, version in path_deps),
+            "workspace path dependencies use canonical version",
+        )
+    )
+
+    root_lock = load_toml(ROOT_LOCK)
+    workspace_names = {package["name"] for package in root_lock["package"]}
+    lock_mismatches: list[str] = []
+    for lockfile in LOCKFILES:
+        for package in load_toml(lockfile)["package"]:
+            if package["name"] in workspace_names and package["version"] != canonical:
+                lock_mismatches.append(
+                    f"{os.path.relpath(lockfile, ROOT)}:{package['name']}={package['version']}"
+                )
+    checks.append(
+        (
+            not lock_mismatches,
+            "tracked lockfiles use canonical first-party version",
+        )
+    )
+
+    with open(UNITY_PACKAGE, encoding="utf-8") as handle:
+        unity_package = json.load(handle)
+    checks.append(
+        (
+            unity_package["version"] == canonical,
+            "Unity source manifest uses canonical version",
+        )
+    )
+    checks.append(
+        (
+            load_toml(GODOT_CARGO)["package"]["version"] == canonical,
+            "Godot source manifest uses canonical version",
+        )
+    )
+
+    changelog = subprocess.run(
+        [
+            sys.executable,
+            EXTRACT_CHANGELOG,
+            "--version",
+            canonical,
+            "--changelog",
+            CHANGELOG,
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    checks.append(
+        (
+            changelog.returncode == 0 and bool(changelog.stdout.strip()),
+            "root CHANGELOG has non-empty canonical release notes",
+        )
+    )
+    with open(UNITY_CHANGELOG, encoding="utf-8") as handle:
+        unity_changelog = handle.read()
+    checks.append(
+        (
+            f"## [{canonical}]" in unity_changelog
+            and f"releases/tag/v{canonical}" in unity_changelog,
+            "Unity CHANGELOG has canonical release section and link",
+        )
+    )
+
     with tempfile.TemporaryDirectory(prefix="release-version-contract.") as scratch:
         cargo_toml = os.path.join(scratch, "Cargo.toml")
         with open(cargo_toml, "w", encoding="utf-8") as handle:


### PR DESCRIPTION
## Summary

- promote the canonical Rust, Unity, Godot, and tracked lockfile versions to 0.1.0
- finalize the root and Unity CHANGELOG entries for the first tagged release
- expand the release version-contract oracle across workspace dependencies, lockfiles, manifests, and changelogs
- refresh the three SBV2/DeBERTa GGUF sidecars regenerated by the 0.1.0 converter and make mismatch diagnostics exhaustive
- retain development fallback versions for Python and npm; the release workflow stamps their validated versions

## Verification

- all tools/release/test_*.py suites pass (including 17/17 version-contract checks)
- release changelog roll/check/extract passes for 0.1.0
- repository shell gates, cargo fmt --all -- --check, and git diff --check pass
- cargo test --workspace passes on Vast.ai at commit 404028d4; the verification instance was destroyed afterward
- parity-sbv2-real passes on final commit 7c999c77, including regenerated GGUF sidecars and real-checkpoint parity
- strict v0.1.0 release dry-run passes on final commit: https://github.com/ayutaz/vokra/actions/runs/32642334949
- all PR checks pass

## Publication safety

This PR does not create a tag or publish packages. External publication remains guarded by the repository variables/secrets and the strict release dry-run.