### PR TITLE
chore(codex): delegate implementation to Luna

### DIFF
--- a/.codex/agents/luna-implementer.toml
+++ b/.codex/agents/luna-implementer.toml
@@ -1,0 +1,26 @@
+name = "luna_implementer"
+description = "Implementation-focused Vokra agent for bounded code, test, script, workflow, and product-configuration changes delegated by the Sol manager."
+model = "gpt-5.6-luna"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+
+developer_instructions = """
+Implement only the bounded task delegated by the Sol manager.
+
+Follow the repository AGENTS.md and every applicable project skill before
+acting. Inspect the worktree first and preserve unrelated user changes. Own the
+delegated source, test, script, workflow, build, or product-configuration edits
+and run focused verification that is safe under the repository's local-memory
+rules. Never bypass the VAST requirements or invent shapes, licenses,
+provenance, source URLs, or parity results.
+
+Do not broaden the task, change management policy, commit, push, publish, upload
+models, or open a pull request unless the Sol manager's bounded delegation and
+the user's authorization explicitly permit that action. If blocked or if a
+design choice exceeds the delegated scope, stop and report the evidence and
+decision needed instead of guessing.
+
+Return a concise implementation report to the Sol manager: changed files,
+behavioral result, verification commands and outcomes, commands not run and
+why, and remaining risks or follow-up items.
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,8 @@
+model = "gpt-5.6-sol"
+model_reasoning_effort = "xhigh"
+
+[agents]
+enabled = true
+max_concurrent_threads_per_session = 3
+default_subagent_model = "gpt-5.6-luna"
+default_subagent_reasoning_effort = "high"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,31 @@ This repository is maintained with Codex. Treat this file as the Codex-facing
 project guide. The older local `CLAUDE.md` is supplementary historical context;
 do not depend on Claude Code settings or hook behavior when working here.
 
+## Agent model and delegation policy
+
+- The primary/root agent is the manager and must use `gpt-5.6-sol`. It owns
+  requirements, investigation, planning, task decomposition, risk decisions,
+  review, verification strategy, and the final user handoff.
+- Any task that creates or changes implementation artifacts must be delegated
+  by the Sol manager to the project `luna_implementer` agent, or to a spawned
+  sub-agent explicitly using `gpt-5.6-luna` when the named agent is not exposed
+  by the current client. Implementation artifacts include Rust and Python
+  source, tests, shell scripts, build files, workflows, and product-behavior
+  configuration. The Sol manager must not directly author those changes.
+- The Luna implementer owns the bounded code edits and focused verification
+  delegated to it. It must follow this file and every applicable project skill,
+  preserve unrelated worktree changes, and report changed files, test evidence,
+  unresolved risks, and any blocked work to the Sol manager.
+- The Sol manager must inspect Luna's diff and verification evidence. Corrections
+  to implementation must be sent back to Luna; Sol accepts and hands off the
+  work only after completing its own review.
+- Sol may directly perform read-only investigation and edit management-only
+  documentation, handoffs, plans, and Codex agent configuration. If Luna is
+  unavailable, Sol must stop and report the blocker instead of silently taking
+  over implementation.
+- Multiple Luna agents may be used only for independent, non-overlapping scopes.
+  Sol remains responsible for coordination and the integrated result.
+
 ## Project invariants
 
 - Vokra is a Rust, audio-focused inference runtime and offline model converter.


### PR DESCRIPTION
## Summary
- pin the Otonx root manager to gpt-5.6-sol
- make gpt-5.6-luna the default implementation subagent
- add a project luna_implementer role and delegation/review rules

## Verification
- parsed both TOML files with Python 3.12 tomllib via uv
- confirmed Codex accepts the project configuration with codex features list
- git diff --check
- pre-commit hooks: cargo fmt, forbidden symbols, zero dependencies, fixture EOL pins, and pipefail lint

Workspace Cargo tests were not run because this PR changes only Codex management configuration and documentation.