### PR TITLE
fix(ci): keep SBV2 UTMOS gate tensor-only

### DIFF
--- a/.github/workflows/parity-sbv2-real.yml
+++ b/.github/workflows/parity-sbv2-real.yml
@@ -824,35 +824,91 @@ jobs:
         # `crates/vokra-models/src/sbv2/parity.rs`'s `UTMOS_ATOL` for the
         # honest-atol derivation.
         #
-        # Weight source: reuses the already-committed
-        # `tests/parity/utmos/source.env` (UTMOS §3.1 sign-off = ☑ Commercial
-        # yousan 2026-07-23; the same URL + sha256 `parity-utmos.yml` uses).
-        # No new owner artifact required — enabling is a one-line repo-vars
-        # flip.
+        # Weight source: the committed `tests/parity/utmos/source.env` must
+        # contain an owner-supplied HTTPS URL for a tensor-only `.safetensors`
+        # export and its fixed 64-hex SHA-256. The historical source record may
+        # retain provenance for an unsafe serialized source, but this workflow
+        # never consumes that source. A repository-variable flip alone is not
+        # enough to enable the gate: the safe export and digest are required.
         #
-        # Fail-closed skip when the variable is not `"1"` (the whole step is
-        # `if:`-gated off, and the Rust test observes `VOKRA_SBV2_UTMOS_ENABLE`
-        # empty → deliberate skip with an eprintln + workflow annotation, per
-        # `parity-deepfilternet3-real.yml` / `parity-utmos.yml` precedent —
-        # fabricated pass 禁止, FR-EX-08 / NFR-QL-04).
+        # Fail-closed behavior has two layers: this step is `if:`-gated off
+        # when the repository variable is not `"1"`; when it is requested but
+        # the safe source pin is absent or malformed, the step emits a visible
+        # BLOCKED_SAFE_STATE_DICT status and writes `effective_enable=0`.
+        # The downstream Rust test therefore receives a deliberate skip rather
+        # than a broken opt-in that could panic or claim parity (FR-EX-08 /
+        # NFR-QL-04).
         id: utmos_prep
         if: vars.VOKRA_SBV2_UTMOS_ENABLE == '1'
         shell: bash
         run: |
           set -euo pipefail
-          # `safetensors` is part of the same frozen SBV2 oracle because
-          # `utmos_prepare_checkpoint.py` is an optional tail of this job.
-          # Reuse the already-committed UTMOS source pin (owner sign-off
-          # docs/license-audit.md §3.1 UTMOS row on 2026-07-23).
+          # Always initialize fail-closed outputs before any network or
+          # preparation operation. If a later command fails, the downstream
+          # Rust test still cannot observe an enabled gate without a GGUF.
+          write_outputs() {
+            {
+              echo "effective_enable=$1"
+              echo "utmos_gguf=$2"
+              echo "safe_state_dict_status=$3"
+            } > "$GITHUB_OUTPUT"
+          }
+          write_outputs 0 "" BLOCKED_SAFE_STATE_DICT
+
+          # `safetensors` is part of the same frozen SBV2 oracle because the
+          # UTMOS preparation tool is an optional tail of this job. The source
+          # file is required by policy, but only its safe state-dict fields are
+          # read below; no legacy serialized source is a CI input.
+          source_file=tests/parity/utmos/source.env
+          if [ ! -f "$source_file" ]; then
+            {
+              echo "### WP-24 UTMOS quality gate: BLOCKED_SAFE_STATE_DICT"
+              echo ""
+              echo "The gate was requested, but the committed \`$source_file\` file is missing."
+              echo ""
+              echo "Effective UTMOS enable: \`0\` (honest skip; no parity claim)."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::parity-sbv2-real: BLOCKED_SAFE_STATE_DICT — $source_file is missing; UTMOS disabled"
+            exit 0
+          fi
           # shellcheck disable=SC1091
           source tests/parity/utmos/source.env
-          : "${CKPT_URL:?tests/parity/utmos/source.env must define CKPT_URL}"
-          : "${CKPT_SHA256:?tests/parity/utmos/source.env must define CKPT_SHA256}"
-          curl -fL --retry 3 -o "$RUNNER_TEMP/utmos-checkpoint.ckpt" "$CKPT_URL"
-          echo "$CKPT_SHA256  $RUNNER_TEMP/utmos-checkpoint.ckpt" | sha256sum -c -
+          state_dict_url="${STATE_DICT_URL:-}"
+          state_dict_sha256="${STATE_DICT_SHA256:-}"
+          if [[ ! "$state_dict_url" =~ ^https://[^[:space:]]+$ ]]; then
+            write_outputs 0 "" BLOCKED_SAFE_STATE_DICT
+            {
+              echo "### WP-24 UTMOS quality gate: BLOCKED_SAFE_STATE_DICT"
+              echo ""
+              echo "The gate was requested, but \`tests/parity/utmos/source.env\` has no valid HTTPS \`STATE_DICT_URL\`."
+              echo "Only a tensor-only \`.safetensors\` export may enter this workflow."
+              echo ""
+              echo "Effective UTMOS enable: \`0\` (honest skip; no parity claim)."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::parity-sbv2-real: BLOCKED_SAFE_STATE_DICT — missing or invalid STATE_DICT_URL; UTMOS disabled"
+            exit 0
+          fi
+          if [[ ! "$state_dict_sha256" =~ ^[0-9a-fA-F]{64}$ ]]; then
+            write_outputs 0 "" BLOCKED_SAFE_STATE_DICT
+            {
+              echo "### WP-24 UTMOS quality gate: BLOCKED_SAFE_STATE_DICT"
+              echo ""
+              echo "The gate was requested, but \`tests/parity/utmos/source.env\` has no valid 64-hex \`STATE_DICT_SHA256\`."
+              echo "The safe tensor-only export cannot be trusted without a fixed digest."
+              echo ""
+              echo "Effective UTMOS enable: \`0\` (honest skip; no parity claim)."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::parity-sbv2-real: BLOCKED_SAFE_STATE_DICT — missing or invalid STATE_DICT_SHA256; UTMOS disabled"
+            exit 0
+          fi
+
+          state_dict_path="$RUNNER_TEMP/utmos-state-dict.safetensors"
+          curl -fL --retry 3 --proto '=https' --tlsv1.2 \
+            -o "$state_dict_path" "$state_dict_url"
+          echo "${state_dict_sha256}  ${state_dict_path}" | sha256sum -c -
           uv run --project "${PARITY_PROJECT}" --frozen python \
             tools/parity/utmos_prepare_checkpoint.py \
-            --ckpt "$RUNNER_TEMP/utmos-checkpoint.ckpt" \
+            --state-dict "$state_dict_path" \
             --output "$RUNNER_TEMP/utmos.safetensors" \
             --config-out "$RUNNER_TEMP/utmos-config.json"
           ./target/release/vokra-cli convert \
@@ -861,7 +917,7 @@ jobs:
             --config "$RUNNER_TEMP/utmos-config.json" \
             --output "$RUNNER_TEMP/utmos.gguf"
           ls -lh "$RUNNER_TEMP/utmos.gguf"
-          echo "utmos_gguf=$RUNNER_TEMP/utmos.gguf" >> "$GITHUB_OUTPUT"
+          write_outputs 1 "$RUNNER_TEMP/utmos.gguf" READY_SAFE_STATE_DICT
 
       - name: Announce WP-24 UTMOS quality gate posture
         # Runs regardless — the annotation on a *disabled* gate is the
@@ -870,29 +926,37 @@ jobs:
         shell: bash
         env:
           UTMOS_ENABLE_VAR: ${{ vars.VOKRA_SBV2_UTMOS_ENABLE }}
+          UTMOS_EFFECTIVE_ENABLE: ${{ steps.utmos_prep.outputs.effective_enable }}
+          UTMOS_STATE_STATUS: ${{ steps.utmos_prep.outputs.safe_state_dict_status }}
         run: |
           set -euo pipefail
-          if [ "${UTMOS_ENABLE_VAR}" = "1" ]; then
+          if [ "${UTMOS_ENABLE_VAR}" != "1" ]; then
+            {
+              echo "### WP-24 UTMOS quality gate: SKIPPED"
+              echo ""
+              echo "\`vars.VOKRA_SBV2_UTMOS_ENABLE\` is not \`1\`; the tail-position UTMOS delta assertion is disabled."
+              echo ""
+              echo "This is an FR-EX-08 explicit skip, not a fabricated pass."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::parity-sbv2-real: WP-24 UTMOS quality gate skipped (repository variable != '1')"
+          elif [ "${UTMOS_EFFECTIVE_ENABLE}" = "1" ]; then
             {
               echo "### WP-24 UTMOS quality gate: ENABLED"
               echo ""
-              echo "\`vars.VOKRA_SBV2_UTMOS_ENABLE=1\` — the tail-position UTMOS delta assertion"
+              echo "A verified tensor-only state-dict produced the UTMOS GGUF; the tail-position UTMOS delta assertion"
               echo "( \`|Δ| <= UTMOS_ATOL\` = 0.05 per \`crates/vokra-models/src/sbv2/parity.rs\`)"
               echo "will fire once the numeric waveform-parity assertion above passes."
             } >> "$GITHUB_STEP_SUMMARY"
           else
             {
-              echo "### WP-24 UTMOS quality gate: SKIPPED"
+              echo "### WP-24 UTMOS quality gate: BLOCKED_SAFE_STATE_DICT"
               echo ""
-              echo "\`vars.VOKRA_SBV2_UTMOS_ENABLE\` is not \`1\` — the tail-position UTMOS delta"
-              echo "assertion will not fire. Set the repository variable"
-              echo "\`VOKRA_SBV2_UTMOS_ENABLE=1\` to enable (no other owner artifact required —"
-              echo "\`tests/parity/utmos/source.env\` is already committed)."
+              echo "The gate was requested, but the verified tensor-only state-dict source is unavailable or preparation did not produce a safe GGUF."
               echo ""
-              echo "This is an FR-EX-08 explicit skip, not a fabricated pass — the SBV2"
-              echo "parity test observes the empty env var and logs an \`eprintln!\` skip diag."
+              echo "Effective UTMOS enable: \`${UTMOS_EFFECTIVE_ENABLE:-0}\` (honest skip; no parity claim)."
+              echo "State-dict status: \`${UTMOS_STATE_STATUS:-unknown}\`."
             } >> "$GITHUB_STEP_SUMMARY"
-            echo "::warning::parity-sbv2-real: WP-24 UTMOS quality gate skipped (vars.VOKRA_SBV2_UTMOS_ENABLE != '1')"
+            echo "::warning::parity-sbv2-real: BLOCKED_SAFE_STATE_DICT — UTMOS requested but effective enable is not 1"
           fi
 
       - name: Run SBV2 real-checkpoint full-manifest parity test
@@ -903,16 +967,14 @@ jobs:
         # route to this step; a missing/failed dump is an explicit visible
         # skip, not a Rust panic pretending to be a numeric result.
         #
-        # WP-24: when `vars.VOKRA_SBV2_UTMOS_ENABLE == "1"`, the two
-        # `VOKRA_SBV2_UTMOS_*` env vars below opt the tail-position UTMOS
-        # quality gate in (see the module doc of `parity_sbv2_real.rs` and
-        # the "Prepare UTMOS22-strong GGUF" step above); an empty value
-        # (var unset OR prep step skipped) triggers the Rust-side clean
-        # skip.
+        # WP-24: only the preparation step's effective output can opt the
+        # tail-position UTMOS quality gate in. A requested-but-blocked run
+        # deliberately passes a zero/empty enable value to Rust, so missing
+        # safe source material cannot become a broken opt-in or parity claim.
         id: parity
         if: always() && steps.reference_fixture.outputs.available == 'true'
         env:
-          VOKRA_SBV2_UTMOS_ENABLE: ${{ vars.VOKRA_SBV2_UTMOS_ENABLE }}
+          VOKRA_SBV2_UTMOS_ENABLE: ${{ steps.utmos_prep.outputs.effective_enable }}
           VOKRA_SBV2_UTMOS_GGUF: ${{ steps.utmos_prep.outputs.utmos_gguf }}
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- remove the stale SBV2 UTMOS path that downloaded the legacy Lightning pickle
- accept only an owner-pinned tensor-only safetensors state dict and SHA-256
- report `BLOCKED_SAFE_STATE_DICT` and disable the downstream UTMOS leg when the safe input is unavailable
- preserve a loud, no-parity-claim boundary until UTMOS safe inputs and independent reference construction exist

## Exact branch state
- stacked base: PR #91 at `240187302b531dfb42d50ddf3535845e58c6145b`
- head: `013238d10a7d5611cfd7c46156df94732e09f1fa`
- stable patch-id across the rebase: `f8df57c2fc680ec504e1eb69be2cb15b27bc235c`
- recovery bundle SHA-256: `368de38e147d5624c12e930a26fb84943a6bf0bca907adf5542693daa6473767`

## Verification
Local static checks after the rebase:
- `git diff --check`
- `bash scripts/check-find-hygiene.sh`
- `bash scripts/check-workflow-advisory-suffix.sh`
- `UV_CACHE_DIR=/private/tmp/vokra-uv-ci-cache bash scripts/check-workflow-hygiene.sh`
- `actionlint .github/workflows/parity-sbv2-real.yml`

The exact head was then replayed in an isolated VAST checkout. `git diff --check`, find hygiene, advisory suffix, all 46 workflow / 36 cron hygiene checks, and checksum-pinned actionlint 1.7.12 passed. No model weight was downloaded or executed, and no local workspace or `vokra-models` Cargo command was run. Fresh GitHub CI is running for the rebased head; the previous 71-success/1-skip result belonged to the superseded head and is not reused.

## Remaining boundary
Numeric UTMOS parity still requires authenticated tensor-only UTMOS and wav2vec state dicts, fixed SHA-256 values, and an owner-approved independent upstream construction path.