### PR TITLE
docs(zonos): clarify isolated dependency self-tests

### DIFF
--- a/tools/parity/zonos_v0_1_reference/README.md
+++ b/tools/parity/zonos_v0_1_reference/README.md
@@ -117,3 +117,11 @@ placeholder-signer, wrong-head/hash, `NO_UPLOAD`-inconsistent, symlinked, or
 overlapping records remain fail-closed. Successful validation authorizes only
 the next pre-acquisition stage; the factual audit status and publication
 disposition do not change.
+
+The wrapper's model-free self-tests intentionally use
+`uv run --no-project --offline --python 3.12`; they exercise only the
+stdlib-backed audit, policy, and contract checks and therefore must not resolve
+or install the reference project. The audit and pre-acquisition paths retain
+the frozen dedicated project invocation (`--project ... --no-sync`), and the
+Transformers 5.10.4 compatibility gate remains a separate required evidence
+boundary before source or checkpoint acquisition.


### PR DESCRIPTION
## Summary

- document that model-free Zonos self-tests intentionally run without resolving the reference project
- distinguish that stdlib-only self-test path from the frozen dedicated project used by dependency audit and pre-acquisition
- retain the separate Transformers 5.10.4 compatibility boundary before any source or checkpoint access

## Validation

- bash -n and ShellCheck for the Zonos worker
- dependency approval self-test
- Zonos inspector, VAST stage, conditioning packet, and dependency-audit self-tests
- run-zonos-inspection.sh --self-test
- forbidden-symbol, zero-dependency, documentation-reference, runbook-citation, platform-support, and M5 residual-blocker gates
- git diff --check

Documentation only. No model/source/checkpoint access, execution, Cargo run, or upload was performed.