### PR TITLE
fix(ci): require safe UTMOS state-dict URL

### DIFF
--- a/.github/workflows/parity-sbv2-real.yml
+++ b/.github/workflows/parity-sbv2-real.yml
@@ -875,17 +875,17 @@ jobs:
           source tests/parity/utmos/source.env
           state_dict_url="${STATE_DICT_URL:-}"
           state_dict_sha256="${STATE_DICT_SHA256:-}"
-          if [[ ! "$state_dict_url" =~ ^https://[^[:space:]]+$ ]]; then
+          if [[ ! "$state_dict_url" =~ ^https://[^[:space:]]+\.safetensors([?#][^[:space:]]*)?$ ]]; then
             write_outputs 0 "" BLOCKED_SAFE_STATE_DICT
             {
               echo "### WP-24 UTMOS quality gate: BLOCKED_SAFE_STATE_DICT"
               echo ""
-              echo "The gate was requested, but \`tests/parity/utmos/source.env\` has no valid HTTPS \`STATE_DICT_URL\`."
-              echo "Only a tensor-only \`.safetensors\` export may enter this workflow."
+              echo "The gate was requested, but \`tests/parity/utmos/source.env\` has no valid HTTPS \`.safetensors\` \`STATE_DICT_URL\`."
+              echo "Only a tensor-only \`.safetensors\` export URL may enter this workflow; legacy serialized-checkpoint URLs are refused."
               echo ""
               echo "Effective UTMOS enable: \`0\` (honest skip; no parity claim)."
             } >> "$GITHUB_STEP_SUMMARY"
-            echo "::warning::parity-sbv2-real: BLOCKED_SAFE_STATE_DICT — missing or invalid STATE_DICT_URL; UTMOS disabled"
+            echo "::warning::parity-sbv2-real: BLOCKED_SAFE_STATE_DICT — missing, non-HTTPS, or non-safetensors STATE_DICT_URL; UTMOS disabled"
             exit 0
           fi
           if [[ ! "$state_dict_sha256" =~ ^[0-9a-fA-F]{64}$ ]]; then
@@ -903,7 +903,7 @@ jobs:
           fi
 
           state_dict_path="$RUNNER_TEMP/utmos-state-dict.safetensors"
-          curl -fL --retry 3 --proto '=https' --tlsv1.2 \
+          curl -fL --retry 3 --proto '=https' --proto-redir '=https' --tlsv1.2 \
             -o "$state_dict_path" "$state_dict_url"
           echo "${state_dict_sha256}  ${state_dict_path}" | sha256sum -c -
           uv run --project "${PARITY_PROJECT}" --frozen python \


### PR DESCRIPTION
## Summary

- Require the optional SBV2 UTMOS source to use HTTPS and a .safetensors URL.
- Restrict redirects to HTTPS.
- Preserve BLOCKED_SAFE_STATE_DICT with effective_enable=0 when the safe source contract is absent or invalid.

## Safety posture

This PR does not provide UTMOS weights and does not claim numeric parity. Legacy .ckpt, pickle, and non-safetensors inputs remain refused. No model, source, checkpoint, token, or artifact was acquired or executed.

## Verification

Exact VAST head: 8823cc712cd3248b4a888f9c83d09ca89e930c6c

- git diff --check
- scripts/check-workflow-hygiene.sh: PASS for 46 workflows and 36 crons
- HTTPS .safetensors URL positive and negative cases: PASS
- legacy CKPT_URL, CKPT_SHA256, .ckpt, .pkl, and pickle input search: absent

Recovered VAST log SHA-256: 1bf35b9c625d0a0c74b4700db1c2087f654c3b37e2a5d7b77ea47682fc256962.