### PR TITLE
docs: refresh current Mac CPU and Metal coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ therefore not frozen — see the planned v1.0.0-rc.1 ABI-policy notes below.
 
 ### Changed
 
+- **2026-09-12 current Apple/public inventory**: at `main` baseline
+  `43d127f1`, the live read-only audit reports 194 public repositories, 193
+  GGUF-bearing repositories and 198 GGUF files. CPU status is `full=133`,
+  `partial=45`, `no-runtime-binder=15`, `not-artifact=1`; Metal status is
+  `full=133`, `blocked-by-cpu=60`, `not-artifact=1`, leaving 61 unresolved
+  public rows. The authorized Scaleway batch passed only for its named Apple
+  CPU/reference, Metal/reference and no-fallback scopes; four separately
+  approved artifacts were published through the gated workflow. This does
+  not constitute full model-catalog completion or a v1.0 release; no tags or
+  GitHub Releases exist yet.
+
 - **2026-08-31 pre-1.0 Rust API line: 0.2.0 → 0.3.0**: this feature line
   intentionally changes the public Rust API while the project remains before
   v1.0. The changes include new model/converter and backend enum variants,

--- a/README.ja.md
+++ b/README.ja.md
@@ -14,15 +14,17 @@ Vokra は provenance を含む GGUF を読み込み、ランタイムでは ONNX
 ロードしません。デフォルトランタイムに外部 Cargo 依存はなく、root
 `Cargo.lock` は first-party の `vokra-*` crate だけで構成されます。
 
-> **開発状況（2026-09-09）:** workspace は `0.3.0` development です。PR #79 の
-> 文書 refresh 開始時点の head は `9efcd16e`（成功 110、想定 skip 13、失敗 0）で、Git tag と
-> 公開済み release はまだありません。読み取り専用 inventory では Mac CPU
-> complete が 131、Apple Metal source route complete が 131、未解決の public row
-> が 63 です。これは pre-1.0・Scaleway 前の snapshot であり、Apple Silicon
-> CPU/reference と Metal/reference/no-fallback の実機 evidence は未主張です。
-> Rust API、C ABI、GGUF metadata、モデル対応範囲は変更される可能性があります。
-> 他プロジェクトで評価するときは正確な commit を固定し、release 公開後は正確な
-> tag または release を固定してください。
+> **開発状況（2026-09-12）:** workspace は `0.3.0` development で、この snapshot の
+> 現行 `main` baseline は `43d127f1` です。読み取り専用の公開 inventory は
+> repository 194、GGUF を持つ repository 193、GGUF file 198 です。内訳は Mac CPU
+> complete 133、partial 45、runtime binder なし 15、non-artifact 1、Apple Metal
+> full 133、CPU 起因の block 60、non-artifact 1 で、未解決の public row は 61 です。
+> [Apple 検証結果](docs/handoff/mac-cpu-metal-scaleway-results-2026-09-11.md)に記録した
+> Apple Silicon batch は named scope のみ合格し、その後、明示的に承認された4件の
+> artifact が公開されました。公開 row はなお61件未解決で、Git tag と公開済み release
+> はなく、Vokra は pre-1.0 のままです。Rust API、C ABI、GGUF metadata、モデル対応範囲は
+> 変更される可能性があります。他プロジェクトで評価するときは正確な commit を固定し、
+> release 公開後は正確な tag または release を固定してください。
 
 ## Vokra の特徴
 

--- a/README.md
+++ b/README.md
@@ -15,16 +15,19 @@ Vokra loads provenance-aware GGUF files and does not load ONNX graphs at
 runtime. The default runtime has no third-party Cargo dependencies: the root
 `Cargo.lock` contains only first-party `vokra-*` crates.
 
-> **Development status (2026-09-09):** the workspace is `0.3.0` development.
-> At the 2026-09-09 audit start, PR #79 pointed at `9efcd16e` (110 successful
-> checks / 13 expected skips / 0 failures); there are no Git tags or published
-> releases yet. The branch's read-only inventory records 131 Mac-CPU-complete
-> and 131 Apple-Metal-source-complete repositories, with 63 public rows still
-> unresolved. This is a pre-1.0, pre-Scaleway snapshot: Apple Silicon
-> CPU/reference and Metal/reference/no-fallback evidence has not been claimed.
-> Rust APIs, the C ABI, GGUF metadata, and model coverage may change. Pin an
-> exact commit when evaluating Vokra in another project; switch to an exact
-> tag or release after one is published.
+> **Development status (2026-09-12):** the workspace is `0.3.0` development;
+> the current `main` baseline for this snapshot is `43d127f1`. The live,
+> read-only public inventory reports 194 repositories, 193 GGUF-bearing
+> repositories and 198 GGUF files: 133 Mac-CPU-complete, 45 partial, 15
+> without a runtime binder and 1 non-artifact; Apple Metal is 133 full, 60
+> blocked by CPU and 1 non-artifact. The bounded Apple Silicon batch recorded
+> in the [Apple results](docs/handoff/mac-cpu-metal-scaleway-results-2026-09-11.md)
+> passed only for its named scopes, and four explicitly approved artifacts
+> were subsequently published. There are still 61 unresolved public rows,
+> no Git tags or published releases, and Vokra remains pre-1.0; Rust APIs, the
+> C ABI, GGUF metadata and model coverage may change. Pin an exact commit when
+> evaluating Vokra in another project; switch to an exact tag or release after
+> one is published.
 
 ## Why Vokra
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,8 @@
 
 **Current-state review:** 2026-09-12
 
-**Reviewed implementation baseline:** GitHub `main` at
-`41ce9ffdd4b0959497f55afa5016822f77a8a7b6`; the pre-documentation code
+**Reviewed implementation baseline:** GitHub `main` at `43d127f1` (2026-09-12);
+the pre-documentation code
 baseline was branch `feat/mac-cpu-metal-full-coverage-2026-08-28` at
 `9f69277d8a0d5df574c1ee95563bd1f005de91d0`; the pre-refresh
 documentation/evidence checkpoint was
@@ -17,20 +17,19 @@ was subsequently merged as `1787818e702bdaba488d52aa1666fd5f08c5ae16`.
 The bounded post-merge VAST and Scaleway execution is recorded in the
 [2026-09-11 Apple results](handoff/mac-cpu-metal-scaleway-results-2026-09-11.md).
 Those accepted hardware verdicts apply only to the rows and exact heads named
-there. They do not change the audit-start inventory of 131 Mac-CPU-complete and
-131 Apple-Metal-source-complete repositories or its 63 unresolved public rows,
-and did not themselves authorize an artifact upload. A separate, explicit
+there. They do not make the complete public catalog Apple-complete, and did
+not themselves authorize an artifact upload. A separate, explicit
 publication approval on 2026-09-12 subsequently replaced the reviewed
 ReazonSpeech NeMo v2, Voice Gender Classifier, BiCodec, and SGMSE VoiceBank
 artifacts through the gated publisher; the exact revisions and hashes are in
 the [post-batch reconciliation record](handoff/mac-cpu-metal-scaleway-results-2026-09-11.md#post-batch-public-artifact-reconciliation-2026-09-12).
-The resulting live audit reports 194 public repositories, 193 repositories
-with GGUFs, and 198 GGUF files. CPU code status is 133 full, 45 partial,
-15 without a runtime binder, and 1 non-artifact; Metal code status is 133 full,
-60 blocked by CPU, and 1 non-artifact. BiCodec and SGMSE remain honestly
-partial at the CLI routing boundary despite successful artifact publication
-and the recorded Apple library-level parity. UTMOS numeric parity remains
-unclaimed.
+The current live audit reports 194 public repositories, 193 repositories with
+GGUFs, and 198 GGUF files. CPU code status is 133 full, 45 partial, 15 without
+a runtime binder, and 1 non-artifact; Metal code status is 133 full, 60 blocked
+by CPU, and 1 non-artifact, leaving 61 unresolved public rows. BiCodec and
+SGMSE remain honestly partial at the CLI routing boundary despite successful
+artifact publication and the recorded Apple library-level parity. UTMOS
+numeric parity remains unclaimed.
 
 This directory contains public guides, generated-surface pointers, design
 decisions, validation evidence, and dated engineering records. Start with the
@@ -55,7 +54,7 @@ environment they name.
 | Deployment policy and legal notes | [Legal compliance](legal-compliance.md) |
 | C ABI changes | [ABI changelog](abi-changelog.md) |
 | Release history | [`CHANGELOG.md`](../CHANGELOG.md) |
-| Current Mac CPU/Metal campaign | [2026-09-11 Apple results](handoff/mac-cpu-metal-scaleway-results-2026-09-11.md) and the [pre-Scaleway remaining-task ledger](handoff/mac-pre-scaleway-remaining-tasks-2026-09-05.md) (the results close only the named execution batch; the 63-row ledger remains the broader scope) |
+| Current Mac CPU/Metal campaign | [2026-09-11 Apple results](handoff/mac-cpu-metal-scaleway-results-2026-09-11.md) and the [remaining-task ledger](handoff/mac-pre-scaleway-remaining-tasks-2026-09-05.md) (the live audit has 61 unresolved rows; the dated ledger retains its historical 63-row baseline) |
 
 Platform tutorials are available for Android, iOS, Unity, Godot, Python, web,
 and the server in English and Japanese under [`tutorials/`](tutorials/).

--- a/docs/api-reference.ja.md
+++ b/docs/api-reference.ja.md
@@ -60,25 +60,36 @@ Python / JS の全バインディングはこの 1 つのヘッダの上に乗�
 
 ## 5. 現行 0.3.0 release と Apple 検証 status
 
-現行の workspace release line は `0.3.0` で、2026-09-09 の監査開始時点の PR #79 head は
-`9efcd16eb63b857f48fc00d0b83d1113defd578b` である。最新 remote check は成功 110、
+現行の workspace release line は `0.3.0` である。
+
+**2026-09-12 current snapshot:** 現行 `main` baseline は `43d127f1` である。読み取り専用の
+live public audit は repository 194、GGUF repository 193、GGUF file 198 を報告している。
+CPU status は `full=133`、`partial=45`、`no-runtime-binder=15`、`not-artifact=1`、Metal
+status は `full=133`、`blocked-by-cpu=60`、`not-artifact=1` で、未解決の public row は61件
+である。承認済みの Scaleway Apple CPU/reference、Metal/reference、no-fallback batch は
+named scope のみ合格し、その後、明示的に承認された4件の artifact が gated workflow 経由で
+公開された。UTMOS numeric parity は未主張で、release tag は0、GitHub Release も0である。
+これは public model catalog 全体の対応完了や v1.0 release readiness を主張するものではない。
+
+**2026-09-09 audit-start historical snapshot:** 監査開始時点の PR #79 head は
+`9efcd16eb63b857f48fc00d0b83d1113defd578b` で、当時の remote check は成功 110、
 想定 skip 13、失敗 0 である。監査開始時点の live public audit は
 194 repository（GGUF repository 193、GGUF file 198）。CPU coverage は `full=131`、
 `partial=45`、
 `no-runtime-binder=17`、`not-artifact=1`、Metal は `full=131`、
 `blocked-by-cpu=62`、`not-artifact=1`、source-level CPU-only は 0 である。
-現時点の release tag は 0、GitHub Release も 0 である。
+その監査開始時点の release tag は 0、GitHub Release も 0 である。
 
-GigaAM v3 / Multilingual は conservative な Metal code route が complete だが、
+GigaAM v3 / Multilingual は conservative な Metal code route が complete だったが、
 Apple hardware verdict は未取得。未解決の public row 63 件は complete と主張しない。
-Scaleway は未開始であり、CI/audit 結果を Apple 実機 evidence の代用とはしない。
+Scaleway は未開始であり、CI/audit 結果を Apple 実機 evidence の代用とはしなかった。
 UTMOS の legacy Lightning checkpoint は制限付き `weights_only=True` loader が意図的に
 拒否するため、numeric parity は主張しない。
 
 ## Keeping this page current
 
-**最終確認日: 2026-09-09 — 監査開始時点の PR #79 head
-`9efcd16eb63b857f48fc00d0b83d1113defd578b` および `include/vokra.h` に対して
+**最終確認日: 2026-09-12 — 現行 `main` baseline `43d127f1` および
+`include/vokra.h` に対して
 確認。** pre-alpha の Python generator と checked-in `ctypes` table は、生成 C
 の全 57 function と完全に一致する。header は 15 typedef、4 enum、2 concrete
 struct、9 opaque handle を持つ。高水準 Python package は、全 C handle に wrapper

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -63,9 +63,21 @@ Each binding documents its own idiomatic surface on top of the C ABI:
 
 ## 5. Current 0.3.0 release and Apple verification status
 
-The current release line is workspace version `0.3.0`. At the 2026-09-09 audit
-start, PR #79 was at `9efcd16eb63b857f48fc00d0b83d1113defd578b`; its remote
-checks then reported
+The current release line is workspace version `0.3.0`.
+
+**2026-09-12 current snapshot:** the current `main` baseline is `43d127f1`.
+The live, read-only public audit reports 194 repositories, 193 GGUF-bearing
+repositories and 198 GGUF files. CPU status is `full=133`, `partial=45`,
+`no-runtime-binder=15`, `not-artifact=1`; Metal status is `full=133`,
+`blocked-by-cpu=60`, `not-artifact=1`, leaving 61 unresolved public rows. The
+authorized Scaleway Apple CPU/reference, Metal/reference and no-fallback batch
+passed only for its named scopes; four separately approved artifacts were then
+published through the gated workflow. UTMOS numeric parity remains unclaimed,
+and there are 0 release tags and 0 GitHub Releases. This is not a claim of
+complete public model-catalog support or v1.0 release readiness.
+
+**2026-09-09 audit-start historical snapshot:** PR #79 was at
+`9efcd16eb63b857f48fc00d0b83d1113defd578b`; its remote checks then reported
 110 successful checks, 13 expected skips, and 0 failures. The audit-start
 public audit reported 194 repositories (193 GGUF repositories, 198 GGUF
 files).
@@ -73,19 +85,19 @@ CPU coverage is
 `full=131`, `partial=45`, `no-runtime-binder=17`, `not-artifact=1`; Metal is
 `full=131`, `blocked-by-cpu=62`, `not-artifact=1`; source-level CPU-only
 coverage is 0.
-There are currently 0 release tags and 0 GitHub Releases.
+At that audit-start snapshot, there were 0 release tags and 0 GitHub Releases.
 
-GigaAM v3 and Multilingual have complete conservative Metal code routes, but
-their Apple-hardware verdicts are not available. The remaining 63 public rows
-are not claimed complete. Scaleway has not started; CI/audit results do not
-substitute for Apple hardware evidence. UTMOS numeric parity is also not
+GigaAM v3 and Multilingual had complete conservative Metal code routes, but
+their Apple-hardware verdicts were not available. The remaining 63 public rows
+were not claimed complete. Scaleway had not started; CI/audit results did not
+substitute for Apple hardware evidence. UTMOS numeric parity was also not
 claimed because its legacy Lightning checkpoint is intentionally refused by
 the restricted `weights_only=True` loader.
 
 ## Keeping this page current
 
-**Last verified: 2026-09-09 — against the audit-start PR #79 head
-`9efcd16eb63b857f48fc00d0b83d1113defd578b` and `include/vokra.h`.** The
+**Last verified: 2026-09-12 — against current `main` baseline `43d127f1` and
+`include/vokra.h`.** The
 pre-alpha Python generator and checked-in `ctypes` table cover all 57 generated
 C functions exactly; the header has 15 typedefs, four enums, two concrete
 structures, and nine opaque handles. The high-level Python package remains a

--- a/docs/m5-owner-verification-checklist.md
+++ b/docs/m5-owner-verification-checklist.md
@@ -2,7 +2,22 @@
 
 **Owner**: 依頼者 (`ayutaz`) — real-hardware verification, real-weight sourcing, legal sign-off, external contracts / infra provisioning, ADR ratification, and the v1.0 GA tag decision.
 
-**2026-09-09 audit-start snapshot:** Before this documentation refresh, PR #79
+**2026-09-12 current-state / supersession note:** the current `main` baseline
+for this snapshot is `43d127f1`. The live, read-only public audit reports 194
+repositories, 193 GGUF-bearing repositories and 198 GGUF files. CPU status is
+`full=133`, `partial=45`, `no-runtime-binder=15`, `not-artifact=1`; Metal status
+is `full=133`, `blocked-by-cpu=60`, `not-artifact=1`, leaving 61 unresolved
+public rows. The authorized Scaleway Apple CPU/reference, Metal/reference and
+no-fallback batch passed only for its named scopes; four separately approved
+artifacts were subsequently published through the gated workflow. UTMOS
+numeric parity remains unclaimed, and there are 0 release tags and 0 GitHub
+Releases. This checklist is not a GA or ABI-freeze declaration.
+
+The current literal Markdown ledger count is **51 checked / 31 unchecked**
+(mechanically counted on 2026-09-12). This is not an exhaustive task count:
+prose-only GA gates remain independently tracked.
+
+**2026-09-09 historical audit-start snapshot:** Before this documentation refresh, PR #79
 was at `9efcd16e` (`CLEAN` / `MERGEABLE`; 110 CI success / 13 intentional skip /
 0 fail). Exact VAST implementation evidence was `caf70eb1` (305 suites / 8,010
 passed / 0 failed / 100 ignored); VAST `50320338` and its 150-GB storage were
@@ -22,9 +37,10 @@ checkpoints are historical workspace `0.2.0` evidence. The active branch is
 workspace `0.3.0`; immediately before this documentation refresh its remote
 head was `d8a93bc3acdb8f9648ecb8dd37ef41657fbf425b` in open PR #79, with 109
 passing checks, 13 expected skips, and no failures or pending checks. The
-current surface has 57 C ABI functions / 15 typedefs and 49 checked / 33
-unchecked literal boxes.
-The GitHub `main` reference remains `41ce9ffdd4b0959497f55afa5016822f77a8a7b6`.
+That historical snapshot's surface had 57 C ABI functions / 15 typedefs and
+49 checked / 33 unchecked literal boxes.
+At that historical snapshot, the GitHub `main` reference was
+`41ce9ffdd4b0959497f55afa5016822f77a8a7b6`.
 This checklist is the remaining action ledger feeding the **v1.0 GA** decision
 (commercial GA + C ABI freeze). It is NOT a GA declaration and NOT a freeze —
 the freeze FIRES at the owner's v1.0 GA tag (M5-13). The 2026-08-18
@@ -40,10 +56,11 @@ branch/operation history remains in
 
 **Verify snapshot at pre-merge branch tip `8d469eb`**: `cargo test --workspace` = 5447 passed / 0 failed / 22 ignored / 199 suites (baseline 5446/21, +1 test +1 scaffold). All gates green: `cargo fmt` / `cargo clippy -D warnings` / `scripts/check-zero-deps.sh` (root Cargo.lock = `vokra-*` only, NFR-DS-02 preserved) / `scripts/check-abi-changelog.sh` / `scripts/gen-c-abi.sh --check` (no drift, v1.0-rc baseline 33 fn + 11 typedef unchanged, no new C ABI). This is historical evidence; PR #27 is merged.
 
-**2026-08-31 current-state rule**: the earlier **94 unchecked boxes** and the
+**2026-08-31 historical count note**: the earlier **94 unchecked boxes** and the
 2026-08-18 **42 checked / 36 unchecked** are historical owner ledgers, not
-current counts of missing implementations. The current literal ledger is
-**49 checked / 33 unchecked**. Those counts are not an exhaustive task count:
+current counts of missing implementations. The 2026-08-31 literal ledger was
+**49 checked / 33 unchecked**. The current 2026-09-12 literal ledger is
+**51 checked / 31 unchecked**. These counts are not an exhaustive task count:
 the M5-03/M5-04/M5-05/M5-06 and M5-10…M5-15 GA gates were written as prose
 rather than Markdown boxes. The live index below includes both sets. A box can
 mean an external legal/infra decision, real-weight access, a deliberately
@@ -58,9 +75,9 @@ Each task: **(a)** what / **(b)** why owner-only / **(c)** reference / **(d)** d
 
 ---
 
-## 0. Live remaining-work index (2026-08-31)
+## 0. Live remaining-work index (2026-09-12)
 
-This table is the complete M5 routing index. The 33 unchecked Markdown boxes
+This table is the complete M5 routing index. The 31 unchecked Markdown boxes
 live mainly in §1.5 and §6; the prose-only rows below are equally real and must
 not disappear from planning merely because `rg '\[ \]'` cannot count them.
 
@@ -80,8 +97,8 @@ not disappear from planning merely because `rg '\[ \]'` cannot count them.
 | M5-13 | Freeze tooling and negative test landed; ABI remains unfrozen | v1.0.0 tag/freeze, `abi-surface` required promotion, delegate/WFST C-export GO/NO-GO (§1.1–§1.3) |
 | M5-14 / M5-15 | CPU/quant/UTMOS implementation waves and advisory gates landed to their documented scope | Final same-rig performance/quality sweeps and GA-quality evidence before the NPU bakeoff |
 | M5-16 / M5-17 | Explicit trigger-gated homes | Implement only when a named consumer/model/toolchain/hardware trigger fires; currently open concrete implementations are listed in §6.6 |
-| Mac CPU/Metal model closure | Six Apple-ready model contracts have strict native CPU routes and independent official VAST evidence: GigaAM v3, GigaAM Multilingual, OmniASR CTC 1B, ReazonSpeech NeMo v2, BiCodec and Voice Gender Classifier. Their transfer packets were intentionally deleted with VAST instances `49168183` and `49261078` on 2026-09-01 because the Scaleway run is long-horizon; both ids read back `instances: null`, so no storage billing or restart target remains. Live inventory is CPU `full=131`, `partial=45`, `no-runtime-binder=17`, `not-artifact=1`; Metal `full=131`, `blocked-by-cpu=62`, `not-artifact=1`, with zero source-level CPU-only rows. GigaAM v3 and Multilingual have complete conservative Metal code routes, but all six rows still lack authenticated Apple-hardware verdicts. | When the Apple stage resumes, regenerate all required packets from the recorded fixed revisions/hashes on new disposable VAST workers, provision the 32 GiB-or-larger Scaleway Apple host, transfer and verify them, run the six Apple CPU/Metal workers, preserve evidence and destroy the new VAST instances. This closes only the prepared rows; it does not close the other 62 CPU-blocked repositories. |
-| SoTA / parity / publish | Converters and many structural proofs landed | The 33 literal boxes cover NPU capture, parity families, implementation follow-ups, publication/destination policy, Voxtral live correction, and optional Pages deployment |
+| Mac CPU/Metal model closure | The bounded authorized Scaleway batch passed Apple CPU/reference, Metal/reference and Metal/CPU no-fallback checks only for its named scopes (Metal backend, Apple BF16 GEMM, SpeechT5, ReazonSpeech NeMo v2, Voice Gender Classifier, OmniASR CTC 1B, BiCodec, GigaAM v3, GigaAM Multilingual and SGMSE VoiceBank). Four separately approved artifacts were subsequently published. The live inventory is CPU `full=133`, `partial=45`, `no-runtime-binder=15`, `not-artifact=1`; Metal `full=133`, `blocked-by-cpu=60`, `not-artifact=1`, leaving 61 unresolved public rows. | The remaining catalog rows still require their own source, owner/legal, artifact, runtime, VAST CPU-parity and (when ready) Apple evidence. The named batch does not close the broader catalog or the remaining M5 GA/platform gates. |
+| SoTA / parity / publish | Converters and many structural proofs landed | The 31 current literal boxes cover NPU capture, parity families, implementation follow-ups, publication/destination policy, Voxtral live correction, and optional Pages deployment |
 
 The cross-milestone Python binding, package distribution, and real-device lab
 gaps are tracked outside this file in

--- a/docs/platform-support/v1.0-rc-support-matrix.md
+++ b/docs/platform-support/v1.0-rc-support-matrix.md
@@ -9,8 +9,24 @@
 **v-label 規律** (2026-07-14 再割当 #2): M4 = **v1.0-rc** (M5 = v1.0 GA)。本確認記録は「v1 の機能完成 (rc) = 全プラットフォーム official support 出揃い」の判定材料であり、**商用 GA 宣言・C ABI 凍結・semver 準拠開始のいずれでもない** (凍結発火は M5-13/v1.0 GA タグ)。
 **drift check**: 本文書が cite する evidence anchor (HTML コメント形式、`anchor:` プレフィックスの行) の実在は `scripts/check-platform-support.sh` が機械検証する (T08)。anchor token は必ず repo 相対パス (`path` または `path#job`) で、`scripts/check-platform-support.sh --list` で列挙できる。
 
-**2026-09-09 current-state / supersession note:** this M4-era matrix retains
-its Part 0.1/0.2 observations as dated history. The current workspace is
+**2026-09-12 current-state / supersession note:** this M4-era matrix retains
+its Part 0.1/0.2 observations as dated history. The current `main` baseline
+for this snapshot is `43d127f1`. The live public inventory reports 194 public
+repositories, 193 GGUF-bearing repositories and 198 GGUF files. CPU status is
+`full=133`, `partial=45`, `no-runtime-binder=15`, `not-artifact=1`; Metal
+status is `full=133`, `blocked-by-cpu=60`, `not-artifact=1`, leaving 61
+unresolved public rows. The bounded Scaleway Apple CPU/reference,
+Metal/reference and no-fallback verdicts passed only for the named scopes in
+the [2026-09-11 results](../handoff/mac-cpu-metal-scaleway-results-2026-09-11.md);
+the public catalog and this six-platform matrix are not thereby complete.
+Four separately approved model artifacts were published through the gated
+workflow. There are still 0 Git tags and 0 published releases, CoreML's
+bakeoff parity/2x result remains **FAIL**, QNN remains an SDK-gated scaffold,
+and UTMOS numeric parity is unclaimed because its legacy Lightning checkpoint
+is refused by the restricted `weights_only=True` loader.
+
+**2026-09-09 historical audit-start note:** this M4-era matrix recorded the
+following audit-start state; it is retained as dated history. The workspace
 `0.3.0`; at the 2026-09-09 audit start PR #79 was `9efcd16e` (110 successful
 checks / 13 expected skips / 0 failures). There are 0 Git tags and 0 published
 releases. The earlier `9f69277d` / `5cd97d12` hashes, workspace `0.2.0`, and


### PR DESCRIPTION
## Summary

- refresh current/public Mac CPU and Apple Metal coverage from 131 complete / 63 remaining to 133 complete / 61 remaining
- record the current 194-repository inventory, 193 GGUF repositories, and 198 GGUF files while keeping the audit snapshot at 43d127f1 explicit
- clarify that the named Scaleway validation scope passed, four approved artifacts are published, and UTMOS numeric parity remains unclaimed
- update the live M5 checklist count to 51 checked / 31 unchecked
- preserve dated historical 131 / 63 and 49 / 33 evidence instead of rewriting it
- keep English and Japanese current documentation synchronized

## Verification

- uv run --no-project --python 3.12 python tools/docs/check_doc_examples.py --self-test
- uv run --no-project --python 3.12 python tools/docs/check_doc_examples.py
- scripts/check-doc-references.sh --self-test and production mode
- scripts/check-runbook-path-citations.sh
- scripts/check-community-docs.sh
- scripts/check-parity-sidecar-citations.sh
- scripts/check-owner-checklist-drift.sh
- scripts/check-platform-support.sh
- scripts/check-abi-changelog.sh
- scripts/check-workflow-hygiene.sh
- scripts/check-codex-hooks.sh
- git diff --check

No local model loading, conversion, forward pass, or workspace-scale Cargo command was run.